### PR TITLE
Paypal Payflow URL Update

### DIFF
--- a/upload/catalog/controller/payment/pp_pro_uk.php
+++ b/upload/catalog/controller/payment/pp_pro_uk.php
@@ -121,9 +121,9 @@ class ControllerPaymentPPProUK extends Controller {
 		$request .= '&CARDISSUE=' . urlencode($this->request->post['cc_issue']);
 		 
 		if (!$this->config->get('pp_pro_uk_test')) {
-			$curl = curl_init('https://payflowpro.verisign.com/transaction');
+			$curl = curl_init('https://payflowpro.paypal.com');
 		} else {
-			$curl = curl_init('https://pilot-payflowpro.verisign.com/transaction');
+			$curl = curl_init('https://pilot-payflowpro.paypal.com');
 		}
 		
 		curl_setopt($curl, CURLOPT_PORT, 443);


### PR DESCRIPTION
Paypal URL has changed, see this old topic from Zen Cart

http://www.zen-cart.com/showthread.php?123576-Payflow-Pro-URL-Change-Update-for-Payflow-and-PayPal-UK-users-Update-by-Sept-2009

Was getting a cURL unknown host error with the old URL, the Paypal Pro UK module is now working correctly for me, might need updating on the non-UK module too but I can't test that one.
