### PR TITLE
Fix for dashboard zero division errors on install (no data)

### DIFF
--- a/upload/admin/controller/common/dashboard.php
+++ b/upload/admin/controller/common/dashboard.php
@@ -38,71 +38,100 @@ class ControllerCommonDashboard extends Controller {
 		// Total Sales
 		$sale_total = $this->model_report_dashboard->getTotalSales();
 		
-		$this->data['sale_total'] = $this->currency->format($sale_total, $this->config->get('config_currency'));
+		if ($sale_total > 0) {
+		
+			$this->data['sale_total'] = $this->currency->format($sale_total, $this->config->get('config_currency'));
 
-		$monthly_total = 0;
+			$monthly_total = 0;
 
-		$results = $this->model_report_dashboard->getTotalSalesByMonth();
+			$results = $this->model_report_dashboard->getTotalSalesByMonth();
+			
+			foreach ($results as $result) {
+				$monthly_total += $result['total'];
+			}
+			
+			$this->data['sale_growth'] = round(($monthly_total / $sale_total) * 100, 2);
+			
+		} else {
 		
-		foreach ($results as $result) {
-			$monthly_total += $result['total'];
-		}
-		
-		$this->data['sale_growth'] = round(($monthly_total / $sale_total) * 100, 2);
-		
+			$this->data['sale_total'] = 0;
+			$this->data['sale_growth'] = 0;
+		}	
+			
 		// Total Orders
 		$this->load->model('sale/order');
-		
+			
 		$order_total = $this->model_sale_order->getTotalOrders();
 		
-		$this->data['order_total'] = $order_total;
-				
-		$monthly_total = 0;
-
-		$results = $this->model_report_dashboard->getTotalOrdersByMonth();
+		if ($order_total > 0) {
+			
+			$this->data['order_total'] = $order_total;
 		
-		foreach ($results as $result) {
-			$monthly_total += $result['total'];
+			$monthly_total = 0;
+
+			$results = $this->model_report_dashboard->getTotalOrdersByMonth();
+			
+			foreach ($results as $result) {
+				$monthly_total += $result['total'];
+			}	
+						
+			$this->data['order_growth'] = round(($monthly_total / $order_total) * 100, 2);
+
+		} else {
+		
+			$this->data['order_total'] = 0;
+			$this->data['order_growth'] = 0;
 		}	
-					
-		$this->data['order_growth'] = round(($monthly_total / $order_total) * 100, 2);		
 				
 		// Customers
 		$this->load->model('sale/customer');
 		
 		$customer_total = $this->model_sale_customer->getTotalCustomers();
 		
-		$this->data['customer_total'] = $customer_total;
+		if ($customer_total > 0) { 
 		
-		$monthly_total = 0;
+			$this->data['customer_total'] = $customer_total;
+		
+			$monthly_total = 0;
 
-		$results = $this->model_report_dashboard->getTotalOrdersByMonth();
+			$results = $this->model_report_dashboard->getTotalOrdersByMonth();
 		
-		foreach ($results as $result) {
-			$monthly_total += $result['total'];
-		}
+			foreach ($results as $result) {
+				$monthly_total += $result['total'];
+			}
 			
-		$this->data['customer_growth'] = round(($monthly_total / $customer_total) * 100, 2);		
+			$this->data['customer_growth'] = round(($monthly_total / $customer_total) * 100, 2);
+			
+		} else {
+		
+			$this->data['customer_total'] = 0;
+			$this->data['customer_growth'] = 0;
+		}		
 		
 		// Marketing
 		$this->load->model('marketing/marketing');
 		
 		$marketing_total = $this->model_marketing_marketing->getTotalMarketings();
 
-		$this->data['marketing_total'] = $marketing_total;
-
-		$monthly_total = 0;
-
-		$results = $this->model_report_dashboard->getTotalOrdersByMonth();
+		if ($customer_total > 0) { 
 		
-		foreach ($results as $result) {
-			$monthly_total += $result['total'];
-		}
+			$this->data['marketing_total'] = $marketing_total;
+
+			$monthly_total = 0;
+
+			$results = $this->model_report_dashboard->getTotalOrdersByMonth();
+		
+			foreach ($results as $result) {
+				$monthly_total += $result['total'];
+			}
 			
-		$this->data['marketing_growth'] = round(($monthly_total / $marketing_total) * 100, 2);
-
-
-
+			$this->data['marketing_growth'] = round(($monthly_total / $marketing_total) * 100, 2);
+			
+		} else {
+		
+			$this->data['marketing_total'] = 0;
+			$this->data['marketing_growth'] = 0;
+		}
 
 		// Number of people onlne
 		$this->load->model('report/online');


### PR DESCRIPTION
Multiple errors returned when there is no values for the statistic totals in the dashboard. Occurs on initial install. This fix bypasses the formulas if values are zero.
