### PR TITLE
Fixed the order of custom fields

### DIFF
--- a/upload/catalog/view/theme/default/template/checkout/guest.tpl
+++ b/upload/catalog/view/theme/default/template/checkout/guest.tpl
@@ -323,17 +323,18 @@
 <script type="text/javascript"><!--
 // Sort the custom fields
 $('#account .form-group[data-sort]').detach().each(function() {
-	if ($(this).attr('data-sort') >= 0 && $(this).attr('data-sort') <= $('#account .form-group').length) {
-		$('#account .form-group').eq($(this).attr('data-sort')).before(this);
-	} 
-	
-	if ($(this).attr('data-sort') > $('#account .form-group').length) {
-		$('#account .form-group:last').after(this);
-	}
-		
-	if ($(this).attr('data-sort') < -$('#account .form-group').length) {
-		$('#account .form-group:first').before(this);
-	}
+    var $items = $('#account .form-group').filter(function() {return $(this).css('display') != 'none'});
+    if ($(this).attr('data-sort') >= 0 && $(this).attr('data-sort') <= $items.length) {
+        $items.eq($(this).attr('data-sort')).before(this);
+    }
+
+    if ($(this).attr('data-sort') > $items.length) {
+        $items.last().after(this);
+    }
+
+    if ($(this).attr('data-sort') < -$items.length) {
+        $items.first().before(this);
+    }
 });
 
 $('#address .form-group[data-sort]').detach().each(function() {


### PR DESCRIPTION
The order of custom fields is working incorrect if exist hidden blocks. For example the block with customer group. I have not used  jQuery selector ":visible" because it does not return the objects