### PR TITLE
System routes extend

### DIFF
--- a/upload/system/engine/action.php
+++ b/upload/system/engine/action.php
@@ -20,6 +20,16 @@ final class Action {
 				
 				continue;
 			}
+
+            if (is_file(DIR_APPLICATION . 'controller/extends/' . str_replace(array('../', '..\\', '..'), '', $path) . '.php')) {
+                $this->file = DIR_APPLICATION . 'controller/extends/' . str_replace(array('../', '..\\', '..'), '', $path) . '.php';
+
+                $this->class = 'Controller' . preg_replace('/[^a-zA-Z0-9]/', '', $path . 'extends');
+
+                array_shift($parts);
+
+                break;
+            }
 			
 			if (is_file(DIR_APPLICATION . 'controller/' . str_replace(array('../', '..\\', '..'), '', $path) . '.php')) {
 				$this->file = DIR_APPLICATION . 'controller/' . str_replace(array('../', '..\\', '..'), '', $path) . '.php';

--- a/upload/system/engine/loader.php
+++ b/upload/system/engine/loader.php
@@ -37,6 +37,15 @@ final class Loader {
 	}
 		
 	public function model($model) {
+
+        $extendFile = DIR_APPLICATION . 'model/extends/' . $model . '.php';
+        $extendClass = 'Model' . preg_replace('/[^a-zA-Z0-9]/', '', $model . 'extends');
+        if (file_exists($extendFile)) {
+            include_once($extendFile);
+            $this->registry->set('model_' . str_replace('/', '_', $model), new $extendClass($this->registry));
+            return;
+        }
+
 		$file  = DIR_APPLICATION . 'model/' . $model . '.php';
 		$class = 'Model' . preg_replace('/[^a-zA-Z0-9]/', '', $model);
 		


### PR DESCRIPTION
Hello.  Already some time work with your system, and sometimes there is a necessity to extend existent classes the methods  
or add a functional to the existent methods.  

Now there are a few variants of decision of the folded problem:  
1) To finish writing the functional straight in existent source codes (that entails problems at the update of the 
system to the update version)
2) To use expansion of VQMOD and by him (at plenty of shallow corrections, it is a very labour intensive task)  

Offer to to make alteration you the variant of decision of the folded problem. In this Pull request I suggest to change 
loaders of model and comptroller thus that it allowed to add the files (in my case in the folder of Extends) and 
inherited from existent classes.  
It to allow, not affecting add or chnage functional system, and will shorten to the minimum corrections after an 
update  you can find Example of expansion of comptroller of Product on reference below: 

https://github.com/vatseek/opencart/commit/acfd1095ca7a03e8abe43008509df3ca97572abf  

Great thanks.
