### PR TITLE
Changes quantity Input from Normal Text to Number

### DIFF
--- a/upload/catalog/view/theme/default/template/product/product.tpl
+++ b/upload/catalog/view/theme/default/template/product/product.tpl
@@ -306,7 +306,7 @@
             <?php } ?>
             <div class="form-group">
               <label class="control-label" for="input-quantity"><?php echo $entry_qty; ?></label>
-              <input type="text" name="quantity" value="<?php echo $minimum; ?>" size="2" id="input-quantity" class="form-control" />
+              <input type="number" name="quantity" value="<?php echo $minimum; ?>" size="2" id="input-quantity" class="form-control" />
               <input type="hidden" name="product_id" value="<?php echo $product_id; ?>" />
               <br />
               <button type="button" id="button-cart" data-loading-text="<?php echo $text_loading; ?>" class="btn btn-primary btn-lg btn-block"><?php echo $button_cart; ?></button>
@@ -434,7 +434,7 @@ $('#button-cart').on('click', function() {
     $.ajax({
         url: 'index.php?route=checkout/cart/add',
         type: 'post',
-        data: $('#product input[type=\'text\'], #product input[type=\'date\'], #product input[type=\'datetime-local\'], #product input[type=\'time\'], #product input[type=\'hidden\'], #product input[type=\'radio\']:checked, #product input[type=\'checkbox\']:checked, #product select, #product textarea'),
+        data: $('#product input[type=\'text\'],#product input[type=\'number\'], #product input[type=\'date\'], #product input[type=\'datetime-local\'], #product input[type=\'time\'], #product input[type=\'hidden\'], #product input[type=\'radio\']:checked, #product input[type=\'checkbox\']:checked, #product select, #product textarea'),
         dataType: 'json',
         beforeSend: function() {
         	$('#button-cart').button('loading');


### PR DESCRIPTION
Changes the Quantity input box to a number instead of a text.  This added a Up and Down Arrow to the box on a normal browser (except older ones that don't support number as an input, they default to text), also brings up a number pad on a mobile device instead of the normal text input keyboard.

"#product input[type=\'number\']," is added to line 437 to make the ajax query work with the new number input.
DO NOT REMOVE THE TEXT INPUT, This will cause older browsers like IE6 to only add 1 item, even if the input is 20 as they default to text.
