### PR TITLE
Update pp_express.php

### DIFF
--- a/upload/catalog/controller/payment/pp_express.php
+++ b/upload/catalog/controller/payment/pp_express.php
@@ -1564,7 +1564,7 @@ class ControllerPaymentPPExpress extends Controller {
 		$request = 'cmd=_notify-validate';
 
 		foreach ($_POST as $key => $value) {
-			$request .= '&' . $key . '=' . urlencode(stripslashes($value));
+			$request .= '&' . $key . '=' . urlencode(html_entity_decode($value, ENT_QUOTES, 'UTF-8'));
 		}
 
 		if ($this->config->get('pp_express_test') == 1) {


### PR DESCRIPTION
If product contains "&" Paypal returns INVALID, this change will fix the issue
