### PR TITLE
PayPal Express total fix

### DIFF
--- a/upload/catalog/model/payment/pp_express.php
+++ b/upload/catalog/model/payment/pp_express.php
@@ -173,7 +173,7 @@ class ModelPaymentPPExpress extends Model {
 
 			$data['L_PAYMENTREQUEST_0_DESC' . $i] = substr($data['L_PAYMENTREQUEST_0_DESC' . $i], 0, 126);
 
-			$item_price = $this->currency->format($item['price'], false, false, false);
+			$item_price = $this->currency->format($this->tax->calculate($item['price'], $item['tax_class_id'], $this->config->get('config_tax')), false, false, false);
 
 			$data['L_PAYMENTREQUEST_0_NAME' . $i] = $item['name'];
 			$data['L_PAYMENTREQUEST_0_NUMBER' . $i] = $item['model'];
@@ -254,7 +254,7 @@ class ModelPaymentPPExpress extends Model {
 		}
 
 		foreach ($total_data as $total_row) {
-			if (!in_array($total_row['code'], array('total', 'sub_total'))) {
+			if (!in_array($total_row['code'], array('total', 'sub_total', 'tax'))) {
 				if ($total_row['value'] != 0) {
 					$item_price = $this->currency->format($total_row['value'], false, false, false);
 


### PR DESCRIPTION
Hello,
my customer noticed that his customers paid a few cents more or less compared to the order's total.

After a quick check I noticed that the issue was with the informations sent to PayPal.

Open Cart calculates the taxes by getting the taxes for a single product and multiplying it for the quantity.
The extension sends to PayPal the net price of the product, the quantity and then the total taxes as if it was another product. The problem is that the total can be different in some cases.

Here it is an example:
**Product A**
Net price: € 1.13
Taxes: 10%
Gross price: € 1.24
Quantity: 100
Taxes: € 11.27
Total price: € 124.00

PayPal receives:
**Product A**
Net price: € 1.13
Quantity: 100
Total: € 113.00

**Taxes** (as (round(net_price \* tax_rate) \* quantity) and not (round(net_price \* quantity) \* tax_rate))
Total: € 11.27

**Total**
€ 124.27

As you can see, on PayPal you'll pay € 124.27 instead of € 124.00 as specified by Open Cart.
The change I'm proposing will send to PayPal the gross price of the product and will not send the taxes as a separate entity.

Thank you
