### PR TITLE
This should fix the issue where a customer, without predefined addresses, is unable to checkout.

### DIFF
--- a/upload/catalog/controller/checkout/payment_address.php
+++ b/upload/catalog/controller/checkout/payment_address.php
@@ -166,9 +166,7 @@ class ControllerCheckoutPaymentAddress extends Controller {
 					unset($this->session->data['payment_method']);	
 					unset($this->session->data['payment_methods']);
 				}
-			} 
-			
-			if ($this->request->post['payment_address'] == 'new') {
+			} else {
 				if ((utf8_strlen($this->request->post['firstname']) < 1) || (utf8_strlen($this->request->post['firstname']) > 32)) {
 					$json['error']['firstname'] = $this->language->get('error_firstname');
 				}


### PR DESCRIPTION
To replicate the problem, create a customer using the admin area.  Do not give that customer an address.  Login as that customer and try to checkout.

This commit will assume that if the customer didn't pick "Use existing address" that they are trying to make a new address.

fixes #80
