### PR TITLE
Fix cli_installer.php

### DIFF
--- a/upload/install/cli_install.php
+++ b/upload/install/cli_install.php
@@ -77,7 +77,7 @@ function get_options($argv) {
 	$defaults = array(
 		'db_hostname' => 'localhost',
 		'db_database' => 'opencart',
-		'db_prefix' => '',
+		'db_prefix' => 'oc_',
 		'db_driver' => 'mysqli',
 		'username' => 'admin',
 		'agree_tnc' => 'no',


### PR DESCRIPTION
Hello, 

I tried to make change to less file as possible to ensure it won't impact the web installer.
For this reason, I need to make a few change on arguments name.

```
Usage:
======

php cli_install.php install --db_hostname localhost --db_username root --db_password pass --db_database opencart --db_driver mysqli --username admin --password admin --email youremail@example.com --agree_tnc yes --http_server http://localhost/opencart
```

I also add a new argument called `db_driver` which is `mysqli` by default.
I removed directories permission checking since the installer can handle this on its own.

Hope this merge request help you.
