### PR TITLE
Update Authorize.net (AIM) for Shipping information

### DIFF
--- a/upload/catalog/controller/payment/authorizenet_aim.php
+++ b/upload/catalog/controller/payment/authorizenet_aim.php
@@ -84,6 +84,16 @@ class ControllerPaymentAuthorizeNetAim extends Controller {
 		$data['x_exp_date'] = $this->request->post['cc_expire_date_month'] . $this->request->post['cc_expire_date_year'];
 		$data['x_card_code'] = $this->request->post['cc_cvv2'];
 		$data['x_invoice_num'] = $this->session->data['order_id'];
+
+		/* Customer Shipping Address Fields */
+		$data['x_ship_to_first_name'] = html_entity_decode($order_info['shipping_firstname'], ENT_QUOTES, 'UTF-8');
+		$data['x_ship_to_last_name'] = html_entity_decode($order_info['shipping_lastname'], ENT_QUOTES, 'UTF-8');
+		$data['x_ship_to_company'] = html_entity_decode($order_info['shipping_company'], ENT_QUOTES, 'UTF-8');
+		$data['x_ship_to_address'] = html_entity_decode($order_info['shipping_address_1'], ENT_QUOTES, 'UTF-8') . ' ' . html_entity_decode($order_info['shipping_address_2'], ENT_QUOTES, 'UTF-8');
+		$data['x_ship_to_city'] = html_entity_decode($order_info['shipping_city'], ENT_QUOTES, 'UTF-8');
+		$data['x_ship_to_state'] = html_entity_decode($order_info['shipping_zone'], ENT_QUOTES, 'UTF-8');
+		$data['x_ship_to_zip'] = html_entity_decode($order_info['shipping_postcode'], ENT_QUOTES, 'UTF-8');
+		$data['x_ship_to_country'] = html_entity_decode($order_info['shipping_country'], ENT_QUOTES, 'UTF-8');
 	
 		if ($this->config->get('authorizenet_aim_mode') == 'test') {
 			$data['x_test_request'] = 'true';


### PR DESCRIPTION
Added extra fields for shipping information, as Authorize.Net was rejecting the Order Confirmation with error "Ship To First name is required". Couple of clients also reported this issue. Don't know if it is fixed in any other way already. But I have reporoduced this issue on latest version and error coming up. So I am proposing this change and its working fine now.
