### PR TITLE
Fix horizontal scroll bar missing in Firefox

### DIFF
--- a/upload/catalog/view/theme/default/stylesheet/stylesheet.css
+++ b/upload/catalog/view/theme/default/stylesheet/stylesheet.css
@@ -1,5 +1,5 @@
 html {
-	overflow: -moz-scrollbars-vertical;
+	overflow-y: scroll;
 	margin: 0;
 	padding: 0;
 }


### PR DESCRIPTION
-moz-scrollbars-vertical; is deprecated and causes the horizontal scroll
bar not to appear when the viewport is narrow in Firefox. overflow-y:
scroll; also works in IE8/9, opera and Chrome. Can be removed completely
if permanent vertical scroll bar is not wanted.
