### PR TITLE
check for customer negative store credit balance before confirm order 

### DIFF
--- a/upload/catalog/language/english/mail/order.php
+++ b/upload/catalog/language/english/mail/order.php
@@ -33,3 +33,4 @@ $_['text_update_order_status']  = 'Your order has been updated to the following 
 $_['text_update_comment']       = 'The comments for your order are:';
 $_['text_update_link']          = 'To view your order click on the link below:';
 $_['text_update_footer']        = 'Please reply to this email if you have any questions.';
+$_['text_negative_balance']     = '<span style="color:red;">Negative Customer Balance.</span>';

--- a/upload/catalog/model/checkout/order.php
+++ b/upload/catalog/model/checkout/order.php
@@ -158,7 +158,13 @@ class ModelCheckoutOrder extends Model {
 		} else {
 			return false;	
 		}
-	}	
+	}
+	
+	// get the customer balance
+  	public function getBalance($customer_id) {
+		$query = $this->db->query("SELECT SUM(amount) AS total FROM " . DB_PREFIX . "customer_transaction WHERE customer_id = '" . (int)$customer_id . "'");
+		return $query->row['total'];
+  	}
 
 	public function confirm($order_id, $order_status_id, $comment = '', $notify = false) {
 		$order_info = $this->getOrder($order_id);
@@ -179,6 +185,16 @@ class ModelCheckoutOrder extends Model {
 			$status = false;
 			
 			$this->load->model('account/customer');
+			
+			 // check if customer balance is negative
+			$this->load->language('mail/order');
+			if ($order_info['customer_id']) {
+				$customerbalance = $this->getBalance($order_info['customer_id']); // get balance
+			if ((int)$customerbalance < 0) {
+					$order_status_id = $this->config->get('config_order_status_id');
+					$comment = $this->language->get('text_negative_balance');
+				}
+			}	
 			
 			if ($order_info['customer_id']) {
 				$results = $this->model_account_customer->getIps($order_info['customer_id']);
@@ -601,6 +617,16 @@ class ModelCheckoutOrder extends Model {
 			$status = false;
 			
 			$this->load->model('account/customer');
+			
+			 // check if customer balance is negative
+			$this->load->language('mail/order');
+			if ($order_info['customer_id']) {
+				$customerbalance = $this->getBalance($order_info['customer_id']); // get balance
+			if ((int)$customerbalance < 0) {
+					$order_status_id = $this->config->get('config_order_status_id');
+					$comment = $this->language->get('text_negative_balance');
+				}
+			}
 			
 			if ($order_info['customer_id']) {
 				$results = $this->model_account_customer->getIps($order_info['customer_id']);


### PR DESCRIPTION
A quick and effective fix to prevent customers using the multiple browser trick and double-spent store credit resulting in complete orders but negative store balance.

Modification simply checks the customer balance on callback (confirm or update) and if the store-credit is negative it sets the order to pending and adds a red notice in the order history.
