### PR TITLE
BUG FIX on affiliate_list.tpl

### DIFF
--- a/upload/admin/view/template/marketing/affiliate_list.tpl
+++ b/upload/admin/view/template/marketing/affiliate_list.tpl
@@ -90,7 +90,7 @@
             </div>
           </div>
         </div>
-        <form action="" method="post" enctype="multipart/form-data" id="form-affiliate">
+        <form action="<?php echo $delete; ?>" method="post" enctype="multipart/form-data" id="form-affiliate">
           <div class="table-responsive">
             <table class="table table-bordered table-hover">
               <thead>


### PR DESCRIPTION
BUG Found on On admin > Marketing > Affiliates
On the list you can't delete an affiliate due a missing action on the form
This fix de bug.
