### PR TITLE
Update upload/install/opencart.sql

### DIFF
--- a/upload/install/opencart.sql
+++ b/upload/install/opencart.sql
@@ -658,7 +658,7 @@ INSERT INTO `oc_country` (`country_id`, `name`, `iso_code_2`, `iso_code_3`, `add
 (123, 'Lithuania', 'LT', 'LTU', '', 0, 1),
 (124, 'Luxembourg', 'LU', 'LUX', '', 0, 1),
 (125, 'Macau', 'MO', 'MAC', '', 0, 1),
-(126, 'Macedonia', 'MK', 'MKD', '', 0, 1),
+(126, 'FYROM', 'MK', 'MKD', '', 0, 1),
 (127, 'Madagascar', 'MG', 'MDG', '', 0, 1),
 (128, 'Malawi', 'MW', 'MWI', '', 0, 1),
 (129, 'Malaysia', 'MY', 'MYS', '', 0, 1),


### PR DESCRIPTION
After having received a relevant email from blueyon@gmail.com; on behalf of; Daniel Kerr [webmaster@opencart.com], in which I was prompted to fix the error in the country name below, I have proceeded with the change.

In detail, I have replaced the country name "Macedonia" (line 661) which is not correct, with it's official one (I went with the abbreviated FYROM, as the full "Former Yugoslav Republic of Macedonia" would be to long).

Another issue remains regarding Yugoslavia which does not exist anymore. That has to be split into Serbia, Cosovo (or Kosovo), Montenegro and Voivodina. I have got no knowledge on the details of the case, so I will pass that on to someone else to correct.

Have a good one,

Nick
