### PR TITLE
admin: fix menu user-info layout to be more compact

### DIFF
--- a/upload/admin/view/stylesheet/stylesheet.css
+++ b/upload/admin/view/stylesheet/stylesheet.css
@@ -126,7 +126,7 @@ span.hidden-xs, span.hidden-sm, span.hidden-md, span.hidden-lg {
 	font-family: 'Handlee', cursive;
 	font-size: 15px;
 	color: #FFF;
-	margin-top: 12px;
+	margin-top: 0;
 	margin-bottom: 0;
 }
 


### PR DESCRIPTION
Screenshot: https://www.dropbox.com/sh/v3ri0qq392k89ke/AADjMQR_wLUewt83-D-pI-pPa/opencart/2014-08-16-oc200-admin-menu-useraccount.png
