### PR TITLE
Update upload/catalog/view/theme/default/template/common/header.tpl

### DIFF
--- a/upload/catalog/view/theme/default/template/common/header.tpl
+++ b/upload/catalog/view/theme/default/template/common/header.tpl
@@ -55,11 +55,7 @@ DD_belatedPNG.fix('#logo img');
   <?php echo $cart; ?>
   <div id="search">
     <div class="button-search"></div>
-    <?php if ($search) { ?>
-    <input type="text" name="search" value="<?php echo $search; ?>" />
-    <?php } else { ?>
-    <input type="text" name="search" value="<?php echo $text_search; ?>" onclick="this.value = '';" onkeydown="this.style.color = '#000000';" />
-    <?php } ?>
+    <input type="text" name="search" placeholder="<?php echo $text_search; ?>" value="<?php echo $search; ?>" />
   </div>
   <div id="welcome">
     <?php if (!$logged) { ?>


### PR DESCRIPTION
Now when the DOCTYPE is HTML5, better if we use the placeholder attribute
instead on inline javascipt for the "Search" text in search field.

Does not work in IE yet, but it's not a must have feature anyway. 
This allows for cleaner HTML-code with no JavaScript.
It also solves another problem, when you accidently search on the
phrase "Search" itself, that can happen sometimes.

EDIT: If IE-support is a must, there is always possible to check for
placeholder support with JavaScript, preferebly a function in the common.js
More info: http://davidwalsh.name/html5-placeholder
   
