### PR TITLE
strip browser locale priority before comparing

### DIFF
--- a/upload/index.php
+++ b/upload/index.php
@@ -147,7 +147,7 @@ if (isset($request->server['HTTP_ACCEPT_LANGUAGE']) && $request->server['HTTP_AC
 					$locale = strtolower(str_replace('_', '-', $locale));
 					if ($locale === $browser_locale) {
 						$detect = $key;
-						break 2;
+						break 3;
 					}
 				}
 			}


### PR DESCRIPTION
could be worth moving browser detect inside elseif line 162 to avoid unnecessary checks.

could also be worth (as i always do in my setups) refactoring error handler and language detection to their own classes and thus having a cleaner index.

kind regards
