### PR TITLE
Opencart 2.0 - Fallback for the main language file

### DIFF
--- a/upload/system/library/language.php
+++ b/upload/system/library/language.php
@@ -15,6 +15,12 @@ class Language {
 	public function load($filename) {
 		$_ = array();
 
+		$file = DIR_LANGUAGE . $this->default . '/' . $this->default . '.php';
+
+		if (file_exists($file)) {
+			require($file);
+		}
+		
 		$file = DIR_LANGUAGE . $this->default . '/' . $filename . '.php';
 
 		if (file_exists($file)) {


### PR DESCRIPTION
I added the greek language in the admin without copying any files and realized there is no language fallback for the main language file (e.g. greek.php falling back to english.php).

As a result the website was missing key translations when switching to the added language.

I imagine the fallback would not work even if there were just a few strings missing from the main language file.

I have added an extra fallback so even if you add languages in the admin without uploading the files it will still work like a charm.

I understand it's not very sound to add languages without uploading any files but it's better to make it fool proof.

![2014-10-16 17_18_25-your store](https://cloud.githubusercontent.com/assets/8582633/4670122/43278cea-5574-11e4-8c93-9a1624465717.png)
![2014-10-16 22_38_32-mozilla firefox](https://cloud.githubusercontent.com/assets/8582633/4670123/4327dd30-5574-11e4-8898-d0988e7910a8.png)
