### PR TITLE
bugfix for shifting replace values

### DIFF
--- a/upload/admin/controller/extension/modification.php
+++ b/upload/admin/controller/extension/modification.php
@@ -171,7 +171,8 @@ class ControllerExtensionModification extends Controller {
 
 										// Create an array of all the start postions of all the matched code
 										while (($pos = strpos($modification[$key], $search, $pos + 1)) !== false) {
-											$match[$i++] = $pos;
+											$match[$i] = $pos - $i;
+											++$i;
 										}
 
 										// Offset
@@ -189,7 +190,7 @@ class ControllerExtensionModification extends Controller {
 										// Only replace the occurance of the string that is equal to the between the offset and limit
 										for ($i = $offset; $i < $limit; $i++) {
 											if (isset($match[$i])) {
-												$modification[$key] = substr_replace($modification[$key], $replace, $match[$i], strlen($search));
+												$modification[$key] = substr_replace($modification[$key], $replace, $match[$i] - $i, strlen($search));
 											}
 										}
 


### PR DESCRIPTION
![midification_shifting_bug](https://cloud.githubusercontent.com/assets/1905204/3945549/a5b6a974-2647-11e4-9192-8be80c2c06fe.jpg)
If using a normal 'search' and 'replace' several times:
E.g. searching for 
`date_format_short`

and replace it with
`datetime_format`

and the search term is existing several times in the file (I want to replace all occurences), the first replacement is correct, but every following match is shifting to the right (the value of $i).
