### PR TITLE
Better file and folder names display in filemanager

### DIFF
--- a/upload/admin/controller/common/filemanager.php
+++ b/upload/admin/controller/common/filemanager.php
@@ -50,7 +50,9 @@ class ControllerCommonFileManager extends Controller {
 		$images = array_splice($images, ($page - 1) * 16, 16);
 
 		foreach ($images as $image) {
-			$name = str_split(basename($image), 14);
+			//if filename is more than 20 characters, only show first 20 characters, dot dot dot and extension
+			$initial = str_split(basename($image), 20);
+			$name = sizeof($initial)>1 ? array($initial[0].'...'.pathinfo($image, PATHINFO_EXTENSION)) : array($initial[0]);
 
 			if (is_dir($image)) {
 				$url = '';


### PR DESCRIPTION
If filename is more than 20 characters, only show first 20 characters, dot dot dot and extension.
Previously, it is adding a space every 14 characters in filenames for new line. It's a bit confusing for user as they wrongly put space in file and folder names.