### PR TITLE
Missing flexslider libraries, Issue 916

### DIFF
--- a/upload/catalog/controller/module/carousel.php
+++ b/upload/catalog/controller/module/carousel.php
@@ -6,12 +6,12 @@ class ControllerModuleCarousel extends Controller {
 		$this->load->model('design/banner');
 		$this->load->model('tool/image');
 
-		$this->document->addScript('catalog/view/javascript/jquery/jquery.jcarousel.min.js');
+		$this->document->addScript('catalog/view/javascript/jquery/flexslider/jquery.flexslider-min.js');
 
-		if (file_exists('catalog/view/theme/' . $this->config->get('config_template') . '/stylesheet/carousel.css')) {
-			$this->document->addStyle('catalog/view/theme/' . $this->config->get('config_template') . '/stylesheet/carousel.css');
+		if (file_exists('catalog/view/theme/' . $this->config->get('config_template') . '/stylesheet/flexslider.css')) {
+			$this->document->addStyle('catalog/view/theme/' . $this->config->get('config_template') . '/stylesheet/flexslider.css');
 		} else {
-			$this->document->addStyle('catalog/view/theme/default/stylesheet/carousel.css');
+			$this->document->addStyle('catalog/view/javascript/jquery/flexslider/flexslider.css');
 		}
 
 		$this->data['limit'] = $setting['limit'];


### PR DESCRIPTION
Replaced jcarousel with flexslider libraries to resolve the missing libraries issue. 

https://github.com/opencart/opencart/issues/916
