### PR TITLE
added htacess commented option for font-awesome

### DIFF
--- a/upload/.htaccess.txt
+++ b/upload/.htaccess.txt
@@ -52,3 +52,10 @@ RewriteRule ^([^?]*) index.php?_route_=$1 [L,QSA]
 
 # 7. disable open_basedir limitations
 # php_admin_value open_basedir none
+
+# 8. If Font-Awesome icons aren't displaying correctly for alternate paths, domains, or subdomains on the same server, this may help:
+#<FilesMatch "\.(ttf|ttc|otf|eot|woff)$">
+# <IfModule mod_headers.c>
+#  Header set Access-Control-Allow-Origin "*"
+# </IfModule>
+#</FilesMatch>


### PR DESCRIPTION
I have two different subdomains that root at the same open cart install.
Font-awesome doesn't allow the other alternate subdomain to use the font files.

adding

<FilesMatch "\.(ttf|ttc|otf|eot|woff)$">
 <IfModule mod_headers.c>
  Header set Access-Control-Allow-Origin "*"
 </IfModule>
</FilesMatch>

fixes this.

For example: If you have an existing website, foo-company.com that roots at ~/public_html and want to install opencart to store.foo-company.com that roots at ~/publc_html/store, font-awesome will work for store.foo-company.com, but it will not work for foo-company.com/store

This edit fixes it so that icons will display correctly in both urls.
