### PR TITLE
better specified extensions in Extension Installer

### DIFF
--- a/upload/admin/language/english/extension/installer.php
+++ b/upload/admin/language/english/extension/installer.php
@@ -18,7 +18,7 @@ $_['entry_overwrite']      = 'Files that will be overwritten';
 $_['entry_progress']       = 'Progress';
 
 // Help
-$_['help_upload']          = 'Requires a Zip or XML modification file.';
+$_['help_upload']          = 'Requires a modification file with extension ".ocmod.zip" or ".ocmod.xml".';
 
 // Error
 $_['error_permission']     = 'Warning: You do not have permission to modify extensions!';


### PR DESCRIPTION
Before:
$_['help_upload']          = 'Requires a Zip or XML modification file.';

Now:
$_['help_upload']          = 'Requires a modification file with extension ".ocmod.zip" or ".ocmod.xml".';
