### PR TITLE
OC 2.0.0.1b: Fixed missing text for button_continue when special is empty

### DIFF
--- a/upload/catalog/controller/product/special.php
+++ b/upload/catalog/controller/product/special.php
@@ -81,6 +81,7 @@ class ControllerProductSpecial extends Controller {
 		$data['button_compare'] = $this->language->get('button_compare');
 		$data['button_list'] = $this->language->get('button_list');
 		$data['button_grid'] = $this->language->get('button_grid');
+		$data['button_continue'] = $this->language->get('button_continue');
 
 		$data['compare'] = $this->url->link('product/compare');
 


### PR DESCRIPTION
Fixes issue #2070

![2014-10-22 03_02_37-special offers](https://cloud.githubusercontent.com/assets/8582633/4729038/d204087c-597e-11e4-9e74-6675667a98dc.png)
