### PR TITLE
fix mismatched variable name in installer

### DIFF
--- a/upload/install/controller/step_3.php
+++ b/upload/install/controller/step_3.php
@@ -242,7 +242,7 @@ class ControllerStep3 extends Controller {
 		if ($this->request->post['db_driver'] == 'mysqli') {
 			$connection = @new mysqli($this->request->post['db_hostname'], $this->request->post['db_username'], $this->request->post['db_password'], $this->request->post['db_database']);
 
-			if ($mysqli->connect_error) {
+			if ($connection->connect_error) {
 				$this->error['warning'] = 'Error: Could not connect to the database please make sure the database server, username and password is correct!';
 			} else {
 				$connection->close();


### PR DESCRIPTION
Since commit b2aaa7d2fc251acc3b3a31833c26518bbd5de91f I received a lot of "Undefined variable: mysqli in ~/install/controller/step_3.php on line 245" notices. This will fix it.
