### PR TITLE
Added separate log message for total paid mismatch

### DIFF
--- a/upload/catalog/controller/payment/pp_standard.php
+++ b/upload/catalog/controller/payment/pp_standard.php
@@ -162,7 +162,7 @@ class ControllerPaymentPPStandard extends Controller {
 								$this->log->write('PP_STANDARD :: TOTAL PAID MISMATCH! ' . $this->request->post['mc_gross']);
 							}
 						}
-					break;
+						break;
 					case 'Denied':
 						$order_status_id = $this->config->get('pp_standard_denied_status_id');
 						break;


### PR DESCRIPTION
Rather than using the "Receiver Email Mismatch" log message for when the paid value is the issue for a "Paypal Standard" payment, log a separate message.
