### PR TITLE
two browser credit trick issue trap text mail

### DIFF
--- a/upload/catalog/language/english/mail/order.php
+++ b/upload/catalog/language/english/mail/order.php
@@ -34,4 +34,7 @@ $_['text_update_order_status']  = 'Your order has been updated to the following 
 $_['text_update_comment']       = 'The comments for your order are:';
 $_['text_update_link']          = 'To view your order click on the link below:';
 $_['text_update_footer']        = 'Please reply to this email if you have any questions.';
+$_['text_tricky_order']         = 'Warning! This order may be tricky! Check the user transactions!';
+$_['text_tricky']         		= 'Warning! This order may be tricky!';
+$_['text_user_balance']         = 'User balance:';
 ?>

--- a/upload/catalog/model/total/credit.php
+++ b/upload/catalog/model/total/credit.php
@@ -5,7 +5,7 @@ class ModelTotalCredit extends Model {
 			$this->load->language('total/credit');
 		 
 			$balance = $this->customer->getBalance();
-			
+
 			if ((float)$balance) {
 				if ($balance > $total) {
 					$credit = $total;	
@@ -30,10 +30,52 @@ class ModelTotalCredit extends Model {
 	
 	public function confirm($order_info, $order_total) {
 		$this->load->language('total/credit');
-		
+
 		if ($order_info['customer_id']) {
-			$this->db->query("INSERT INTO " . DB_PREFIX . "customer_transaction SET customer_id = '" . (int)$order_info['customer_id'] . "', order_id = '" . (int)$order_info['order_id'] . "', description = '" . $this->db->escape(sprintf($this->language->get('text_order_id'), (int)$order_info['order_id'])) . "', amount = '" . (float)$order_total['value'] . "', date_added = NOW()");				
+			$this->db->query("INSERT INTO " . DB_PREFIX . "customer_transaction SET customer_id = '" . (int)$order_info['customer_id'] . "', order_id = '" . (int)$order_info['order_id'] . "', description = '" . $this->db->escape(sprintf($this->language->get('text_order_id'), (int)$order_info['order_id'])) . "', amount = '" . (float)$order_total['value'] . "', date_added = NOW()");
+			if(($balance=(int)$this->customer->getBalance()) < 0) {
+				if ($this->config->get('config_alert_mail')) {
+					$language = new Language($order_info['language_directory']);
+					$language->load($order_info['language_filename']);
+					$language->load('mail/order');
+
+					$subject = sprintf($language->get('text_new_subject')." ".$language->get('text_tricky'), html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8'), $order_info['order_id']);
+
+					// Text
+					$text  = $language->get('text_new_received') . "\n\n";
+					$text .= $language->get('text_new_order_id') . ' ' . $order_info['order_id'] . "\n";
+					$text .= $language->get('text_new_date_added') . ' ' . date($language->get('date_format_short'), strtotime($order_info['date_added'])) . "\n";
+					$text .= $language->get('text_new_order_status') . ' ' . $order_info['order_status_id'] . "\n\n";
+					$text .= $language->get('text_tricky_order') . "\n";
+					$text .= $language->get('text_user_balance')." ".$balance. "\n";
+
+					$mail = new Mail();
+					$mail->protocol = $this->config->get('config_mail_protocol');
+					$mail->parameter = $this->config->get('config_mail_parameter');
+					$mail->hostname = $this->config->get('config_smtp_host');
+					$mail->username = $this->config->get('config_smtp_username');
+					$mail->password = $this->config->get('config_smtp_password');
+					$mail->port = $this->config->get('config_smtp_port');
+					$mail->timeout = $this->config->get('config_smtp_timeout');
+					$mail->setTo($this->config->get('config_email'));
+					$mail->setFrom($this->config->get('config_email'));
+					$mail->setSender($order_info['store_name']);
+					$mail->setSubject(html_entity_decode($subject, ENT_QUOTES, 'UTF-8'));
+					$mail->setText(html_entity_decode($text, ENT_QUOTES, 'UTF-8'));
+					$mail->send();
+
+					// Send to additional alert emails
+					$emails = explode(',', $this->config->get('config_alert_emails'));
+
+					foreach ($emails as $email) {
+						if ($email && preg_match('/^[^\@]+@.*\.[a-z]{2,6}$/i', $email)) {
+							$mail->setTo($email);
+							$mail->send();
+						}
+					}
+				}
+			}
 		}
-	}	
+	}
 }
 ?>


### PR DESCRIPTION
Here is the original issiue: 
"I think there is a bug when using store credits. When I add a credit to a customer account, lets say 50 euro and I will open the opencart webshop in multiple browsers at the same time and create an order in every browser until all browsers have placed the order and are now on a payment processing page of a Payment service provider, then all orders have received the credit of 50 euro.

When all orders are now paid, the customer will have a negative credit in his account but a store admin doesn't get notified about this so when the customer will never return to place another order then we have lost the total amount that was credited for the other orders.

Please let me know if you have enought information or I will add some screenshots etc."

I tried to solve this by checking the user transaction balance after the comfirm and if this value is in minus an email will be warn about the order may be tricky!
