### PR TITLE
modification.php > fix new lines for replace value

### DIFF
--- a/upload/admin/controller/extension/modification.php
+++ b/upload/admin/controller/extension/modification.php
@@ -189,7 +189,7 @@ class ControllerExtensionModification extends Controller {
 										// Only replace the occurance of the string that is equal to the between the offset and limit
 										for ($i = $offset; $i < $limit; $i++) {
 											if (isset($match[$i])) {
-												$modification[$key] = substr_replace($modification[$key], $replace, $match[$i], strlen($search));
+												$modification[$key] = substr_replace($modification[$key], trim($replace), $match[$i], strlen($search));
 											}
 										}
 
@@ -209,7 +209,7 @@ class ControllerExtensionModification extends Controller {
 											$limit = -1;
 										}
 
-										$modification[$key] = preg_replace($search, $replace, $modification[$key], $limit);
+										$modification[$key] = preg_replace($search, trim($replace), $modification[$key], $limit);
 									}
 								}
 							}


### PR DESCRIPTION
To avoid new lines - which could break the code - I propose to trim the $replace value.
If inside the ocmod this is written (the replacement in a new, seperate line - github does not display this correct):
`<add position="replace">
                <![CDATA[
                    replace_value
                ]]>
            </add>`
otherwise the ocmod has always to be this way:
`<add position="replace">
                <![CDATA[replace_value]]>
            </add>`
