### PR TITLE
Fix for ftp_mkdir error during extension installation OCMOD

### DIFF
--- a/upload/admin/controller/extension/installer.php
+++ b/upload/admin/controller/extension/installer.php
@@ -326,7 +326,7 @@ class ControllerExtensionInstaller extends Controller {
 							
 							if (is_dir($file)) {
 								$list = ftp_nlist($connection, substr($destination, 0, strrpos($destination, '/')));
-                                $destination = substr($destination, strrpos($destination, '/') + 1);
+                                				$destination = substr($destination, strrpos($destination, '/') + 1);
 								
 								if (!in_array($destination, $list)) {
 									if (!ftp_mkdir($connection, $destination)) {


### PR DESCRIPTION
After I successfully tested the installation of my extension locally, I tried to install it on the latest version 2.0.1.0 on a hosted server.

I again got the dreaded ftp_mkdir errors "ftp_mkdir(): Can't create directory: File exists"

I echoed the values of the $list array and the $destination which looked like the following image.
It tries to find the value "admin/language/greek" in the array instead of "greek".

The one line I added in this pull request solved this problem and allowed me to complete the installation of the extension.

I don't know if it is the best solution since I don't know the root cause of the issue.

Please, admins, take a look at it. It's been 2 releases of OC2 already and I can't make a simple translation extension work on any of them.

![2014-12-02 03_10_12-](https://cloud.githubusercontent.com/assets/8582633/5256568/46cbeaf2-79d3-11e4-80e1-44d08392f9f2.png)
