### PR TITLE
Pass all translations to view in Controller::render()

### DIFF
--- a/upload/system/engine/controller.php
+++ b/upload/system/engine/controller.php
@@ -76,6 +76,7 @@ abstract class Controller {
 
 		if (file_exists(DIR_TEMPLATE . $this->template)) {
 			extract($this->data);
+			extract($this->language->all());
 
 			ob_start();
 

--- a/upload/system/library/language.php
+++ b/upload/system/library/language.php
@@ -40,5 +40,9 @@ class Language {
 		//	exit();
 		}
 	}
+
+    public function all() {
+        return $this->data;
+    }
 }
 ?>


### PR DESCRIPTION
There are tons of code as following in Controller derived classes,

```
$this->data['head_title'] = $this->language->get('head_title');
$this->data['......'] = $this->language->get('......');
```

it's boring and not insteresting. we can avoid this is by adding one line of code
in Controller::render(),

```
extract($this->language->all());
```

where all() is a new method of Language class, it just returns all translations.

By doing this, the tons of boring code can be removed without any side effect.
