### PR TITLE
copyProduct: unused var assignment and db join

### DIFF
--- a/upload/admin/model/catalog/product.php
+++ b/upload/admin/model/catalog/product.php
@@ -279,11 +279,9 @@ class ModelCatalogProduct extends Model {
 	}
 
 	public function copyProduct($product_id) {
-		$query = $this->db->query("SELECT DISTINCT * FROM " . DB_PREFIX . "product p LEFT JOIN " . DB_PREFIX . "product_description pd ON (p.product_id = pd.product_id) WHERE p.product_id = '" . (int)$product_id . "' AND pd.language_id = '" . (int)$this->config->get('config_language_id') . "'");
+		$query = $this->db->query("SELECT DISTINCT * FROM " . DB_PREFIX . "product p WHERE p.product_id = '" . (int)$product_id . "'");
 
 		if ($query->num_rows) {
-			$data = array();
-
 			$data = $query->row;
 
 			$data['sku'] = '';


### PR DESCRIPTION
- we just need product table columns her, we are not displayin localized infos.
- i still believe array_merge is not necessary here, a simple key assignment would be better: keys starting with "product_" are not present in $data (i.e. ) $query->row