### PR TITLE
File cache driver optimizations

### DIFF
--- a/upload/system/library/driver/cache/file.php
+++ b/upload/system/library/driver/cache/file.php
@@ -5,12 +5,10 @@ class CacheFile {
 	public function __construct($expire = 3600) {
 		$this->expire = $expire;
 		
-		$files = glob(DIR_CACHE . 'cache.*');
-
-		if ($files) {			
+		if (rand(1,100) <= 30 && $files = glob(DIR_CACHE . 'cache.*')) {
 			foreach ($files as $file) {
 				$time = substr(strrchr($file, '.'), 1);
-
+	
 				if ($time < time()) {
 					if (file_exists($file)) {
 						unlink($file);
@@ -39,11 +37,7 @@ class CacheFile {
 
 		$file = DIR_CACHE . 'cache.' . preg_replace('/[^A-Z0-9\._-]/i', '', $key) . '.' . (time() + $this->expire);
 
-		$handle = fopen($file, 'w');
-
-		fwrite($handle, serialize($value));
-
-		fclose($handle);
+		file_put_contents($file, serialize($value), LOCK_EX);
 	}
 
 	public function delete($key) {


### PR DESCRIPTION
1. Replace fopen(), fwrite() and fclose() with file_put contents to avoid race conditions when writing the file contents. Currently an exclusive lock is not acquired which could cause unexpected errors when multiple php threads try to save the same file.
2. Cache cleanup optimization. Currently a cleanup is executed on every request, which is not necessary and is more or less a performance penalty (especially when having thousands of cache files, which is the case with some extensions) . I added a condition, so the cleanup is executed randomly based on probability It's currently 30%, but you can change it (or make it a setting) if you want.
