### PR TITLE
Admin Tweak - Reverse Default Order of Reviews

### DIFF
--- a/upload/admin/controller/catalog/review.php
+++ b/upload/admin/controller/catalog/review.php
@@ -182,19 +182,20 @@ class ControllerCatalogReview extends Controller {
 		} else {
 			$filter_date_added = null;
 		}
-
-		if (isset($this->request->get['sort'])) {
-			$sort = $this->request->get['sort'];
-		} else {
-			$sort = 'r.date_added';
-		}
-
+		
 		if (isset($this->request->get['order'])) {
 			$order = $this->request->get['order'];
 		} else {
 			$order = 'ASC';
 		}
-
+		
+		if (isset($this->request->get['sort'])) {
+			$sort = $this->request->get['sort'];
+		} else {
+			$sort = 'r.date_added';
+			$order = 'DESC';
+		}
+		
 		if (isset($this->request->get['page'])) {
 			$page = $this->request->get['page'];
 		} else {


### PR DESCRIPTION
OpenCart lists reviews ordered by date added in ascending order (oldest first) by default. This patch reverses the default order (newest first) so that the reviews awaiting moderation are shown first.
This tweak in the Admin Panel can save us a click or two, and in day-to-day operations, these clicks add up.
This is one of the functions performed by one of the two functions performed by my extension http://www.opencart.com/index.php?route=extension/extension/info&extension_id=7841&filter_username=OC2PS&page=2