### PR TITLE
BUG FIX on address_form.tpl

### DIFF
--- a/upload/catalog/view/theme/default/template/account/address_form.tpl
+++ b/upload/catalog/view/theme/default/template/account/address_form.tpl
@@ -131,7 +131,7 @@
               <div>
                 <?php foreach ($custom_field['custom_field_value'] as $custom_field_value) { ?>
                 <div class="radio">
-                  <?php if (isset($address_custom_field[$custom_field['custom_field_id']]) && $custom_field_value['custom_field_value_id'] == $address_custom_field['value']) { ?>
+                  <?php if (isset($address_custom_field[$custom_field['custom_field_id']]) && $custom_field_value['custom_field_value_id'] == $address_custom_field[$custom_field['custom_field_id']]) { ?>
                   <label>
                     <input type="radio" name="custom_field[<?php echo $custom_field['custom_field_id']; ?>]" value="<?php echo $custom_field_value['custom_field_value_id']; ?>" checked="checked" />
                     <?php echo $custom_field_value['name']; ?></label>


### PR DESCRIPTION
This BUG apply to the following situation:
Custom field in radio style associate to shipping address and requiered
Then you try to edit the address from your address book
and bug notice appear sayin 'value' is unknow

This fix the bug

I also think that we need to fix the other instances where
$address_custom_field['value'])
must be
$address_custom_field[$custom_field['custom_field_id']])

like in checkbox and select section (Lines 114 and 159), but I have tested this with the radio type only.

So comments are welcome
