### PR TITLE
Избавляемся от дублей категорий

### DIFF
--- a/upload/catalog/controller/common/seo_url.php
+++ b/upload/catalog/controller/common/seo_url.php
@@ -38,7 +38,8 @@ class ControllerCommonSeoUrl extends Controller {
 						$this->request->get['information_id'] = $url[1];
 					}	
 				} else {
-					$this->request->get['route'] = 'error/not_found';	
+					$this->request->get['route'] = 'error/not_found';
+					return $this->forward($this->request->get['route']);
 				}
 			}
 			


### PR DESCRIPTION
Проблема дублей при включенных Seo url решается при помощи rel="canonikal", но это только в товарах. А категории доступны по разным адресам, и их очень много. Например http://site.tt/desktops/mac/a http://site.tt/desktops/mac/ab http://site.tt/desktops/mac/abc http://site.tt/desktops/mac/abcd и т.д.
Изменение позволит избавиться от существующих дублей категорий. После изменения такие URL будут отдавать 404 Error, а категория будет доступна только по URL http://ocstore.tt/desktops/mac
