### PR TITLE
Escape special chars in product name and model

### DIFF
--- a/upload/catalog/controller/payment/pp_standard.php
+++ b/upload/catalog/controller/payment/pp_standard.php
@@ -43,8 +43,8 @@ class ControllerPaymentPPStandard extends Controller {
 				}
 
 				$data['products'][] = array(
-					'name'     => $product['name'],
-					'model'    => $product['model'],
+					'name'     => htmlspecialchars($product['name']),
+					'model'    => htmlspecialchars($product['model']),
 					'price'    => $this->currency->format($product['price'], $order_info['currency_code'], false, false),
 					'quantity' => $product['quantity'],
 					'option'   => $option_data,


### PR DESCRIPTION
As this is passed more or less directly to the HTML-Form in the view, having special chars in the product name could prevent correct data from being send
