### PR TITLE
Fix uninstall module  - layout_module issue.

### DIFF
--- a/upload/admin/model/extension/module.php
+++ b/upload/admin/model/extension/module.php
@@ -37,6 +37,6 @@ class ModelExtensionModule extends Model {
 	
 	public function deleteModulesByCode($code) {
 		$this->db->query("DELETE FROM `" . DB_PREFIX . "module` WHERE `code` = '" . $this->db->escape($code) . "'");
-		$this->db->query("DELETE FROM `" . DB_PREFIX . "layout_module` WHERE `code` LIKE '" . $this->db->escape($code . '.%') . "'");
+		$this->db->query("DELETE FROM `" . DB_PREFIX . "layout_module` WHERE `code` LIKE '" . $this->db->escape($code) . "' OR `code` LIKE '" . $this->db->escape($code . '.%') . "'");
 	}	
 }


### PR DESCRIPTION
Steps to replicate:
1. Log in to admin
2. Install a module like Account from Modules
3. Put the module on a layout like Home from Layouts
4. Go back to Modules and uninstall module Account

Expected results: the row from `layout_module` table for module Account and Layout Home must be deleted

Actual results: the row is not deleted and if you go now to Layout Home you will see other module replacing the uninstalled Account; if you will click save than this module will replace module Account in the DB table

This is a trivial issue and can create small problems when you will have many modules on a layout.
