### PR TITLE
Amazon-like "You Save"

### DIFF
--- a/upload/catalog/controller/product/product.php
+++ b/upload/catalog/controller/product/product.php
@@ -233,6 +233,7 @@ class ControllerProductProduct extends Controller {
 			$data['text_points'] = $this->language->get('text_points');
 			$data['text_stock'] = $this->language->get('text_stock');
 			$data['text_discount'] = $this->language->get('text_discount');
+			$data['text_yousave'] = $this->language->get('text_yousave');
 			$data['text_tax'] = $this->language->get('text_tax');
 			$data['text_option'] = $this->language->get('text_option');
 			$data['text_minimum'] = sprintf($this->language->get('text_minimum'), $product_info['minimum']);
@@ -310,6 +311,8 @@ class ControllerProductProduct extends Controller {
 
 			if ((float)$product_info['special']) {
 				$data['special'] = $this->currency->format($this->tax->calculate($product_info['special'], $product_info['tax_class_id'], $this->config->get('config_tax')));
+				$data['yousave'] = $this->currency->format($this->tax->calculate($product_info['price']-$product_info['special'], $product_info['tax_class_id'], $this->config->get('config_tax')));
+				$data['yousavepercent'] = round(($product_info['price']-$product_info['special'])*100/$product_info['price'],0);
 			} else {
 				$data['special'] = false;
 			}
@@ -410,6 +413,8 @@ class ControllerProductProduct extends Controller {
 
 				if ((float)$result['special']) {
 					$special = $this->currency->format($this->tax->calculate($result['special'], $result['tax_class_id'], $this->config->get('config_tax')));
+					$yousave = $this->currency->format($this->tax->calculate($result['price']-$result['special'], $result['tax_class_id'], $this->config->get('config_tax')));
+					$yousavepercent = round(($result['price']-$result['special'])*100/$result['price'],0);
 				} else {
 					$special = false;
 				}

--- a/upload/catalog/language/english/product/product.php
+++ b/upload/catalog/language/english/product/product.php
@@ -8,6 +8,7 @@ $_['text_reward']              = 'Reward Points:';
 $_['text_points']              = 'Price in reward points:';
 $_['text_stock']               = 'Availability:';
 $_['text_instock']             = 'In Stock';
+$_['text_yousave']             = 'You save:';
 $_['text_tax']                 = 'Ex Tax:';
 $_['text_discount']            = ' or more ';
 $_['text_option']              = 'Available Options';

--- a/upload/catalog/view/theme/default/template/product/product.tpl
+++ b/upload/catalog/view/theme/default/template/product/product.tpl
@@ -152,6 +152,7 @@
             <li><span style="text-decoration: line-through;"><?php echo $price; ?></span></li>
             <li>
               <h2><?php echo $special; ?></h2>
+              <span class="you-save"><?php echo $text_yousave; ?> <?php echo $yousave . ' (' . $yousavepercent . '%)'; ?>
             </li>
             <?php } ?>
             <?php if ($tax) { ?>


### PR DESCRIPTION
Savings are important for customers. Showing only the old price and new is not enough as it requires customers to make mental calculations as to how much they are saving.
Amazon understands this - that's why it shows the savings separately http://www.amazon.com/dp/B00CX5P8FC/ref=br_imp_ara-1/179-1035819-2800748?pf_rd_m=ATVPDKIKX0DER&pf_rd_s=desktop-hero-1&pf_rd_r=0YFM6R2R090AJAR40480&pf_rd_t=36701&pf_rd_p=2039920302&pf_rd_i=desktop

This patch adds savings ($ and %) information below the price on the product page if a valid special price exists for the product.

This is useful for many OpenCart installs as evidenced from my popular extension
http://www.opencart.com/index.php?route=extension/extension/info&extension_id=8319