### PR TITLE
Typo error in date_modified field in api table

### DIFF
--- a/upload/install/opencart.sql
+++ b/upload/install/opencart.sql
@@ -215,7 +215,7 @@ CREATE TABLE IF NOT EXISTS `oc_api` (
   `key` text NOT NULL,
   `status` tinyint(1) NOT NULL,
   `date_added` datetime NOT NULL,
-  `date_modififed` datetime NOT NULL,
+  `date_modified` datetime NOT NULL,
   PRIMARY KEY (`api_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 


### PR DESCRIPTION
this throws an runtime error when you try to save an API
