### PR TITLE
Update success.php

### DIFF
--- a/upload/catalog/controller/checkout/success.php
+++ b/upload/catalog/controller/checkout/success.php
@@ -37,6 +37,7 @@ class ControllerCheckoutSuccess extends Controller {
 			unset($this->session->data['reward']);
 			unset($this->session->data['voucher']);
 			unset($this->session->data['vouchers']);
+			unset($this->session->data['totals']); 
 		}	
 		
 		$this->document->setTitle($this->language->get('heading_title'));


### PR DESCRIPTION
If totals are not unset on success, store credit can be double spent using the multiple browser method and cause negative store credit balance. 
I cannot think of any reaon why totals should not be unset on order success, so I have added one line for doing so.
