### PR TITLE
Update /upload/system/library/captcha.php

### DIFF
--- a/upload/system/library/captcha.php
+++ b/upload/system/library/captcha.php
@@ -9,7 +9,11 @@ class Captcha {
 	}
 
 	function getCode(){
-		return $this->code;
+		$out = ob_get_contents();
+		$out = str_replace(array("\n", "\r", "\t", " "), "", $this->code);
+		ob_end_clean();
+		
+		return $out;
 	}
 
 	function showImage() {


### PR DESCRIPTION
Newlines at the beginning of images being generated causes the images to not render (broken image shown instead).

This fixes the possible newline at the beginning of the code ensuring the image generates correctly.
