### PR TITLE
Update upload/catalog/controller/account/download.php

### DIFF
--- a/upload/catalog/controller/account/download.php
+++ b/upload/catalog/controller/account/download.php
@@ -178,7 +178,16 @@ class ControllerAccountDownload extends Controller {
 					
 					if (ob_get_level()) ob_end_clean();
 					
-					readfile($file, 'rb');
+					ob_clean();
+					$handle = fopen($file, "rb");
+					$chunksize=(filesize($file)/1024);
+			
+					set_time_limit(0);
+					while (!feof($handle)) {
+						echo fgets($handle, $chunksize);
+						flush();
+					}
+					fclose($handle);
 					
 					$this->model_account_download->updateRemaining($this->request->get['order_download_id']);
 					


### PR DESCRIPTION
readfile has problems with large files. 
I tested it on a 300+ MB file download and failed.

I propose this change as read on http://stackoverflow.com/questions/9458553/php-readfile-doesnt-work-but-only-for-20-meg-files
