### PR TITLE
Protection from unauthorized file upload in product/product/upload

### DIFF
--- a/upload/catalog/controller/product/product.php
+++ b/upload/catalog/controller/product/product.php
@@ -448,6 +448,13 @@ class ControllerProductProduct extends Controller {
 			}
 			
 			$this->model_catalog_product->updateViewed($this->request->get['product_id']);
+
+            // Protection for file upload
+            $this->session->data['csrf'] = md5(mt_rand());
+            $this->data['upload_path'] = $this->url->link(
+                'product/product/upload',
+                'csrf=' . $this->session->data['csrf'] . $url, 'SSL'
+            );
 			
 			if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/product/product.tpl')) {
 				$this->template = $this->config->get('config_template') . '/template/product/product.tpl';
@@ -669,6 +676,11 @@ class ControllerProductProduct extends Controller {
 	
 	public function upload() {
 		$this->language->load('product/product');
+        // Protection for against unauthorized file upload
+        if (!isset($this->request->get['csrf']) OR $this->request->get['csrf'] !== $this->session->data['csrf']) {
+            header($this->language->get('error_upload'), null, 400);
+            exit;
+        }
 		
 		$json = array();
 		

--- a/upload/catalog/view/theme/default/template/product/product.tpl
+++ b/upload/catalog/view/theme/default/template/product/product.tpl
@@ -478,7 +478,7 @@ $('#button-cart').click(function() {
 <?php if ($option['type'] == 'file') { ?>
 <script type="text/javascript"><!--
 new AjaxUpload('#button-option-<?php echo $option['product_option_id']; ?>', {
-    action: 'index.php?route=product/product/upload',
+    action: '<?php echo $upload_path; ?>',
     name: 'file',
     autoSubmit: true,
     responseType: 'json',


### PR DESCRIPTION
OpenCart has no checks from unauthorized uploading files via the product/product/upload action. There is only a test for mime type of the uploaded file, but the page with the following code allows you to upload any number of files on the server, filling all available space.

``` html
<html>
<body>
  <!-- Change action for your OpenCart location -->
  <form action="http://localhost/opencart/index.php?route=product/product/upload" method="post" enctype="multipart/form-data">
    <input type="file" name="file">
    <input type="submit" value="Submit File">
  </form>
</body>
</html>
```

This code adds a check for compliance with csrf parameter.
