### PR TITLE
Fixed disabled currencies being usable by customers

### DIFF
--- a/upload/system/library/currency.php
+++ b/upload/system/library/currency.php
@@ -11,16 +11,8 @@ class Currency {
 		$this->session = $registry->get('session');
 
 		$query = $this->db->query("SELECT * FROM " . DB_PREFIX . "currency");
-
 		foreach ($query->rows as $result) {
-			$this->currencies[$result['code']] = array(
-				'currency_id'   => $result['currency_id'],
-				'title'         => $result['title'],
-				'symbol_left'   => $result['symbol_left'],
-				'symbol_right'  => $result['symbol_right'],
-				'decimal_place' => $result['decimal_place'],
-				'value'         => $result['value']
-			); 
+			$this->currencies[$result['code']] = $result;
 		}
 
 		if (isset($this->request->get['currency']) && (array_key_exists($this->request->get['currency'], $this->currencies))) {
@@ -29,12 +21,17 @@ class Currency {
 			$this->set($this->session->data['currency']);
 		} elseif ((isset($this->request->cookie['currency'])) && (array_key_exists($this->request->cookie['currency'], $this->currencies))) {
 			$this->set($this->request->cookie['currency']);
-		} else {
+		}
+		if (!$this->code) {
 			$this->set($this->config->get('config_currency'));
 		}
 	}
 
 	public function set($currency) {
+		if (empty($this->currencies[$currency]['status'])) {
+			return false;
+		}
+		
 		$this->code = $currency;
 
 		if (!isset($this->session->data['currency']) || ($this->session->data['currency'] != $currency)) {


### PR DESCRIPTION
Currencies with a status of "Disabled" can still be selected from the frontend using the URL `http://example.com/?currency=GBP` for example. Disabled currencies also remain in a user's session and orders placed will use the currency selected.

The commit fixes both issues as simply as possible.

Edit: Sorry for the duplicate pull requests. Still kinda learning to use GitHub...
