### PR TITLE
FIX for schema or host agnostic web sites (e.g. multiple domain setup)

### DIFF
--- a/upload/catalog/controller/common/seo_url.php
+++ b/upload/catalog/controller/common/seo_url.php
@@ -112,7 +112,7 @@ class ControllerCommonSeoUrl extends Controller {
 				}
 			}
 
-			return $url_info['scheme'] . '://' . $url_info['host'] . (isset($url_info['port']) ? ':' . $url_info['port'] : '') . str_replace('/index.php', '', $url_info['path']) . $url . $query;
+			return (array_key_exists('host', $url_info) ? (array_key_exists('scheme', $url_info) ? $url_info['scheme'] . '://' : '//') . $url_info['host'] . (array_key_exists('port', $url_info) ? ':' . $url_info['port'] : '') : '/') . str_replace('/index.php', '', $url_info['path']) . $url . $query;
 		} else {
 			return $link;
 		}


### PR DESCRIPTION
Hello Daniel.

I've made and tested this quick fix to allow schema or host agnostic webs. This is really useful when having multiple domains for the same client.

It already worked without SEO_URLs but it complained when activating, so I fixed it.

It doesn't break normal usage, it's just a verification of key existence before usage.

After this patch, these configurations are valid on the config.php file (the new default could be '/' for less installation steps!):

// Scheme agnostic website (Note: the '//' is required):
define('HTTP_SERVER', '//www.domain.com/'); 

// Domain agnostic website:
define('HTTP_SERVER', '/');

ps: the $url_data to $url_info renaming on last version almost lost me.
