### PR TITLE
Fixes for SEO urls

### DIFF
--- a/upload/system/library/url.php
+++ b/upload/system/library/url.php
@@ -32,5 +32,21 @@ class Url {
 				
 		return $url;
 	}
+
+	function build($url) {
+		if (function_exists('http_build_url')) {
+			return http_build_url($url);
+		}
+		return implode('', array(
+			'scheme'   => $url['scheme'] . '://',
+			'userpass' => (empty($url['user']) || empty($url['pass']) ? '' : $url['user'] . ':' . $url['pass'] . '@'),
+			'host'     => $url['host'],
+			'port'     => (empty($url['port']) ? '' : ':' . $url['port']),
+			'path'     => $url['path'],
+			'query'    => (empty($url['query']) ? '' : '?' . $url['query']),
+			'fragment' => (empty($url['fragment']) ? '' : '#' . $url['fragment']),
+		));
+	}
+
 }
 ?>


### PR DESCRIPTION
- The homepage route needs to be rewritten as '/' when SEO urls are enabled.
- Also fixes a bug where subcategories that don't have an SEO keyword set will generate links to their parent category instead. This fix bails on the whole $url if any part of the path is missing a keyword.
- $searches should make it easier to add new rules for arbitrary routes in future.
- Adds utility method build() to Url library to take advantage of http_build_url() if it's installed on the server.
