### PR TITLE
Make PayPal total match OpenCart total

### DIFF
--- a/upload/catalog/controller/payment/pp_standard.php
+++ b/upload/catalog/controller/payment/pp_standard.php
@@ -24,7 +24,8 @@ class ControllerPaymentPPStandard extends Controller {
 			$this->data['item_name'] = html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8');				
 			
 			$this->data['products'] = array();
-			
+			$subtotal = 0;
+
 			foreach ($this->cart->getProducts() as $product) {
 				$option_data = array();
 	
@@ -42,11 +43,14 @@ class ControllerPaymentPPStandard extends Controller {
 						'value' => (utf8_strlen($value) > 20 ? utf8_substr($value, 0, 20) . '..' : $value)
 					);
 				}
-				
+
+				$price = $this->currency->format($product['price'], $order_info['currency_code'], false, false);
+				$subtotal += $price * $product['quantity'];
+
 				$this->data['products'][] = array(
 					'name'     => $product['name'],
 					'model'    => $product['model'],
-					'price'    => $this->currency->format($product['price'], $order_info['currency_code'], false, false),
+					'price'    => $price,
 					'quantity' => $product['quantity'],
 					'option'   => $option_data,
 					'weight'   => $product['weight']
@@ -54,8 +58,8 @@ class ControllerPaymentPPStandard extends Controller {
 			}	
 			
 			$this->data['discount_amount_cart'] = 0;
-			
-			$total = $this->currency->format($order_info['total'] - $this->cart->getSubTotal(), $order_info['currency_code'], false, false);
+
+			$total = $this->currency->format($order_info['total'], $order_info['currency_code'], false, false) - $subtotal;
 
 			if ($total > 0) {
 				$this->data['products'][] = array(


### PR DESCRIPTION
As PayPal uses less precision in its calculations, its total can differ
from the cart total. Calculating subtotal this way ensures they match.
