### PR TITLE
Fixed smtp send mail.

### DIFF
--- a/upload/system/library/mail.php
+++ b/upload/system/library/mail.php
@@ -20,7 +20,9 @@ class Mail {
 
 	public function __construct($config = array()) {
 		foreach ($config as $key => $value) {
-			$this->$key = $value;
+			if ($value) {
+				$this->$key = $value;
+			}
 		}
 	}
 


### PR DESCRIPTION
Error:
Warning: fsockopen() expects parameter 5 to be double, string given in /Applications/XAMPP/xamppfiles/htdocs/menon/system/library/mail.php on line 167Notice: Error: () in /Applications/XAMPP/xamppfiles/htdocs/menon/system/library/mail.php on line 170

Cause:
This error occurred because it was not set value for the timeout.
Since there was no condition he changed the default value (`php public $ smtp_timeout = 5;`) for empty string.

Thanks.
