### PR TITLE
Fixed Admin Order Updates

### DIFF
--- a/upload/admin/controller/sale/order.php
+++ b/upload/admin/controller/sale/order.php
@@ -640,7 +640,7 @@ class ControllerSaleOrder extends Controller {
 
 		$data['cancel'] = $this->url->link('sale/order', 'token=' . $this->session->data['token'] . $url, 'SSL');
 
-		if (isset($this->request->get['order_id']) && ($this->request->server['REQUEST_METHOD'] != 'POST')) {
+		if (isset($this->request->get['order_id'])) {
 			$order_info = $this->model_sale_order->getOrder($this->request->get['order_id']);
 		}
 


### PR DESCRIPTION
With the "&& ($this->request->server['REQUEST_METHOD'] != 'POST')" still in the changed line, updating an order from the admin panel caused a long list of errors stating $order_info wasn't defined.

Besides I don't see the need to check the GET variable and the request method, if the get is set, then we obviously didn't use POST. and if it was a POST, the GET will not be set, if I am wrong, please let me know how, and show me a better way to do this.
