### PR TITLE
add modification directory to install check

### DIFF
--- a/upload/install/controller/step_2.php
+++ b/upload/install/controller/step_2.php
@@ -87,6 +87,7 @@ class ControllerStep2 extends Controller {
 		$data['cache'] = DIR_SYSTEM . 'cache';
 		$data['logs'] = DIR_SYSTEM . 'logs';
 		$data['download'] = DIR_SYSTEM . 'download';
+		$data['download'] = DIR_SYSTEM . 'modification';
 		$data['upload'] = DIR_SYSTEM . 'upload';
 		$data['image'] = DIR_OPENCART . 'image';
 		$data['image_cache'] = DIR_OPENCART . 'image/cache';


### PR DESCRIPTION
Some server configurations prevent the script from writing to modification dir, which causes errors when attempting to install ocmods
