### PR TITLE
Added salt columns to tables for 1.5.4 upgrade

### DIFF
--- a/upload/install/upgrade.sql
+++ b/upload/install/upgrade.sql
@@ -236,3 +236,7 @@ UPDATE `oc_setting` set `group` = replace(`group`, 'alertpay', 'payza');
 UPDATE `oc_setting` set `key` = replace(`key`, 'alertpay', 'payza');
 UPDATE `oc_order` set `payment_method` = replace(`payment_method`, 'AlertPay', 'Payza');
 UPDATE `oc_order` set `payment_code` = replace(`payment_code`, 'alertpay', 'payza');
+
+ALTER TABLE `oc_affiliate` ADD `salt` varchar(9) COLLATE utf8_bin NOT NULL DEFAULT '' after `password`;
+ALTER TABLE `oc_customer`  ADD `salt` varchar(9) COLLATE utf8_bin NOT NULL DEFAULT '' after `password`;
+ALTER TABLE `oc_user`      ADD `salt` varchar(9) COLLATE utf8_bin NOT NULL DEFAULT '' after `password`;


### PR DESCRIPTION
I was unable to login into admin after updating some core files. The "salt" column was missing from 3 tables. I have added the alter tables to the upgrade.sql file.
