### PR TITLE
Fix for OpenBay Pro orders.

### DIFF
--- a/upload/system/engine/controller.php
+++ b/upload/system/engine/controller.php
@@ -65,8 +65,7 @@ abstract class Controller {
 				return false;
 			}
 		} else {
-			trigger_error('Error: Could not load controller ' . $child . '!');
-			exit();					
+			return false;				
 		}		
 	}
 	


### PR DESCRIPTION
hasAction method returns false if a controller does not exist rather than stopping the application.
