### PR TITLE
Fixed Search for Products with Special Characters

### DIFF
--- a/upload/catalog/controller/product/search.php
+++ b/upload/catalog/controller/product/search.php
@@ -10,7 +10,7 @@ class ControllerProductSearch extends Controller {
 		$this->load->model('tool/image'); 
 		
 		if (isset($this->request->get['search'])) {
-			$search = $this->request->get['search'];
+			$search = htmlentities($this->request->get['search'], ENT_QUOTES);
 		} else {
 			$search = '';
 		} 


### PR DESCRIPTION
Searches for products with special characters returned zero results. This is due to the special characters being converted to their HTML entities in the DB. For that reason, the search string needs to the same treatment to return any matches.
