### PR TITLE
Update string filters in usps.php for v1.1 of USPS WebTools API

### DIFF
--- a/upload/catalog/model/shipping/usps.php
+++ b/upload/catalog/model/shipping/usps.php
@@ -325,9 +325,9 @@ class ModelShippingUsps extends Model {
 
 				curl_close($curl);
 
-				// strip reg, trade and ** out 01-02-2011
-				$result = str_replace('&amp;lt;sup&amp;gt;&amp;amp;reg;&amp;lt;/sup&amp;gt;', '', $result);
-				$result = str_replace('&amp;lt;sup&amp;gt;&amp;amp;trade;&amp;lt;/sup&amp;gt;', '', $result);
+				// strip reg, trade and ** out, updated 9-11-2013
+				$result = str_replace('&amp;lt;sup&amp;gt;&amp;#174;&amp;lt;/sup&amp;gt;', '', $result);
+				$result = str_replace('&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt;', '', $result);
 				$result = str_replace('**', '', $result);
 				$result = str_replace("\r\n", '', $result);
 				$result = str_replace('\"', '"', $result);


### PR DESCRIPTION
Updated filters to strip out reg and trademarks for USPS WebTools API v1.1 (released Jul. 28th, 2013).
