### PR TITLE
Fix session not cleared on admin login as customer

### DIFF
--- a/upload/catalog/controller/account/login.php
+++ b/upload/catalog/controller/account/login.php
@@ -8,6 +8,26 @@ class ControllerAccountLogin extends Controller {
 		// Login override for admin users
 		if (!empty($this->request->get['token'])) {
 			$this->customer->logout();
+			$this->cart->clear();
+
+			unset($this->session->data['wishlist']);
+			unset($this->session->data['shipping_address_id']);
+			unset($this->session->data['shipping_country_id']);
+			unset($this->session->data['shipping_zone_id']);
+			unset($this->session->data['shipping_postcode']);
+			unset($this->session->data['shipping_method']);
+			unset($this->session->data['shipping_methods']);
+			unset($this->session->data['payment_address_id']);
+			unset($this->session->data['payment_country_id']);
+			unset($this->session->data['payment_zone_id']);
+			unset($this->session->data['payment_method']);
+			unset($this->session->data['payment_methods']);
+			unset($this->session->data['comment']);
+			unset($this->session->data['order_id']);
+			unset($this->session->data['coupon']);
+			unset($this->session->data['reward']);
+			unset($this->session->data['voucher']);
+			unset($this->session->data['vouchers']);
 			
 			$customer_info = $this->model_account_customer->getCustomerByToken($this->request->get['token']);
 			


### PR DESCRIPTION
When logging in as a customer from admin, session data is not cleared causing carts and wish lists being merged from previous login.
