### PR TITLE
.htaccess changes for robots.txt

### DIFF
--- a/upload/.htaccess.txt
+++ b/upload/.htaccess.txt
@@ -10,7 +10,7 @@ Options +FollowSymlinks
 Options -Indexes
 
 # Prevent Direct Access to files
-<FilesMatch "\.(tpl|ini|log)">
+<FilesMatch "(?i)((\.tpl|\.ini|\.log|(?<!robots)\.txt))">
  Order deny,allow
  Deny from all
 </FilesMatch>


### PR DESCRIPTION
this is protect following files match
        error.txt, php.ini, and tpl files (i added caseles version with "(?i)"
        error.TXT, php.INI files can be protected, etc.
    You can find more information http://www.pcre.org/pcre.txt
    At the end i ignore robots.txt file from file match.
