### PR TITLE
Fix 404 not found page breadcrumb

### DIFF
--- a/upload/catalog/controller/error/not_found.php
+++ b/upload/catalog/controller/error/not_found.php
@@ -15,7 +15,7 @@ class ControllerErrorNotFound extends Controller {
 		
 		if (isset($this->request->get['route'])) {
        		$this->data['breadcrumbs'][] = array(
-        		'text'      => $this->language->get('text_error'),
+				'text'      => $this->language->get('heading_title'),
 				'href'      => $this->url->link($this->request->get['route']),
         		'separator' => $this->language->get('text_separator')
       		);	   	


### PR DESCRIPTION
Fixes the 404 not found page breadcrumb as it was using the content and
not the title causing problems if links were added to the error text.
