### PR TITLE
Wait for the banner message from the mail server before delivery

### DIFF
--- a/upload/system/library/mail.php
+++ b/upload/system/library/mail.php
@@ -165,7 +165,7 @@ class Mail {
 					socket_set_timeout($handle, $this->timeout, 0);
 				}
 
-				while ($line = fgets($handle, 515)) {
+				while ($line = fgets($handle, 515) and $line === false) {
 					if (substr($line, 3, 1) == ' ') {
 						break;
 					}


### PR DESCRIPTION
Wait until the banner message from the mail server is displayed before continuing. In the event of a successful connection to the mail server but no welcome message yet - because the server is slow to respond - the mail library would simply continue with the SMTP conversation resulting in a "554 SMTP synchronization error". This change loops until $line (the response from the mail server) is not false. Ref: http://www.faqs.org/rfcs/rfc2821.html, section 3.1.
