### PR TITLE
Dramatically boost load performance of products and categories on large stores

### DIFF
--- a/upload/install/opencart.sql
+++ b/upload/install/opencart.sql
@@ -318,7 +318,8 @@ CREATE TABLE `oc_category` (
   `status` tinyint(1) NOT NULL,
   `date_added` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `date_modified` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
-  PRIMARY KEY (`category_id`)
+  PRIMARY KEY (`category_id`),
+  KEY `parent_id` (`parent_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 
 --
@@ -435,7 +436,8 @@ CREATE TABLE `oc_category_path` (
   `category_id` int(11) NOT NULL,
   `path_id` int(11) NOT NULL,
   `level` int(11) NOT NULL,
-  PRIMARY KEY (`category_id`,`path_id`)
+  PRIMARY KEY (`category_id`,`path_id`),
+  KEY `path_id` (`path_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 
 --
@@ -2348,7 +2350,9 @@ CREATE TABLE `oc_product` (
   `viewed` int(5) NOT NULL DEFAULT '0',
   `date_added` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `date_modified` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
-  PRIMARY KEY (`product_id`)
+  PRIMARY KEY (`product_id`),
+  KEY `stock_status_id` (`stock_status_id`),
+  KEY `manufacturer_id` (`manufacturer_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 
 --
@@ -2388,7 +2392,8 @@ CREATE TABLE `oc_product_attribute` (
   `attribute_id` int(11) NOT NULL,
   `language_id` int(11) NOT NULL,
   `text` text NOT NULL,
-  PRIMARY KEY (`product_id`,`attribute_id`,`language_id`)
+  PRIMARY KEY (`product_id`,`attribute_id`,`language_id`),
+  KEY `attribute_id` (`attribute_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 
 --
@@ -2486,7 +2491,8 @@ DROP TABLE IF EXISTS `oc_product_filter`;
 CREATE TABLE `oc_product_filter` (
   `product_id` int(11) NOT NULL,
   `filter_id` int(11) NOT NULL,
-  PRIMARY KEY (`product_id`,`filter_id`)
+  PRIMARY KEY (`product_id`,`filter_id`),
+  KEY `filter_id` (`filter_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 
 --
@@ -2505,7 +2511,8 @@ CREATE TABLE `oc_product_image` (
   `product_id` int(11) NOT NULL,
   `image` varchar(255) DEFAULT NULL,
   `sort_order` int(3) NOT NULL DEFAULT '0',
-  PRIMARY KEY (`product_image_id`)
+  PRIMARY KEY (`product_image_id`),
+  KEY `product_id` (`product_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 
 --
@@ -2588,7 +2595,9 @@ CREATE TABLE `oc_product_option` (
   `option_id` int(11) NOT NULL,
   `value` text NOT NULL,
   `required` tinyint(1) NOT NULL,
-  PRIMARY KEY (`product_option_id`)
+  PRIMARY KEY (`product_option_id`),
+  KEY `product_id` (`product_id`),
+  KEY `option_id` (`option_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 
 --
@@ -2756,7 +2765,8 @@ DROP TABLE IF EXISTS `oc_product_to_category`;
 CREATE TABLE `oc_product_to_category` (
   `product_id` int(11) NOT NULL,
   `category_id` int(11) NOT NULL,
-  PRIMARY KEY (`product_id`,`category_id`)
+  PRIMARY KEY (`product_id`,`category_id`),
+  KEY `category_id` (`category_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 
 --
@@ -3332,7 +3342,9 @@ CREATE TABLE `oc_url_alias` (
   `url_alias_id` int(11) NOT NULL AUTO_INCREMENT,
   `query` varchar(255) NOT NULL,
   `keyword` varchar(255) NOT NULL,
-  PRIMARY KEY (`url_alias_id`)
+  PRIMARY KEY (`url_alias_id`),
+  KEY `query` (`query`),
+  KEY `keyword` (`keyword`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 
 --


### PR DESCRIPTION
Dramatically boost load performance of products and categories on large stores (10,000+ products, 500+ nested categories, product filters and options) due to multi-column indexes, as explained in detail here:

http://bloke.org/php/opencart-is-slow-with-many-categories/
https://github.com/opencart/opencart/issues/177

I have tested these changes across 13 different OpenCart installations, there was a substantial reduction in page load time (even with caching enabled). Furthermore, MySQL load was reduced by an average 15-20% (sometimes more).

As explained in the links above, when a MySQL index has multiple columns, only the first column will perform as an indexed column. The remaining columns will appear un-indexed, unless the first column is also filtered during the query.
For example, if the table has an index on product_id,category_id:

Selecting all categories "WHERE product_id = 123" IS indexed, because product_id comes first in the index.

Selecting all categories "WHERE product_id = 123 AND category_id = 7" IS indexed, because both indexed columns are specified.

Selecting all products "WHERE category_id = 7" is NOT indexed, because the first column in the index is 'product_id' and that has not been specified, which makes the second index useless.

This is all backed up and explained very clearly by the MySQL documentation:
http://dev.mysql.com/doc/refman/5.0/en/multiple-column-indexes.html

> MySQL cannot use the index to perform lookups if the columns do not form a leftmost prefix of the index. Suppose that you have the SELECT statements shown here:
> 
> ``` SQL
> SELECT * FROM tbl_name WHERE col1=val1;
> SELECT * FROM tbl_name WHERE col1=val1 AND col2=val2;
> SELECT * FROM tbl_name WHERE col2=val2;
> SELECT * FROM tbl_name WHERE col2=val2 AND col3=val3;
> ```
> 
> If an index exists on (col1, col2, col3), only the first two queries use the index. The third and fourth queries do involve indexed columns, but (col2) and (col2, col3) are not leftmost prefixes of (col1, col2, col3).

There is obviously going to be a minor performance hit when creating new products (as the indexes are updated), however this is so negligible as to be almost unworthy of mention (bulk-adding 10,000 products may take a few seconds longer).
