### PR TITLE
Possible division by zero at Weight::convert()

### DIFF
--- a/upload/system/library/weight.php
+++ b/upload/system/library/weight.php
@@ -26,13 +26,13 @@ class Weight {
 		if (isset($this->weights[$from])) {
 			$from = $this->weights[$from]['value'];
 		} else {
-			$from = 0;
+			$from = 1;
 		}
 
 		if (isset($this->weights[$to])) {
 			$to = $this->weights[$to]['value'];
 		} else {
-			$to = 0;
+			$to = 1;
 		}
 
 		return $value * ($to / $from);


### PR DESCRIPTION
When Weight_Format_ID ($from) is not set for the goods item record, method results with division by zero. Possibly the right idea is to output unchanged $value if either $this->weights[$from] OR $this->weights[$to] is not set.
