### PR TITLE
Fix installation after field name change views -> viewed

### DIFF
--- a/upload/install/opencart.sql
+++ b/upload/install/opencart.sql
@@ -2356,7 +2356,7 @@ CREATE TABLE `oc_product` (
   `minimum` int(11) NOT NULL DEFAULT '1',
   `sort_order` int(11) NOT NULL DEFAULT '0',
   `status` tinyint(1) NOT NULL DEFAULT '0',
-  `views` int(5) NOT NULL DEFAULT '0',
+  `viewed` int(5) NOT NULL DEFAULT '0',
   `date_added` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `date_modified` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   PRIMARY KEY (`product_id`)


### PR DESCRIPTION
After the change from 'views' to 'viewed' for the oc_products table, the create statement was not updated and it was breaking installation. This changes updates the create statement to match the new field name, and completes installation successfully.
