### PR TITLE
Fixing the usage of ternary operator in model which caused Empty Query error

### DIFF
--- a/upload/admin/model/openbay/amazon_listing.php
+++ b/upload/admin/model/openbay/amazon_listing.php
@@ -119,7 +119,7 @@ class ModelOpenbayAmazonListing extends Model {
 		$response = (array)$response;
 
 		if($response['status'] === 1) {
-			$this->db->query("REPLACE INTO `" . DB_PREFIX . "amazon_product` SET `product_id` = " . (int)$data['product_id'] . ", `status` = 'uploaded', `marketplaces` = '" . $this->db->escape($data['marketplace']) . "', `version` = 3, `var` = '" . isset($data['var']) ? $this->db->escape($data['var']) : '' . "'");
+			$this->db->query("REPLACE INTO `" . DB_PREFIX . "amazon_product` SET `product_id` = " . (int)$data['product_id'] . ", `status` = 'uploaded', `marketplaces` = '" . $this->db->escape($data['marketplace']) . "', `version` = 3, `var` = '" . $this->db->escape(isset($data['var']) ? $data['var'] : '') . "'");
 		}
 
 		return $response;


### PR DESCRIPTION
Fixed the Empty Query error caused by incorrect usage of the ternary operator.
