### PR TITLE
fix for mobile dropdown menus + standardization of @media width amounts

### DIFF
--- a/upload/catalog/view/theme/default/stylesheet/stylesheet.css
+++ b/upload/catalog/view/theme/default/stylesheet/stylesheet.css
@@ -246,10 +246,19 @@ div.required .control-label:before {
 	color: #ffffff;
 	background-color: #229ac8;
 }
-@media (max-width: 768px) {
-#menu {
-	border-radius: 4px;
+#menu .navbar-collapse {
+	overflow: visible !important;
 }
+@media (max-width: 767px) {
+	#menu {
+		border-radius: 4px;
+	}
+	#menu div.dropdown-inner > ul.list-unstyled {
+		display: block;
+	}
+	#menu div.dropdown-menu {
+		margin-left: 0 !important;
+	}
 }
 /* content */
 #content {
@@ -558,7 +567,7 @@ h2.price {
 }
 }
 
-@media (max-width: 768px) {
+@media (max-width: 767px) {
 .product-thumb .caption {
 	min-height: 0;
 }		


### PR DESCRIPTION
Mobile dropdown menu for the 'MP3 players' category was not visible, so I included the following fix:
# menu .navbar-collapse {

```
overflow: visible !important;
```

}
After that, the menus were still being cut off do to the -202px added to the large dropdown menu and the fact that menu with it's four columns was simply to wide to fit in the screen, so I reduced them all into a single column and made this fix:
@media (max-width: 767px) {
    #menu div.dropdown-inner > ul.list-unstyled {
        display: block;
    }
    #menu div.dropdown-menu {
        margin-left: 0 !important;
    }
}
and merged it with the other @media entry for #menu.

I also standardized the lower @media max-widths to 767 (instead of 768), because that's what the bootstrap.css file does.
