### PR TITLE
remove FTP step from modificaiton .zip upload

### DIFF
--- a/upload/admin/controller/extension/installer.php
+++ b/upload/admin/controller/extension/installer.php
@@ -128,12 +128,14 @@ class ControllerExtensionInstaller extends Controller {
 						);
 
 						// FTP
+                                                /*
 						$json['step'][] = array(
 							'text' => $this->language->get('text_ftp'),
 							'url'  => str_replace('&amp;', '&', $this->url->link('extension/installer/ftp', 'token=' . $this->session->data['token'], 'SSL')),
 							'path' => $path
 						);
-						
+						*/
+                                                
 						// Send make and array of actions to carry out
 						while ($entry = zip_read($zip)) {
 							$zip_name = zip_entry_name($entry);


### PR DESCRIPTION
I am not sure why the FTP step is a part of this. I was testing my first .zip archive modification and couldn't understand what purpose it served. I commented it out and it everything seems to work fine (zip contained an install.xml and install.sql). Once the files are uploaded there shouldn't be any need to FTP anything. Let me know if I am missing something.
