### PR TITLE
Optimised to open and close file once, rather than each write.

### DIFF
--- a/upload/system/library/log.php
+++ b/upload/system/library/log.php
@@ -1,18 +1,17 @@
 <?php
 class Log {
-	private $filename;
+	private $filehandle;
 
 	public function __construct($filename) {
-		$this->filename = $filename;
+		$file = DIR_LOGS . $filename;
+		$this->filehandle = fopen($file, 'a');
+	}
+
+	public function __destruct() {
+		fclose($this->filehandle); 
 	}
 
 	public function write($message) {
-		$file = DIR_LOGS . $this->filename;
-
-		$handle = fopen($file, 'a'); 
-
-		fwrite($handle, date('Y-m-d G:i:s') . ' - ' . $message . "\n");
-
-		fclose($handle); 
+		fwrite($this->filehandle, date('Y-m-d G:i:s') . ' - ' . $message . "\n");
 	}
 }


### PR DESCRIPTION
This pays dividends when used with tools writing lots of log messages. One file open/close per class instance rather than open/write/close per $log->write($msg).
