### PR TITLE
Handle AJAX request when session has timed out

### DIFF
--- a/upload/admin/controller/common/login.php
+++ b/upload/admin/controller/common/login.php
@@ -7,7 +7,9 @@ class ControllerCommonLogin extends Controller {
 
 		$this->document->setTitle($this->language->get('heading_title'));
 
-		if ($this->user->isLogged() && isset($this->request->get['token']) && ($this->request->get['token'] == $this->session->data['token'])) {
+		if (!empty($this->request->server['HTTP_X_REQUESTED_WITH']) && strtolower($this->request->server['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest') {
+			die($this->language->get('error_token'));
+		} elseif ($this->user->isLogged() && isset($this->request->get['token']) && ($this->request->get['token'] == $this->session->data['token'])) {
 			$this->response->redirect($this->url->link('common/dashboard', 'token=' . $this->session->data['token'], 'SSL'));
 		}
 


### PR DESCRIPTION
Problem: You are logged in to admin (and the user session has timed out). Then you use a function that performs an ajax request. What happens is this: the login page is returned as a result to the ajax request, which cannot be handled and causes confusion to the user.

This is where the magic happens: HTTP_X_REQUESTED_WITH == 'xmlhttprequest'
This works to detect ajax requests from all javascript libraries. 

Maybe there's a better solution to this, like returning a:
$json['error'] = $this->language->get('error_token');

But that requires that the ajax call functions handles it.
