### PR TITLE
Update upload/system/library/request.php

### DIFF
--- a/upload/system/library/request.php
+++ b/upload/system/library/request.php
@@ -30,7 +30,7 @@ class Request {
 	    		$data[$this->clean($key)] = $this->clean($value);
 	  		}
 		} else { 
-	  		$data = htmlspecialchars($data, ENT_COMPAT, 'UTF-8')
+	  		$data = htmlspecialchars($data, ENT_COMPAT, 'UTF-8');
 		}
 
 		return $data;


### PR DESCRIPTION
Default encoding for the htmlspecialchars function is ISO-8859-1 in versions of PHP prior to 5.4.0, and UTF-8 from PHP 5.4.0 onwards. Better if encoding is always specified to UTF-8. I think this is what may have caused "broken" settings in modules (like in welcome module) etc. resulting in error messages like "Notice: unserialize() [function.unserialize]: Error at offset 58793 of 65535 bytes in admin/index.php" 
