### PR TITLE
Update payment_address.php

### DIFF
--- a/upload/catalog/controller/checkout/payment_address.php
+++ b/upload/catalog/controller/checkout/payment_address.php
@@ -178,7 +178,8 @@ class ControllerCheckoutPaymentAddress extends Controller {
 						'customer_id' => $this->customer->getId(),
 						'name'        => $this->customer->getFirstName() . ' ' . $this->customer->getLastName()
 					);
-
+					
+					$this->load->model('account/activity');
 					$this->model_account_activity->addActivity('address_add', $activity_data);
 				}
 			}


### PR DESCRIPTION
Fixes an Error when adding a new address while checking out. (I don't know if this error is caused because I imported a backup from an older version of OpenCart, or if this is a normal issue, but this fixed it either way)

The error was: (Which is caused by the missing addActivity function found in file in the added line)
SyntaxError: JSON.parse: unexpected character at line 1 column 1 of the JSON data
OK

<b>Fatal error</b>:  Call to a member function addActivity() on a non-object in <b>Z:\xampp\htdocs\printstore2\catalog\controller\checkout\payment_address.php</b> on line <b>182</b><br />

![error](https://cloud.githubusercontent.com/assets/7613391/3006470/21b0e6d2-de2e-11e3-8c5b-573fc3698b6c.jpg)
