### PR TITLE
Fix E_NOTICE showing when product keyword isn't set

### DIFF
--- a/upload/admin/model/catalog/product.php
+++ b/upload/admin/model/catalog/product.php
@@ -108,7 +108,7 @@ class ModelCatalogProduct extends Model {
 			}
 		}
 						
-		if ($data['keyword']) {
+		if (isset($data['keyword'])) {
 			$this->db->query("INSERT INTO " . DB_PREFIX . "url_alias SET query = 'product_id=" . (int)$product_id . "', keyword = '" . $this->db->escape($data['keyword']) . "'");
 		}
 						


### PR DESCRIPTION
Small fix in catalog/product model which now doesn't show an E_NOTICE anymore and is consistent with the other checks.
