### PR TITLE
Added a simple getter for the output in the response class

### DIFF
--- a/upload/system/library/response.php
+++ b/upload/system/library/response.php
@@ -21,6 +21,10 @@ class Response {
 		$this->output = $output;
 	}
 
+	public function getOutput() {
+		return $this->output;
+	}
+
 	private function compress($data, $level = 0) {
 		if (isset($_SERVER['HTTP_ACCEPT_ENCODING']) && (strpos($_SERVER['HTTP_ACCEPT_ENCODING'], 'gzip') !== false)) {
 			$encoding = 'gzip';


### PR DESCRIPTION
Inside a UnitTest it would be necessary to check contents of the output with assertions. By adding a simple getter to the output class, this would be possible. An example would be something like this:

``` php
class ControllerAccountWishListTest extends OpenCartTest {  
    public function testAddingAProductToTheAccountWishList() {

        // load the the wishlist controller within accout folder
        $controller = $this->loadControllerByRoute("account/wishlist");

        // set some test params for your request
        $this->request->post['product_id'] = 123;

        $controller->add();

        // get the response
        $output = $this->response->getOutput();

        // write some custom assertions for the ouput to verify the test
                // ... 
    }   
}
```

More can be found [here](https://github.com/openmandragora/opencart-test-suite)...
