### PR TITLE
OC 2.0.1.1 - Added a second placeholder for the store name instead of 'us'

### DIFF
--- a/upload/catalog/language/english/account/success.php
+++ b/upload/catalog/language/english/account/success.php
@@ -3,7 +3,7 @@
 $_['heading_title'] = 'Your Account Has Been Created!';
 
 // Text
-$_['text_message']  = '<p>Congratulations! Your new account has been successfully created!</p> <p>You can now take advantage of member privileges to enhance your online shopping experience with us.</p> <p>If you have ANY questions about the operation of this online shop, please e-mail the store owner.</p> <p>A confirmation has been sent to the provided e-mail address. If you have not received it within the hour, please <a href="%s">contact us</a>.</p>';
+$_['text_message']  = '<p>Congratulations! Your new account has been successfully created!</p> <p>You can now take advantage of member privileges to enhance your online shopping experience with %s.</p> <p>If you have ANY questions about the operation of this online shop, please e-mail the store owner.</p> <p>A confirmation has been sent to the provided e-mail address. If you have not received it within the hour, please <a href="%s">contact us</a>.</p>';
 $_['text_approval'] = '<p>Thank you for registering with %s!</p><p>You will be notified by e-mail once your account has been activated by the store owner.</p><p>If you have ANY questions about the operation of this online shop, please <a href="%s">contact the store owner</a>.</p>';
 $_['text_account']  = 'Account';
 $_['text_success']  = 'Success';


### PR DESCRIPTION
"This commit has broken then the account registration link.
In account.php sprintf expects 2 placeholders where there is only one in the new string"

It is commit https://github.com/gortsilas/opencart/commit/0073f03e6a8882973df776163e2afc11a8486844

It actually moved the error from affiliates to account since only one of the strings had 2 placeholders but their respective sprintf functions are identical.

$data['text_message'] = sprintf($this->language->get('text_message'), $this->config->get('config_name'), $this->url->link('information/contact'));

The second placeholder must fix the issue.