### PR TITLE
Fixed save payment_method in admin edit order.

### DIFF
--- a/upload/catalog/controller/api/order.php
+++ b/upload/catalog/controller/api/order.php
@@ -351,7 +351,7 @@ class ControllerApiOrder extends Controller {
 				}
 
 				// Payment Method
-				if (!isset($this->session->data['payment_method'])) {
+				if (!isset($this->request->post['payment_method'])) {
 					$json['error'] = $this->language->get('error_payment_method');
 				}
 
@@ -430,14 +430,15 @@ class ControllerApiOrder extends Controller {
 					$order_data['payment_address_format'] = $this->session->data['payment_address']['address_format'];
 					$order_data['payment_custom_field'] = $this->session->data['payment_address']['custom_field'];
 
-					if (isset($this->session->data['payment_method']['title'])) {
-						$order_data['payment_method'] = $this->session->data['payment_method']['title'];
+
+					if (isset($this->session->data['payment_methods'][$this->request->post['payment_method']]['title'])) {
+						$order_data['payment_method'] = $this->session->data['payment_methods'][$this->request->post['payment_method']]['title'];
 					} else {
 						$order_data['payment_method'] = '';
 					}
 
-					if (isset($this->session->data['payment_method']['code'])) {
-						$order_data['payment_code'] = $this->session->data['payment_method']['code'];
+					if (isset($this->session->data['payment_methods'][$this->request->post['payment_method']]['code'])) {
+						$order_data['payment_code'] = $this->session->data['payment_methods'][$this->request->post['payment_method']]['code'];
 					} else {
 						$order_data['payment_code'] = '';
 					}


### PR DESCRIPTION
Based on issue #2361 I began to investigate the difficulty and found that "payment_method" was not being saved.

After my changes I realized several tests and always saved correctly.

The problem also seems to be happening with the "shipping_method". If no fix for this day maybe I correct the night.

![image](https://cloud.githubusercontent.com/assets/1612563/5223003/f1d0b006-7693-11e4-8f7e-8b179df5a7e9.png)
