### PR TITLE
Fixed opencart.sql for CREATE TABLE oc_settings

### DIFF
--- a/upload/install/opencart.sql
+++ b/upload/install/opencart.sql
@@ -3145,7 +3145,7 @@ CREATE TABLE `oc_review` (
 -- Table structure for table `oc_setting`
 --
 DROP TABLE IF EXISTS `oc_setting`;
-CREATE TABLE IF NOT EXISTS `oc_setting` (
+CREATE TABLE `oc_setting` (
   `setting_id` int(11) NOT NULL AUTO_INCREMENT,
   `store_id` int(11) NOT NULL DEFAULT '0',
   `group` varchar(32) NOT NULL,


### PR DESCRIPTION
opencart.sql file contained incorrect SQL syntax for creating DB table oc_settings. Though the DROP TABLE was added the part CREATE TABLE IF NOT EXIST was not unified with the rest of CREATE TABLE statements. Therefore I removed IF NOT EXIST part.
