### PR TITLE
Fix for Authorize.net AIM

### DIFF
--- a/upload/catalog/controller/payment/authorizenet_aim.php
+++ b/upload/catalog/controller/payment/authorizenet_aim.php
@@ -145,34 +145,35 @@ class ControllerPaymentAuthorizeNetAim extends Controller {
 			}
 		
 			if ($response_info[1] == '1') {
-				if (strtoupper($response_info[38]) == strtoupper(md5($this->config->get('authorizenet_aim_hash') . $this->config->get('authorizenet_aim_login') . $response_info[7] . $this->currency->format($order_info['total'], $order_info['currency_code'], 1.00000, false)))) {
-					$this->model_checkout_order->confirm($this->session->data['order_id'], $this->config->get('config_order_status_id'));
-					
-					$message = '';
-					
-					if (isset($response_info['5'])) {
-						$message .= 'Authorization Code: ' . $response_info['5'] . "\n";
-					}
-					
-					if (isset($response_info['6'])) {
-						$message .= 'AVS Response: ' . $response_info['6'] . "\n";
-					}
-			
-					if (isset($response_info['7'])) {
-						$message .= 'Transaction ID: ' . $response_info['7'] . "\n";
-					}
-	
-					if (isset($response_info['39'])) {
-						$message .= 'Card Code Response: ' . $response_info['39'] . "\n";
-					}
-					
-					if (isset($response_info['40'])) {
-						$message .= 'Cardholder Authentication Verification Response: ' . $response_info['40'] . "\n";
-					}				
-	
-					$this->model_checkout_order->update($this->session->data['order_id'], $this->config->get('authorizenet_aim_order_status_id'), $message, false);				
+				
+				$this->model_checkout_order->confirm($this->session->data['order_id'], $this->config->get('config_order_status_id'));
+				
+				$message = '';
+				
+				if (isset($response_info['5'])) {
+					$message .= 'Authorization Code: ' . $response_info['5'] . "\n";
 				}
 				
+				if (isset($response_info['6'])) {
+					$message .= 'AVS Response: ' . $response_info['6'] . "\n";
+				}
+		
+				if (isset($response_info['7'])) {
+					$message .= 'Transaction ID: ' . $response_info['7'] . "\n";
+				}
+
+				if (isset($response_info['39'])) {
+					$message .= 'Card Code Response: ' . $response_info['39'] . "\n";
+				}
+				
+				if (isset($response_info['40'])) {
+					$message .= 'Cardholder Authentication Verification Response: ' . $response_info['40'] . "\n";
+				}				
+	
+				if (!$this->config->get('authorizenet_aim_hash') || (strtoupper($response_info[38]) == strtoupper(md5($this->config->get('authorizenet_aim_hash') . $this->config->get('authorizenet_aim_login') . $response_info[7] . $this->currency->format($order_info['total'], $order_info['currency_code'], 1.00000, false))))) {
+					$this->model_checkout_order->update($this->session->data['order_id'], $this->config->get('authorizenet_aim_order_status_id'), $message, false);
+				}
+								
 				$json['success'] = $this->url->link('checkout/success', '', 'SSL');
 			} else {
 				$json['error'] = $response_info[4];


### PR DESCRIPTION
The core version was not alerting the admin of successfully paid orders if the md5 hash failed. This is because md5 isn't a required field, but the code was assuming it was. So now it will always update to "config_order_status_id" if paid successfully, but will only use the "authorizenet_aim_order_status_id" when the md5 hash passes. This then allows the Admins to see they have an order in a Pending state if the md5 failed.

I also made it so that if md5 hash is not being used, it will always update it to the final status.

This will resolve all the people complaining about missing orders for Authorize.net
