### PR TITLE
upload/catalog/controler/common/seo_url.php

### DIFF
--- a/upload/catalog/controller/common/seo_url.php
+++ b/upload/catalog/controller/common/seo_url.php
@@ -41,14 +41,16 @@ class ControllerCommonSeoUrl extends Controller {
 				}
 			}
 			
-			if (isset($this->request->get['product_id'])) {
-				$this->request->get['route'] = 'product/product';
-			} elseif (isset($this->request->get['path'])) {
-				$this->request->get['route'] = 'product/category';
-			} elseif (isset($this->request->get['manufacturer_id'])) {
-				$this->request->get['route'] = 'product/manufacturer/info';
-			} elseif (isset($this->request->get['information_id'])) {
-				$this->request->get['route'] = 'information/information';
+			if(!isset($this->request->get['route'])){
+				if (isset($this->request->get['product_id'])) {
+					$this->request->get['route'] = 'product/product';
+				} elseif (isset($this->request->get['path'])) {
+					$this->request->get['route'] = 'product/category';
+				} elseif (isset($this->request->get['manufacturer_id'])) {
+					$this->request->get['route'] = 'product/manufacturer/info';
+				} elseif (isset($this->request->get['information_id'])) {
+					$this->request->get['route'] = 'information/information';
+				}
 			}
 			
 			if (isset($this->request->get['route'])) {


### PR DESCRIPTION
Currently there is a problem causing Duplicate content in search engines

When SEO URLs is enabled

example

www.domain.com/existing-category/non-existent-product

Instead of displaying a 404 error page because the product does not exist, it displays the category.

If the non-existent-product used to exist and has been indexed by search engines, now when it is crawled, the category page is picked up as duplicate content.
