### PR TITLE
Insert space between BASE64 encoded sender name and email address

### DIFF
--- a/upload/system/library/mail.php
+++ b/upload/system/library/mail.php
@@ -193,7 +193,7 @@ class Mail {
 					
 					$reply = '';
 
-					while ($line = fgets($handle, 515) and $line === false) {
+					while ($line = fgets($handle, 515)) {
 						$reply .= $line;
 
 						if (substr($line, 3, 1) == ' ') {


### PR DESCRIPTION
Fix for https://github.com/opencart/opencart/issues/190. Without a space between the BASE64 encoded sender name and email address spamassassin triggers the FROM_MISSP_REPLYTO and TO_NO_BRKTS_FROM_MSSP rules giving a very high score to the message. This results in messages being caught in junk filters or discarded.
