### PR TITLE
Display preference of list or grid is not remembered between sessions.

### DIFF
--- a/upload/catalog/view/javascript/jquery/jquery.total-storage.min.js
+++ b/upload/catalog/view/javascript/jquery/jquery.total-storage.min.js
@@ -1,0 +1,31 @@
+/*
+ * TotalStorage
+ *
+ * Copyright (c) 2012 Jared Novack & Upstatement (upstatement.com)
+ * Dual licensed under the MIT and GPL licenses:
+ * http://www.opensource.org/licenses/mit-license.php
+ * http://www.gnu.org/licenses/gpl.html
+ *
+ * Total Storage is the conceptual the love child of jStorage by Andris Reinman, 
+ * and Cookie by Klaus Hartl -- though this is not connected to either project.
+ *
+ * @name $.totalStorage
+ * @cat Plugins/Cookie
+ * @author Jared Novack/jared@upstatement.com
+ * @version 1.1.2
+ * @url http://upstatement.com/blog/2012/01/jquery-local-storage-done-right-and-easy/
+ */
+(function($){var ls=window.localStorage;var supported;if(typeof ls=='undefined'||typeof window.JSON=='undefined'){supported=false;}else{supported=true;}
+$.totalStorage=function(key,value,options){return $.totalStorage.impl.init(key,value);}
+$.totalStorage.setItem=function(key,value){return $.totalStorage.impl.setItem(key,value);}
+$.totalStorage.getItem=function(key){return $.totalStorage.impl.getItem(key);}
+$.totalStorage.getAll=function(){return $.totalStorage.impl.getAll();}
+$.totalStorage.deleteItem=function(key){return $.totalStorage.impl.deleteItem(key);}
+$.totalStorage.impl={init:function(key,value){if(typeof value!='undefined'){return this.setItem(key,value);}else{return this.getItem(key);}},setItem:function(key,value){if(!supported){try{$.cookie(key,value);return value;}catch(e){console.log('Local Storage not supported by this browser. Install the cookie plugin on your site to take advantage of the same functionality. You can get it at https://github.com/carhartl/jquery-cookie');}}
+var saver=JSON.stringify(value);ls.setItem(key,saver);return this.parseResult(saver);},getItem:function(key){if(!supported){try{return this.parseResult($.cookie(key));}catch(e){return null;}}
+return this.parseResult(ls.getItem(key));},deleteItem:function(key){if(!supported){try{$.cookie(key,null);return true;}catch(e){return false;}}
+ls.removeItem(key);return true;},getAll:function(){var items=new Array();if(!supported){try{var pairs=document.cookie.split(";");for(var i=0;i<pairs.length;i++){var pair=pairs[i].split('=');var key=pair[0];items.push({key:key,value:this.parseResult($.cookie(key))});}}catch(e){return null;}}else{for(var i in ls){if(i.length){items.push({key:i,value:this.parseResult(ls.getItem(i))});}}}
+return items;},parseResult:function(res){var ret;try{ret=JSON.parse(res);if(ret=='true'){ret=true;}
+if(ret=='false'){ret=false;}
+if(parseFloat(ret)==ret&&typeof ret!="object"){ret=parseFloat(ret);}}catch(e){}
+return ret;}}})(jQuery);

--- a/upload/catalog/view/theme/default/template/common/header.tpl
+++ b/upload/catalog/view/theme/default/template/common/header.tpl
@@ -28,6 +28,7 @@
 <link rel="stylesheet" type="text/css" href="catalog/view/javascript/jquery/colorbox/colorbox.css" media="screen" />
 <script type="text/javascript" src="catalog/view/javascript/jquery/tabs.js"></script>
 <script type="text/javascript" src="catalog/view/javascript/common.js"></script>
+<script type="text/javascript" src="catalog/view/javascript/jquery/jquery.total-storage.min.js"></script>
 <?php foreach ($scripts as $script) { ?>
 <script type="text/javascript" src="<?php echo $script; ?>"></script>
 <?php } ?>

--- a/upload/catalog/view/theme/default/template/product/category.tpl
+++ b/upload/catalog/view/theme/default/template/product/category.tpl
@@ -150,7 +150,7 @@ function display(view) {
 		
 		$('.display').html('<b><?php echo $text_display; ?></b> <?php echo $text_list; ?> <b>/</b> <a onclick="display(\'grid\');"><?php echo $text_grid; ?></a>');
 		
-		$.cookie('display', 'list'); 
+		$.totalStorage('display', 'list'); 
 	} else {
 		$('.product-list').attr('class', 'product-grid');
 		
@@ -187,11 +187,11 @@ function display(view) {
 					
 		$('.display').html('<b><?php echo $text_display; ?></b> <a onclick="display(\'list\');"><?php echo $text_list; ?></a> <b>/</b> <?php echo $text_grid; ?>');
 		
-		$.cookie('display', 'grid');
+		$.totalStorage('display', 'grid');
 	}
 }
 
-view = $.cookie('display');
+view = $.totalStorage('display');
 
 if (view) {
 	display(view);

--- a/upload/catalog/view/theme/default/template/product/manufacturer_info.tpl
+++ b/upload/catalog/view/theme/default/template/product/manufacturer_info.tpl
@@ -114,7 +114,7 @@ function display(view) {
 		
 		$('.display').html('<b><?php echo $text_display; ?></b> <?php echo $text_list; ?> <b>/</b> <a onclick="display(\'grid\');"><?php echo $text_grid; ?></a>');
 		
-		$.cookie('display', 'list'); 
+		$.totalStorage('display', 'list'); 
 	} else {
 		$('.product-list').attr('class', 'product-grid');
 		
@@ -151,11 +151,11 @@ function display(view) {
 					
 		$('.display').html('<b><?php echo $text_display; ?></b> <a onclick="display(\'list\');"><?php echo $text_list; ?></a> <b>/</b> <?php echo $text_grid; ?>');
 		
-		$.cookie('display', 'grid');
+		$.totalStorage('display', 'grid');
 	}
 }
 
-view = $.cookie('display');
+view = $.totalStorage('display');
 
 if (view) {
 	display(view);

--- a/upload/catalog/view/theme/default/template/product/search.tpl
+++ b/upload/catalog/view/theme/default/template/product/search.tpl
@@ -197,7 +197,7 @@ function display(view) {
 		
 		$('.display').html('<b><?php echo $text_display; ?></b> <?php echo $text_list; ?> <b>/</b> <a onclick="display(\'grid\');"><?php echo $text_grid; ?></a>');
 		
-		$.cookie('display', 'list'); 
+		$.totalStorage('display', 'list'); 
 	} else {
 		$('.product-list').attr('class', 'product-grid');
 		
@@ -234,11 +234,11 @@ function display(view) {
 					
 		$('.display').html('<b><?php echo $text_display; ?></b> <a onclick="display(\'list\');"><?php echo $text_list; ?></a> <b>/</b> <?php echo $text_grid; ?>');
 		
-		$.cookie('display', 'grid');
+		$.totalStorage('display', 'grid');
 	}
 }
 
-view = $.cookie('display');
+view = $.totalStorage('display');
 
 if (view) {
 	display(view);

--- a/upload/catalog/view/theme/default/template/product/special.tpl
+++ b/upload/catalog/view/theme/default/template/product/special.tpl
@@ -111,7 +111,7 @@ function display(view) {
 		
 		$('.display').html('<b><?php echo $text_display; ?></b> <?php echo $text_list; ?> <b>/</b> <a onclick="display(\'grid\');"><?php echo $text_grid; ?></a>');
 		
-		$.cookie('display', 'list'); 
+		$.totalStorage('display', 'list'); 
 	} else {
 		$('.product-list').attr('class', 'product-grid');
 		
@@ -148,11 +148,11 @@ function display(view) {
 					
 		$('.display').html('<b><?php echo $text_display; ?></b> <a onclick="display(\'list\');"><?php echo $text_list; ?></a> <b>/</b> <?php echo $text_grid; ?>');
 		
-		$.cookie('display', 'grid');
+		$.totalStorage('display', 'grid');
 	}
 }
 
-view = $.cookie('display');
+view = $.totalStorage('display');
 
 if (view) {
 	display(view);


### PR DESCRIPTION
Add jquery.total-storage.min.js to provide an integrated localStorage and cookie solution. (https://github.com/jarednova/jquery-total-storage)
Modfiy the 'display' .cookie calls to use .totalStorage
This makes the list/grid display option non-expiring and remembered from session to session.
Small added bonus, the cookie for display doesn't get sent to the server.
