### PR TITLE
issue #1020 - One way to make the list/grid controls responsive again

### DIFF
--- a/upload/catalog/view/javascript/common.js
+++ b/upload/catalog/view/javascript/common.js
@@ -51,11 +51,21 @@ $(document).ready(function() {
 	// Product-grid to product-list
 	$('#list-view').click(function() {
 		$('.product-grid').removeClass('product-grid').addClass('product-list');
+		$('.product-list').removeClass('col-lg-4 col-md-4 col-sm-6 col-xs-12');
+		$('.product-list').addClass('col-sm-12');
+		$('.product-list .product-thumb').addClass('row');
+		$('.product-list .image').addClass('col-sm-2');
+		$('.product-list .caption').addClass('col-sm-7');
 	});
 	
 	// Product-list to product-grid
 	$('#grid-view').click(function() {
 		$('.product-list').removeClass('product-list').addClass('product-grid');
+		$('.product-grid').removeClass('col-sm-12');
+		$('.product-grid .product-thumb').removeClass('row');
+		$('.product-grid').addClass('col-lg-4 col-md-4 col-sm-6 col-xs-12');
+		$('.product-grid .image').removeClass('col-sm-2');
+		$('.product-grid .caption').removeClass('col-sm-7');
 	});
 	
 	// tooltips on hover

--- a/upload/catalog/view/theme/default/stylesheet/stylesheet.css
+++ b/upload/catalog/view/theme/default/stylesheet/stylesheet.css
@@ -579,10 +579,6 @@ h2.price {
 }
 }
 
-
-
-
-
 .product-list .col-sm-3 {
 	float: none;
 	width: auto;
@@ -592,18 +588,12 @@ h2.price {
 }
 .product-list .product-thumb .image {
 	padding: 0 2%;
-	float: left;
-	width: 26%;
 }
 .product-list .product-thumb .caption {
 	padding: 0;
-	float: left;
-	width: 70%;
+        min-height: 0px;
 }
 .product-list .product-thumb .button-group {
-	float: left;
-	width: 70%;
-	width: 250px;
 	border: 1px solid #DDD;
 }
 

--- a/upload/catalog/view/theme/default/template/module/bestseller.tpl
+++ b/upload/catalog/view/theme/default/template/module/bestseller.tpl
@@ -1,5 +1,5 @@
 <h3><?php echo $heading_title; ?></h3>
-<div class="row product-layout">
+<div class="row product-layout product-grid">
   <?php foreach ($products as $product) { ?>
   <div class="col-lg-3 col-md-3 col-sm-6 col-xs-12">
     <div class="product-thumb transition">

--- a/upload/catalog/view/theme/default/template/module/featured.tpl
+++ b/upload/catalog/view/theme/default/template/module/featured.tpl
@@ -1,5 +1,5 @@
 <h3><?php echo $heading_title; ?></h3>
-<div class="row product-layout">
+<div class="row product-layout product-grid">
   <?php foreach ($products as $product) { ?>
   <div class="col-lg-3 col-md-3 col-sm-6 col-xs-12">
     <div class="product-thumb transition">

--- a/upload/catalog/view/theme/default/template/module/latest.tpl
+++ b/upload/catalog/view/theme/default/template/module/latest.tpl
@@ -1,5 +1,5 @@
 <h3><?php echo $heading_title; ?></h3>
-<div class="row product-layout">
+<div class="row product-layout product-grid">
   <?php foreach ($products as $product) { ?>
   <div class="col-lg-3 col-md-3 col-sm-6 col-xs-12">
     <div class="product-thumb transition">

--- a/upload/catalog/view/theme/default/template/module/special.tpl
+++ b/upload/catalog/view/theme/default/template/module/special.tpl
@@ -1,5 +1,5 @@
 <h3><?php echo $heading_title; ?></h3>
-<div class="row product-layout">
+<div class="row product-layout product-grid">
   <?php foreach ($products as $product) { ?>
   <div class="col-lg-3 col-md-3 col-sm-6 col-xs-12">
     <div class="product-thumb transition">

--- a/upload/catalog/view/theme/default/template/product/category.tpl
+++ b/upload/catalog/view/theme/default/template/product/category.tpl
@@ -101,7 +101,7 @@
         <?php } else { ?>
         <?php $class = 'col-lg-3 col-md-3 col-sm-6 col-xs-12'; ?>
         <?php } ?>
-        <div class="<?php echo $class; ?> product-layout">
+        <div class="<?php echo $class; ?> product-layout product-grid">
           <div class="product-thumb transition">
             <div class="image"><a href="<?php echo $product['href']; ?>"><img src="<?php echo $product['thumb']; ?>" alt="<?php echo $product['name']; ?>" title="<?php echo $product['name']; ?>" class="img-responsive" /></a></div>
             <div class="caption">


### PR DESCRIPTION
- Changing grid classes through common.js when list/grid controls are clicked.
- Removed some css rendered obsolete by the above.
- Added product-grid class in several tpl files.
  (products are in grid layout by default)
- A few minor tweaks.

The script in common.js worked on the product-grid and product-list classes, which were missing, hence the additions to the tpl files. Extended the same script to change around the grid classes for a row layout.

As it looks like this was kind of a todo after some layout changes, I'm unsure whether this is the best way, so do review with care.
