### PR TITLE
Improve image lib and tool

### DIFF
--- a/upload/catalog/model/tool/image.php
+++ b/upload/catalog/model/tool/image.php
@@ -1,14 +1,15 @@
 <?php
 class ModelToolImage extends Model {
-	public function resize($filename, $width, $height) {
+	public function resize($filename, $width, $height, $type = '') {
 		if (!is_file(DIR_IMAGE . $filename)) {
 			return;
 		}
 
 		$extension = pathinfo($filename, PATHINFO_EXTENSION);
+		$type = ($type) ? '-' . $type : '';
 
 		$old_image = $filename;
-		$new_image = 'cache/' . utf8_substr($filename, 0, utf8_strrpos($filename, '.')) . '-' . $width . 'x' . $height .'.' . $extension;
+		$new_image = 'cache/' . utf8_substr($filename, 0, utf8_strrpos($filename, '.')) . $type . '-' . $width . 'x' . $height .'.' . $extension;
 
 		if (!is_file(DIR_IMAGE . $new_image) || (filectime(DIR_IMAGE . $old_image) > filectime(DIR_IMAGE . $new_image))) {
 			$path = '';
@@ -27,7 +28,7 @@ class ModelToolImage extends Model {
 
 			if ($width_orig != $width || $height_orig != $height) {
 				$image = new Image(DIR_IMAGE . $old_image);
-				$image->resize($width, $height);
+				$image->resize($width, $height, $type);
 				$image->save(DIR_IMAGE . $new_image);
 			} else {
 				copy(DIR_IMAGE . $old_image, DIR_IMAGE . $new_image);


### PR DESCRIPTION
Improvement:
- Add "fit" option with symbol `f` which will automatically detect the new image size and resize the image proportionally to remove white space.
- Apply image resize option above to model/tool/image in format: `$this->model_tool_image->resize($image, $new_width, $new_height, $resize_type)`
- Fix watermark different image type issue (image .jpg while watermark .png) by allowing to set mime on lib/image->create()
- Add new watermark position "center" and apply as default watermark position in switch statement
- Add watermark offset option to increase visibility watermark image position not in the edge of main image
- Add new method `imagecopymerge_alpha()` to fix .png transparancy issue (used by watermark).

Note: watermark is not yet applied to `$this->model_tool_image->resize`
