### PR TITLE
Add the missing DIR_UPLOAD variable in cli_install.php

### DIFF
--- a/upload/install/cli_install.php
+++ b/upload/install/cli_install.php
@@ -202,6 +202,7 @@ function write_config_files($options) {
 	$output .= 'define(\'DIR_IMAGE\', \'' . DIR_OPENCART . 'image/\');' . "\n";
 	$output .= 'define(\'DIR_CACHE\', \'' . DIR_OPENCART . 'system/cache/\');' . "\n";
 	$output .= 'define(\'DIR_DOWNLOAD\', \'' . DIR_OPENCART . 'system/download/\');' . "\n";
+	$output .= 'define(\'DIR_UPLOAD\', \'' . DIR_OPENCART . 'system/upload/\');' . "\n";
 	$output .= 'define(\'DIR_MODIFICATION\', \'' . DIR_OPENCART . 'system/modification/\');' . "\n";
 	$output .= 'define(\'DIR_LOGS\', \'' . DIR_OPENCART . 'system/logs/\');' . "\n\n";
 


### PR DESCRIPTION
The DIR_UPLOAD variable is missing if it's installed via cli. When it's installed through the web wizard it's ok because it's defined in upload/install/controller/step_3.php. Just need to add the same line to the cli_install.php