### PR TITLE
Update encryption.php

### DIFF
--- a/upload/system/library/encryption.php
+++ b/upload/system/library/encryption.php
@@ -7,10 +7,10 @@ final class Encryption {
 	}
 
 	public function encrypt($value) {
-		return strtr(base64_encode(mcrypt_encrypt(MCRYPT_RIJNDAEL_256, hash('sha256', $this->key, true), $value, MCRYPT_MODE_ECB)), '+/=', '-_,');
+		return strtr(base64_encode(mcrypt_encrypt(MCRYPT_RIJNDAEL_128, hash('sha256', $this->key, true), $value, MCRYPT_MODE_ECB)), '+/=', '-_,');
 	}
 
 	public function decrypt($value) {
-		return trim(mcrypt_decrypt(MCRYPT_RIJNDAEL_256, hash('sha256', $this->key, true), base64_decode(strtr($value, '-_,', '+/=')), MCRYPT_MODE_ECB));
+		return trim(mcrypt_decrypt(MCRYPT_RIJNDAEL_128, hash('sha256', $this->key, true), base64_decode(strtr($value, '-_,', '+/=')), MCRYPT_MODE_ECB));
 	}
 }


### PR DESCRIPTION
MCRYPT_RIJNDAEL_256 is not AES. AES is specifically only a 128-bit block cipher.

Note: There are numerous other issues here. ECB for payment data? No IV or authentication? Will revisit later.
