### PR TITLE
load account/activity module in shipping_address

### DIFF
--- a/upload/catalog/controller/checkout/shipping_address.php
+++ b/upload/catalog/controller/checkout/shipping_address.php
@@ -199,6 +199,10 @@ class ControllerCheckoutShippingAddress extends Controller {
 					unset($this->session->data['shipping_method']);						
 					unset($this->session->data['shipping_methods']);
 					
+					
+					// Add to activity log
+					$this->load->model('account/activity');
+			
 					$activity_data = array(
 						'customer_id' => $this->customer->getId(),
 						'name'        => $this->customer->getFirstName() . ' ' . $this->customer->getLastName()


### PR DESCRIPTION
Someone forgot to load the module.  This causes a fatal error otherwise.
I found this error while attempting to input different billing and shipping addresses
