### PR TITLE
If [1] found give error of function getModule into a not object

### DIFF
--- a/upload/catalog/controller/common/content_top.php
+++ b/upload/catalog/controller/common/content_top.php
@@ -51,6 +51,7 @@ class ControllerCommonContentTop extends Controller {
 			}
 			
 			if (isset($part[1])) {
+				$this->load->model('extension/module');
 				$setting_info = $this->model_extension_module->getModule($part[1]);
 				
 				if ($setting_info && $setting_info['status']) {


### PR DESCRIPTION
This patch affect only one row that done an error into front page
when $part[1] founded.
