### PR TITLE
Fix seo_url so it can work with subcategories that dont have a url segment

### DIFF
--- a/upload/catalog/controller/common/seo_url.php
+++ b/upload/catalog/controller/common/seo_url.php
@@ -89,7 +89,10 @@ class ControllerCommonSeoUrl extends Controller {
 				
 						if ($query->num_rows) {
 							$url .= '/' . $query->row['keyword'];
-						}							
+						} else {
+							$url = '';
+							break;
+						}						
 					}
 					
 					unset($data[$key]);


### PR DESCRIPTION
Fix seo_url so it can work with categories that have a url segment and subcategories that dont

Example:
I have a Bikes category that has the segment url "bikes", under it I added a Mountain Bikes subcategory but I forgot to give it a segment url.
The function will build my url up to the point when it can't find a url segment for my subcategory and I end up with $url = '/bikes' for my Mountain Bikes subcategory.
I added a break and I also reset the $url var so it can return the unprettified url instead "product/category&path=58_151".
