### PR TITLE
Multilingual reviews

### DIFF
--- a/upload/catalog/model/catalog/review.php
+++ b/upload/catalog/model/catalog/review.php
@@ -3,7 +3,7 @@ class ModelCatalogReview extends Model {
 	public function addReview($product_id, $data) {
 		$this->event->trigger('pre.review.add', $data);
 
-		$this->db->query("INSERT INTO " . DB_PREFIX . "review SET author = '" . $this->db->escape($data['name']) . "', customer_id = '" . (int)$this->customer->getId() . "', product_id = '" . (int)$product_id . "', text = '" . $this->db->escape($data['text']) . "', rating = '" . (int)$data['rating'] . "', date_added = NOW()");
+		$this->db->query("INSERT INTO " . DB_PREFIX . "review SET author = '" . $this->db->escape($data['name']) . "', customer_id = '" . (int)$this->customer->getId() . "', product_id = '" . (int)$product_id . "', text = '" . $this->db->escape($data['text']) . "', rating = '" . (int)$data['rating'] . "', language_id = '" . (int)$this->config->get('config_language_id') . "', date_added = NOW()");
 
 		$review_id = $this->db->getLastId();
 
@@ -51,8 +51,8 @@ class ModelCatalogReview extends Model {
 		if ($limit < 1) {
 			$limit = 20;
 		}
-
-		$query = $this->db->query("SELECT r.review_id, r.author, r.rating, r.text, p.product_id, pd.name, p.price, p.image, r.date_added FROM " . DB_PREFIX . "review r LEFT JOIN " . DB_PREFIX . "product p ON (r.product_id = p.product_id) LEFT JOIN " . DB_PREFIX . "product_description pd ON (p.product_id = pd.product_id) WHERE p.product_id = '" . (int)$product_id . "' AND p.date_available <= NOW() AND p.status = '1' AND r.status = '1' AND pd.language_id = '" . (int)$this->config->get('config_language_id') . "' ORDER BY r.date_added DESC LIMIT " . (int)$start . "," . (int)$limit);
+		
+		$query = $this->db->query("SELECT r.review_id, r.author, r.rating, r.text, p.product_id, pd.name, p.price, p.image, r.date_added FROM " . DB_PREFIX . "review r LEFT JOIN " . DB_PREFIX . "product p ON (r.product_id = p.product_id) LEFT JOIN " . DB_PREFIX . "product_description pd ON (p.product_id = pd.product_id) WHERE p.product_id = '" . (int)$product_id . "' AND p.date_available <= NOW() AND p.status = '1' AND r.status = '1' AND pd.language_id = '" . (int)$this->config->get('config_language_id') . "' ORDER BY r.language_id = '" . (int)$this->config->get('config_language_id') . "' DESC, r.language_id ASC, r.date_added DESC LIMIT " . (int)$start . "," . (int)$limit);
 
 		return $query->rows;
 	}

--- a/upload/install/opencart.sql
+++ b/upload/install/opencart.sql
@@ -2963,6 +2963,7 @@ CREATE TABLE IF NOT EXISTS `oc_review` (
   `author` varchar(64) NOT NULL,
   `text` text NOT NULL,
   `rating` int(1) NOT NULL,
+  `language_id` int(11) NOT NULL DEFAULT '0',
   `status` tinyint(1) NOT NULL DEFAULT '0',
   `date_added` datetime NOT NULL,
   `date_modified` datetime NOT NULL,


### PR DESCRIPTION
Sites that offer reviews across countries have dealt with and resolved the issue of multilingual reviews in a pretty good way - show reviews in current language on top before showing reviews in other languages. http://www.tripadvisor.com.sg/Hotel_Review-g274887-d1185721-Reviews-Firstapartments_Inn_City_Center-Budapest_Central_Hungary.html

This patch adds the same function to OpenCart.
http://forum.opencart.com/viewtopic.php?f=20&t=15655
http://forum.opencart.com/viewtopic.php?f=110&t=19900