### PR TITLE
admin: fixed "returns" links to sale/customer/edit in Dashboard recent a...

### DIFF
--- a/upload/admin/controller/dashboard/activity.php
+++ b/upload/admin/controller/dashboard/activity.php
@@ -14,20 +14,22 @@ class ControllerDashboardActivity extends Controller {
 		$this->load->model('report/activity');
 
 		$results = $this->model_report_activity->getActivities();
-
+		
 		foreach ($results as $result) {
 			$comment = vsprintf($this->language->get('text_' . $result['key']), unserialize($result['data']));
 
 			$find = array(
 				'customer_id=',
 				'order_id=',
-				'affiliate_id='
+				'affiliate_id=',
+				'return_id='
 			);
 
 			$replace = array(
 				$this->url->link('sale/customer/edit', 'token=' . $this->session->data['token'] . '&customer_id=', 'SSL'),
 				$this->url->link('sale/order/info', 'token=' . $this->session->data['token'] . '&order_id=', 'SSL'),
-				$this->url->link('marketing/affiliate/edit', 'token=' . $this->session->data['token'] . '&affiliate_id=', 'SSL')
+				$this->url->link('marketing/affiliate/edit', 'token=' . $this->session->data['token'] . '&affiliate_id=', 'SSL'),
+				$this->url->link('sale/return/edit', 'token=' . $this->session->data['token'] . '&return_id=', 'SSL')
 			);
 
 			$data['activities'][] = array(

--- a/upload/admin/language/english/dashboard/activity.php
+++ b/upload/admin/language/english/dashboard/activity.php
@@ -11,8 +11,8 @@ $_['text_customer_forgotten']      = '<a href="customer_id=%d">%s</a> has reques
 $_['text_customer_login']          = '<a href="customer_id=%d">%s</a> logged in.';
 $_['text_customer_password']       = '<a href="customer_id=%d">%s</a> updated their account password.';
 $_['text_customer_register']       = '<a href="customer_id=%d">%s</a> registered a new account.';
-$_['text_customer_return_account'] = '<a href="customer_id=%d">%s</a> submitted a product return.';
-$_['text_customer_return_guest']   = '%s submitted a product return.';
+$_['text_customer_return_account'] = '<a href="customer_id=%d">%s</a> submitted a product <a href="return_id=%d">return</a>.';
+$_['text_customer_return_guest']   = '%s submitted a product <a href="return_id=%d">return</a>.';
 $_['text_customer_order_account']  = '<a href="customer_id=%d">%s</a> date_added a <a href="order_id=%d">new order</a>.';
 $_['text_customer_order_guest']    = '%s created a <a href="order_id=%d">new order</a>.';
 $_['text_affiliate_edit']          = '<a href="affiliate_id=%d">%s</a> updated their account details.';

--- a/upload/catalog/controller/account/return.php
+++ b/upload/catalog/controller/account/return.php
@@ -288,16 +288,16 @@ class ControllerAccountReturn extends Controller {
 
 			if ($this->customer->isLogged()) {
 				$activity_data = array(
-					'return_id'   => $return_id,
 					'customer_id' => $this->customer->getId(),
-					'name'        => $this->customer->getFirstName() . ' ' . $this->customer->getLastName()
+					'name'        => $this->customer->getFirstName() . ' ' . $this->customer->getLastName(),
+					'return_id'   => $return_id
 				);
 
 				$this->model_account_activity->addActivity('return_account', $activity_data);
 			} else {
 				$activity_data = array(
-					'return_id'   => $return_id,
-					'name'        => $this->request->post['firstname'] . ' ' . $this->request->post['lastname']
+					'name'        => $this->request->post['firstname'] . ' ' . $this->request->post['lastname'],
+					'return_id'   => $return_id
 				);
 
 				$this->model_account_activity->addActivity('return_guest', $activity_data);


### PR DESCRIPTION
admin: fixed "returns" links to sale/customer/edit in Dashboard recent activity comments (there was wrong order of serialized activity data)
admin: added "returns" links to sale/return/edit in Dashboard recent activity comments
screenshot before this commit: http://prntscr.com/4utv2d
screenshot after this commit: http://prntscr.com/4utval
