### PR TITLE
[mysqli] fetch_assoc addition instead of fetch_array. 

### DIFF
--- a/upload/system/database/mmysqli.php
+++ b/upload/system/database/mmysqli.php
@@ -29,7 +29,7 @@ final class mMySQLi {
 				$result = new stdClass();
 				$data = array();
 
-				while ($row = $query->fetch_array()) {
+				while ($row = $query->fetch_assoc()) {
 					$data[] = $row;
 				}
 


### PR DESCRIPTION
The default for fetch_array gives both numbered indices and associative indices. But the numbered indices are never used.
