### PR TITLE
Display Prices With Tax affects UPS insurance

### DIFF
--- a/upload/system/library/cart.php
+++ b/upload/system/library/cart.php
@@ -338,7 +338,7 @@ class Cart {
 		$total = 0;
 		
 		foreach ($this->getProducts() as $product) {
-			$total += $this->tax->calculate($product['price'], $product['tax_class_id'], $this->config->get('config_tax')) * $product['quantity'];
+			$total += $this->tax->calculate($product['price'], $product['tax_class_id']) * $product['quantity'];
 		}
 
 		return $total;


### PR DESCRIPTION
getTotal called by the UPS shipping calculator returns a different value
depending on the Display Prices With Tax option.
