### PR TITLE
undefined method Response::setContentType?

### DIFF
--- a/upload/catalog/controller/feed/google_sitemap.php
+++ b/upload/catalog/controller/feed/google_sitemap.php
@@ -65,7 +65,7 @@ class ControllerFeedGoogleSitemap extends Controller {
 
 			$output .= '</urlset>';
 
-			$this->response->setContentType('Content-Type: application/xml');
+			$this->response->addHeader('Content-Type: application/xml');
 			$this->response->setOutput($output);
 		}
 	}


### PR DESCRIPTION
Please verify...
anyway, it would be nice to have an hash array for the headers property of Response.
keys would be the header names and values the header values (either scalar or array) 
In that case we could have a 
setHeader($name, $value) method
addHeader($name, $value) for multiple values headers
setContentType($contentType) calling setHeader('Content-type', $contentType)
getHeaderLine($name) whose output will be used with php header() method
