### PR TITLE
X-UA-Compatible meta-tag for better IE compatibility

### DIFF
--- a/upload/catalog/view/theme/default/template/common/header.tpl
+++ b/upload/catalog/view/theme/default/template/common/header.tpl
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html dir="<?php echo $direction; ?>" lang="<?php echo $lang; ?>">
 <head>
+<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 <meta charset="UTF-8" />
 <title><?php echo $title; ?></title>
 <base href="<?php echo $base; ?>" />


### PR DESCRIPTION
This meta-tag forces Internet Explorer to always render using the standard engine, it also removes the Compatibility View button in adressbar. Many IE users have Compatibility View to "On" without even knowing it, which results in rendering in quirks mode (like it's rendered in IE6). This meta-tag only affects IE users. I fixed a client problem the other day just by adding this meta-tag. It must be located right under head-tag for this to work.

Add it if you want...

More info: http://stackoverflow.com/questions/6771258/whats-the-difference-if-meta-http-equiv-x-ua-compatible-content-ie-edge
