### PR TITLE
Return permission error as json for ajax requests

### DIFF
--- a/upload/admin/controller/error/permission.php
+++ b/upload/admin/controller/error/permission.php
@@ -52,9 +52,27 @@ class ControllerErrorPermission extends Controller {
 				'error/permission'
 			);
 
-			if (!in_array($route, $ignore) && !$this->user->hasPermission('access', $route)) {
+			$ajax = array(
+                                'dashboard/chart',
+                                'dashboard/map'
+			);
+
+			if (!in_array($route, $ignore) && !in_array($route, $ajax) && !$this->user->hasPermission('access', $route)) {
 				return new Action('error/permission');
 			}
+                        
+			if (in_array($route, $ajax) && !$this->user->hasPermission('access', $route)) {
+				return new Action('error/permission/json');
+			}
+                        
 		}
+	}
+	public function json() {
+		$this->load->language('error/permission');
+                
+		$json['error'] = $this->language->get('text_permission');
+                
+		$this->response->addHeader('Content-Type: application/json');
+		$this->response->setOutput(json_encode($json));
 	}
 }


### PR DESCRIPTION
**Issue**
I installed a demo site. When I log in as demo user in the administration it throws 2 json parse errors for the ajax requests it does for the map and the chart. The demo user has no permission to see the data so instead of a json response it sends the whole Access Denied Page.

**Fix**
(in admin/error/permission)
I added a second array with ajax routes and a function to send the permission error as a json response to pages in this array.

**Complications**
Since it sends no data to the chart engine it throws a javascript error which is addressed in a separate pull request -> gortsilas:chart-no-data (#2415)
