### PR TITLE
Infinite loop

### DIFF
--- a/upload/admin/controller/extension/modification.php
+++ b/upload/admin/controller/extension/modification.php
@@ -292,7 +292,11 @@ class ControllerExtensionModification extends Controller {
 														$line_id += count($new_lines);
 														break;
 													case 'after':
-														array_splice($lines, ($line_id + 1) + $offset, 0, explode("\n", $add));
+														$new_lines = explode("\n", $add);
+
+														array_splice($lines, ($line_id + 1) + $offset, 0, $new_lines);
+
+														$line_id += count($new_lines);
 														break;
 												}
 												


### PR DESCRIPTION
In modification file, when using position="after" attribute, if you add same line in search attribute, it creates infinite loop. 

It seems "line_id" variable has been forgotten to decrease in "after" case. I committed with the solution.

Here is the test xml code:
```xml
<modification>
	<name>Test XML</name>
	<code>test_xml</code>
	<version>0.0.1</version>
	<author>burakcakirel</author>

	<file path="admin/controller/catalog/product.php">
		<operation>
			<search><![CDATA[$this->response->setOutput(json_encode($json));]]></search>
			<add position="after"><![CDATA[
			#test line
			$this->response->setOutput(json_encode($json));
			]]></add>
		</operation>
	</file>
</modification>