### PR TITLE
Pass phone number to PayPal

### DIFF
--- a/upload/catalog/controller/payment/pp_standard.php
+++ b/upload/catalog/controller/payment/pp_standard.php
@@ -76,7 +76,6 @@ class ControllerPaymentPPStandard extends Controller {
 			$this->data['address1'] = html_entity_decode($order_info['payment_address_1'], ENT_QUOTES, 'UTF-8');	
 			$this->data['address2'] = html_entity_decode($order_info['payment_address_2'], ENT_QUOTES, 'UTF-8');	
 			$this->data['city'] = html_entity_decode($order_info['payment_city'], ENT_QUOTES, 'UTF-8');	
-			$this->data['state'] = $order_info['payment_zone'];
 			$this->data['zip'] = html_entity_decode($order_info['payment_postcode'], ENT_QUOTES, 'UTF-8');	
 			$this->data['country'] = $order_info['payment_iso_code_2'];
 			$this->data['night_phone_b'] = $order_info['telephone'];

--- a/upload/catalog/view/theme/default/template/payment/pp_standard.tpl
+++ b/upload/catalog/view/theme/default/template/payment/pp_standard.tpl
@@ -29,7 +29,6 @@
   <input type="hidden" name="address1" value="<?php echo $address1; ?>" />
   <input type="hidden" name="address2" value="<?php echo $address2; ?>" />
   <input type="hidden" name="city" value="<?php echo $city; ?>" />
-  <input type="hidden" name="state" value="<?php echo $state; ?>" />
   <input type="hidden" name="zip" value="<?php echo $zip; ?>" />
   <input type="hidden" name="country" value="<?php echo $country; ?>" />
   <input type="hidden" name="address_override" value="0" />


### PR DESCRIPTION
Pass billing state and phone number to PayPal so that they are shown when paying by credit card. Without this the telephone and state field are not populated.
