### PR TITLE
remove redundant product_attribute DELETE queries

### DIFF
--- a/upload/admin/model/catalog/product.php
+++ b/upload/admin/model/catalog/product.php
@@ -147,8 +147,6 @@ class ModelCatalogProduct extends Model {
 		if (!empty($data['product_attribute'])) {
 			foreach ($data['product_attribute'] as $product_attribute) {
 				if ($product_attribute['attribute_id']) {
-					$this->db->query("DELETE FROM " . DB_PREFIX . "product_attribute WHERE product_id = '" . (int)$product_id . "' AND attribute_id = '" . (int)$product_attribute['attribute_id'] . "'");
-					
 					foreach ($product_attribute['product_attribute_description'] as $language_id => $product_attribute_description) {				
 						$this->db->query("INSERT INTO " . DB_PREFIX . "product_attribute SET product_id = '" . (int)$product_id . "', attribute_id = '" . (int)$product_attribute['attribute_id'] . "', language_id = '" . (int)$language_id . "', text = '" .  $this->db->escape($product_attribute_description['text']) . "'");
 					}


### PR DESCRIPTION
previous (outside the if condition) query

DELETE FROM product_attribute WHERE product_id = :product_id"

already gets rid of the rows
