### PR TITLE
mysqli_result::num_rows

### DIFF
--- a/upload/system/library/driver/database/mysqli.php
+++ b/upload/system/library/driver/database/mysqli.php
@@ -16,7 +16,7 @@ final class DBMySQLi {
 		$query = $this->link->query($sql);
 
 		if (!$this->link->errno) {
-			if (isset($query->num_rows)) {
+			if ($query instanceof mysqli_result) {
 				$data = array();
 
 				while ($row = $query->fetch_assoc()) {


### PR DESCRIPTION
Please verify.
If you still use php 5.2 but want to switch to mysqli driver $query->num_rows will not pass the isset test.
For mysqli : a SELECT (and SHOW and DESCRIBE) statement will always return a mysqli_result, in other cases it will return a boolean, so we could just check the return type.
