### PR TITLE
Fix admin getZonesByCountryId so that it only returns enabled zones

### DIFF
--- a/upload/admin/model/localisation/zone.php
+++ b/upload/admin/model/localisation/zone.php
@@ -66,7 +66,7 @@ class ModelLocalisationZone extends Model {
 		$zone_data = $this->cache->get('zone.' . (int)$country_id);
 	
 		if (!$zone_data) {
-			$query = $this->db->query("SELECT * FROM " . DB_PREFIX . "zone WHERE country_id = '" . (int)$country_id . "' ORDER BY name");
+			$query = $this->db->query("SELECT * FROM " . DB_PREFIX . "zone WHERE country_id = '" . (int)$country_id . "' AND status = '1' ORDER BY name");
 	
 			$zone_data = $query->rows;
 			


### PR DESCRIPTION
Fix admin getZonesByCountryId so that it only returns enabled zones otherwise in the admin customer and order pages you can select zones that are disabled
The change means that the admin and catalog getZonesByCountryId functions return the same zones
