### PR TITLE
Stop infomation pages being indexed twice

### DIFF
--- a/upload/catalog/controller/information/information.php
+++ b/upload/catalog/controller/information/information.php
@@ -106,6 +106,7 @@ class ControllerInformationInformation extends Controller {
 			$output .= '<head>' . "\n";
 			$output .= '  <title>' . $information_info['title'] . '</title>' . "\n";
 			$output .= '  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">' . "\n";
+			$output .= '  <meta name="robots" content="noindex">' . "\n";
 			$output .= '</head>' . "\n";
 			$output .= '<body>' . "\n";
 			$output .= '  <h1>' . $information_info['title'] . '</h1>' . "\n";


### PR DESCRIPTION
Stops privacy policy and affiliate policy being indexed twice by search engines.
