### PR TITLE
The order's comments are not included within the HTML emailed invoice.

### DIFF
--- a/upload/catalog/model/checkout/order.php
+++ b/upload/catalog/model/checkout/order.php
@@ -302,8 +302,8 @@ class ModelCheckoutOrder extends Model {
 			$template->data['telephone'] = $order_info['telephone'];
 			$template->data['ip'] = $order_info['ip'];
 			
-			if ($comment && $notify) {
-				$template->data['comment'] = nl2br($comment);
+			if ($order_info['comment']) {
+				$template->data['comment'] = nl2br($order_info['comment']);
 			} else {
 				$template->data['comment'] = '';
 			}


### PR DESCRIPTION
This fixes HTML emailed invoice not showing comments.
