### PR TITLE
OC 2.0.0.1b: Fixed not loading flexslider in manufacturers error page carousel

### DIFF
--- a/upload/catalog/controller/product/manufacturer.php
+++ b/upload/catalog/controller/product/manufacturer.php
@@ -366,6 +366,9 @@ class ControllerProductManufacturer extends Controller {
 				$this->response->setOutput($this->load->view('default/template/product/manufacturer_info.tpl', $data));
 			}
 		} else {
+			$this->document->addStyle('catalog/view/javascript/jquery/flexslider/flexslider.css');
+			$this->document->addScript('catalog/view/javascript/jquery/flexslider/jquery.flexslider-min.js');
+		
 			$url = '';
 
 			if (isset($this->request->get['manufacturer_id'])) {


### PR DESCRIPTION
This is what the carousel looks like in the manufacturer's error page without flexslider css and js scripts loaded.
I added style and script in case manufacturer_id=0.

![2014-10-22 04_21_19-brand not found](https://cloud.githubusercontent.com/assets/8582633/4729591/023f2458-598a-11e4-9003-f5b67084f1f0.png)
