### PR TITLE
BUG FIX on address.php

### DIFF
--- a/upload/catalog/controller/account/address.php
+++ b/upload/catalog/controller/account/address.php
@@ -356,6 +356,12 @@ class ControllerAccountAddress extends Controller {
 			$data['error_zone'] = '';
 		}
 
+		if (isset($this->error['custom_field'])) {
+			$data['error_custom_field'] = $this->error['custom_field'];
+		} else {
+			$data['error_custom_field'] = array();
+		}
+		
 		if (!isset($this->request->get['address_id'])) {
 			$data['action'] = $this->url->link('account/address/add', '', 'SSL');
 		} else {


### PR DESCRIPTION
When you have customs fields associated with shipping address, that are requiered and have been left in blank by the user, a bug exist in which the custom field is not marked in red, and the explain text is not displayed.

This code Fix the bug

pd: I have spent 6 hours to figure it out because i'm new to opencart.

Regards
