### PR TITLE
http_server followed by a trailing slash

### DIFF
--- a/upload/install/cli_install.php
+++ b/upload/install/cli_install.php
@@ -118,6 +118,9 @@ function valid($options) {
 	if ($options['agree_tnc'] !== 'yes') {
 		$missing[] = 'agree_tnc (should be yes)';
 	}
+	if (!preg_match('#/$#', $options['http_server'])) {
+		$options['http_server'] = $options['http_server'].'/';
+	}
 	$valid = count($missing) === 0 && $options['agree_tnc'] === 'yes';
 	return array($valid, $missing);
 }


### PR DESCRIPTION
File usage advice to use --http_server http://localhost/opencart (without trailing slash) and the CLI installer concatenate other directories without adding "/" before the concatenated directory thus saving wrong URLs in config files as eg.: http://localhost/opencartadmin
