### PR TITLE
extension/modification/refresh does not clear modification files

### DIFF
--- a/upload/admin/controller/extension/modification.php
+++ b/upload/admin/controller/extension/modification.php
@@ -63,14 +63,8 @@ class ControllerExtensionModification extends Controller {
 			$log = array();
 
 			// Clear all modification files
-			$files = glob(DIR_MODIFICATION . '{*.php,*.tpl}', GLOB_BRACE);
-
-			if ($files) {
-				foreach ($files as $file) {
-					if (file_exists($file)) {
-						unlink($file);
-					}
-				}
+			foreach(new RecursiveIteratorIterator(new RecursiveDirectoryIterator(DIR_MODIFICATION, FilesystemIterator::SKIP_DOTS), RecursiveIteratorIterator::CHILD_FIRST) as $path) {
+				$path->isDir() ? rmdir($path->getPathname()) : unlink($path->getPathname());
 			}
 
 			// Begin


### PR DESCRIPTION
glob() is not recursive, so no files are deleted on refresh as the modification system mimics the folder structure in contrast to vQmod
