### PR TITLE
Fix issue with Klarna fee disappearing when updating order in admin

### DIFF
--- a/upload/catalog/model/total/klarna_fee.php
+++ b/upload/catalog/model/total/klarna_fee.php
@@ -4,32 +4,32 @@ class ModelTotalKlarnaFee extends Model {
         $this->load->language('total/klarna_fee');
 
 		$status = true;
-		
+
 		$klarna_fee = $this->config->get('klarna_fee');
-		
+
 		if (isset($this->session->data['payment_address_id'])) {
 			$this->load->model('account/address');
-			
+
 			$address = $this->model_account_address->getAddress($this->session->data['payment_address_id']);
 		} elseif (isset($this->session->data['guest']['payment'])) {
 			$address = $this->session->data['guest']['payment'];
-        } elseif (isset($this->request->post['payment_country_id'])) {
+		} elseif (isset($this->request->post['payment_country_id'])) {
 
-            $this->load->model('localisation/country');
-            $country_info = $this->model_localisation_country->getCountry($this->request->post['payment_country_id']);
+			$this->load->model('localisation/country');
+			$country_info = $this->model_localisation_country->getCountry($this->request->post['payment_country_id']);
 
-            if ($country_info) {
-                $address = array('iso_code_3' => $country_info['iso_code_3']);
-            }
-        }
+			if ($country_info) {
+				$address = array('iso_code_3' => $country_info['iso_code_3']);
+			}
+		}
 
-        $code = false;
+		$code = false;
 
-        if (isset($this->request->post['payment_code'])) {
-            $code = $this->request->post['payment_code'];
-        } elseif (isset($this->session->data['payment_method']['code'])) {
-            $code = $this->session->data['payment_method']['code'];
-        }
+		if (isset($this->request->post['payment_code'])) {
+			$code = $this->request->post['payment_code'];
+		} elseif (isset($this->session->data['payment_method']['code'])) {
+			$code = $this->session->data['payment_method']['code'];
+		}
 
 		if (!isset($address)) {
 			$status = false;
@@ -42,7 +42,7 @@ class ModelTotalKlarnaFee extends Model {
 		} elseif ($this->cart->getSubTotal() >= $klarna_fee[$address['iso_code_3']]['total']) {
 			$status = false;
 		}
-		
+
         if ($status) {
 			$total_data[] = array(
 				'code'       => 'klarna_fee',
@@ -51,9 +51,9 @@ class ModelTotalKlarnaFee extends Model {
 				'value'      => $klarna_fee[$address['iso_code_3']]['fee'],
 				'sort_order' => $klarna_fee[$address['iso_code_3']]['sort_order']
 			);
-			
+
 			$tax_rates = $this->tax->getRates($klarna_fee[$address['iso_code_3']]['fee'], $klarna_fee[$address['iso_code_3']]['tax_class_id']);
-			
+
 			foreach ($tax_rates as $tax_rate) {
 				if (!isset($taxes[$tax_rate['tax_rate_id']])) {
 					$taxes[$tax_rate['tax_rate_id']] = $tax_rate['amount'];
@@ -61,7 +61,7 @@ class ModelTotalKlarnaFee extends Model {
 					$taxes[$tax_rate['tax_rate_id']] += $tax_rate['amount'];
 				}
 			}
-			
+
 			$total += $klarna_fee[$address['iso_code_3']]['fee'];
         }
     }


### PR DESCRIPTION
When the order has a Klarna fee and is updated in the admin panel, the fee is removed. 

This is because neither the address or the selected payment option is available in `ModelTotalKlarnaFee` when called from the admin panel. 

This pull request changes how the information is retrieved to fetch the required information from the `POST` request instead. 

This issue has been verified in version 1.5.5.1 and this fix has been tested with that version. 
