### PR TITLE
REDUNDANT SORTING?

### DIFF
--- a/upload/catalog/controller/checkout/cart.php
+++ b/upload/catalog/controller/checkout/cart.php
@@ -216,14 +216,6 @@ class ControllerCheckoutCart extends Controller {
 						$this->{'model_total_' . $result['code']}->getTotal($total_data, $total, $taxes);
 					}
 				}
-				
-				$sort_order = array(); 
-			  
-				foreach ($total_data as $key => $value) {
-					$sort_order[$key] = $value['sort_order'];
-				}
-	
-				array_multisort($sort_order, SORT_ASC, $total_data);				
 			}
 			
 			$data['totals'] = $total_data;


### PR DESCRIPTION
Can anyone confirm?

this

``` PHP
array_multisort($sort_order, SORT_ASC, $results);
```

is sorting the $results array already. Inside the $results loop each total model modifies $total_data always appending a new array. So $total_data elements should be already sorted by the corresponding "{model_total}_sort_order".

This is done in many other places.

Can anyone confirm? 

regards
