### PR TITLE
Added ommitted folders that need chmod for installation

### DIFF
--- a/install.txt
+++ b/install.txt
@@ -20,12 +20,15 @@ These instructions are for a manual installation using FTP, cPanel or other web 
 
 2. Rename config-dist.php to config.php and admin/config-dist.php to admin/config.php
 
-3. For Linux/Unix make sure the following folders and files are writable.
+3. For Linux/Unix make sure the following folders exist and files are writable.
 
 		chmod 0755 or 0777 image/
 		chmod 0755 or 0777 image/cache/
+		chmod 0755 or 0777 image/data/
 		chmod 0755 or 0777 cache/
 		chmod 0755 or 0777 download/
+		chmod 0755 or 0777 system/cache/
+		chmod 0755 or 0777 system/logs/
 		chmod 0755 or 0777 config.php
 		chmod 0755 or 0777 admin/config.php
 


### PR DESCRIPTION
when installing opencart, some folders mentioned in install.txt do not exist yet. the installer than lists some more folders than are contained in install.txt to be chmod'ed.
