### PR TITLE
compress() method refactoring

### DIFF
--- a/upload/system/library/response.php
+++ b/upload/system/library/response.php
@@ -27,43 +27,38 @@ class Response {
 	}
 
 	private function compress($data, $level = 0) {
-		if (isset($_SERVER['HTTP_ACCEPT_ENCODING']) && (strpos($_SERVER['HTTP_ACCEPT_ENCODING'], 'gzip') !== false)) {
-			$encoding = 'gzip';
-		}
-
-		if (isset($_SERVER['HTTP_ACCEPT_ENCODING']) && (strpos($_SERVER['HTTP_ACCEPT_ENCODING'], 'x-gzip') !== false)) {
-			$encoding = 'x-gzip';
-		}
-
-		if (!isset($encoding)) {
+        $encoding = null;
+        if (isset($_SERVER['HTTP_ACCEPT_ENCODING'])) {
+            if (strpos($_SERVER['HTTP_ACCEPT_ENCODING'], 'x-gzip') !== false) {
+                $encoding = 'x-gzip';
+            } elseif (strpos($_SERVER['HTTP_ACCEPT_ENCODING'], 'gzip') !== false) {
+                $encoding = 'gzip';
+            }
+        }
+		if (!$encoding) {
 			return $data;
 		}
+		
+		$level = (int) $level;
 
-		if (!extension_loaded('zlib') || ini_get('zlib.output_compression')) {
-			return $data;
-		}
-
-		if (headers_sent()) {
-			return $data;
-		}
-
-		if (connection_status()) {
+		if (($level < -1 || $level > 9)
+		    || !extension_loaded('zlib')
+		    || ini_get('zlib.output_compression')
+		    || headers_sent()
+		    || connection_status() !== CONNECTION_NORMAL
+	    ) {
 			return $data;
 		}
 
 		$this->addHeader('Content-Encoding: ' . $encoding);
 
-		return gzencode($data, (int)$level);
+		return gzencode($data, $level);
 	}
 
 	public function output() {
 		if ($this->output) {
-			if ($this->level) {
-				$output = $this->compress($this->output, $this->level);
-			} else {
-				$output = $this->output;
-			}
-
+		    $output = $this->level ? $this->compress($this->output, $this->level) : $this->output;
+		    
 			if (!headers_sent()) {
 				foreach ($this->headers as $header) {
 					header($header, true);


### PR DESCRIPTION
merge http request accept-encoding tests, testing longer match first...
exclude invalid gzencode compression levels ( if ($this->level) evaluates to TRUE for negative values and -1 is an acceptable=zlib-default compression value for gzencode).
