### PR TITLE
On product page when switching tabs, viewport jumping too high.

### DIFF
--- a/upload/catalog/view/javascript/jquery/tabs.js
+++ b/upload/catalog/view/javascript/jquery/tabs.js
@@ -6,16 +6,16 @@ $.fn.tabs = function() {
 		
 		$(obj.attr('href')).hide();
 		
-		$(obj).click(function() {
+		obj.click(function() {
 			$(selector).removeClass('selected');
-			
-			$(selector).each(function(i, element) {
-				$($(element).attr('href')).hide();
-			});
 			
 			$(this).addClass('selected');
 			
 			$($(this).attr('href')).fadeIn();
+			
+			$(selector).not(this).each(function(i, element) {
+				$($(element).attr('href')).hide();
+			});
 			
 			return false;
 		});


### PR DESCRIPTION
Fixed in this commit.
