### PR TITLE
Corrected a major bug

### DIFF
--- a/upload/install/view/template/step_3.tpl
+++ b/upload/install/view/template/step_3.tpl
@@ -108,7 +108,7 @@
           <div class="form-group required">
             <label class="col-sm-2 control-label" for="input-password"><?php echo $entry_password; ?></label>
             <div class="col-sm-10">
-              <input type="text" name="password" value="<?php echo $password; ?>" id="input-password" class="form-control" />
+              <input type="password" name="password" value="<?php echo $password; ?>" id="input-password" class="form-control" />
               <?php if ($error_password) { ?>
               <div class="text-danger"><?php echo $error_password; ?></div>
               <?php } ?>


### PR DESCRIPTION
Corrected a major bug, which have been around for years.

Since the type attribute on the password input where set to "text", the password where visible, also allowing computers, tablets, smartphones and so on to enter the password to the dictionary, which is a standard action for most mobile devices. Computers would remember the password and possible suggest that in the future.

Again, this "bug" have been around for way to long now, and it kinda piss me of, especially since it is a major security risk, and that you can compromise your (possible go-to) password.

Please do pull in this pull request, so that we can get rid of this bug.

Note: The "change" in line 145 is caused by the online editor on GitHub.
