### PR TITLE
Update PP Express to Handle Lengthy Product Descriptions

### DIFF
--- a/upload/catalog/model/payment/pp_express.php
+++ b/upload/catalog/model/payment/pp_express.php
@@ -169,6 +169,8 @@ class ModelPaymentPPExpress extends Model {
 
                 $option_count++;
             }
+            
+            $data['L_PAYMENTREQUEST_0_DESC' . $i] = substr($data['L_PAYMENTREQUEST_0_DESC' . $i], 0, 126);
 
             $item_price = $this->currency->format($item['price'], false, false, false);
 


### PR DESCRIPTION
Upon checkout, some of our customers were receiving error 11812 (the value of description parameter has been truncated.) This caused quite a mess since the orders weren't showing up in the admin and the customer wasn't receiving a confirmation. To address this, I made the described change so that the description adheres to the 127 single-byte character limit that has been imposed by Paypal.
