### PR TITLE
Adds missing username field to admin profile template

### DIFF
--- a/upload/admin/controller/common/profile.php
+++ b/upload/admin/controller/common/profile.php
@@ -12,6 +12,7 @@ class ControllerCommonProfile extends Controller {
 		if ($user_info) {
 			$data['firstname'] = $user_info['firstname'];
 			$data['lastname'] = $user_info['lastname'];
+			$data['username'] = $user_info['username'];
 			
 			$data['user_group'] = $user_info['user_group'] ;
 


### PR DESCRIPTION
In the admin profile template, the username field is used. This field is missing in the admin profile controller, however.
