### PR TITLE
Fixed issue #449 (Resources remain available even in maintenance mode).

### DIFF
--- a/upload/index.php
+++ b/upload/index.php
@@ -226,11 +226,11 @@ $registry->set('encryption', new Encryption($config->get('config_encryption')));
 // Front Controller 
 $controller = new Front($registry);
 
-// SEO URL's
-$controller->addPreAction(new Action('common/seo_url'));	
-
 // Maintenance Mode
 $controller->addPreAction(new Action('common/maintenance'));
+
+// SEO URL's
+$controller->addPreAction(new Action('common/seo_url'));	
 	
 // Router
 if (isset($request->get['route'])) {


### PR DESCRIPTION
Fixed issue #449: common/maintenance is called before common/seo_url to check if the site is in maintenance mode.
