### PR TITLE
Add product photos and links in order mail

### DIFF
--- a/upload/catalog/model/checkout/order.php
+++ b/upload/catalog/model/checkout/order.php
@@ -413,6 +413,8 @@ class ModelCheckoutOrder extends Model {
 				$subject = sprintf($language->get('text_new_subject'), $order_info['store_name'], $order_id);
 
 				// HTML Mail
+				$this->load->model('tool/image');
+				
 				$data = array();
 
 				$data['title'] = sprintf($language->get('text_new_subject'), html_entity_decode($order_info['store_name'], ENT_QUOTES, 'UTF-8'), $order_id);
@@ -541,7 +543,12 @@ class ModelCheckoutOrder extends Model {
 
 				foreach ($order_product_query->rows as $product) {
 					$option_data = array();
-
+					
+					$product_query = $this->db->query("SELECT image FROM " . DB_PREFIX . "product WHERE product_id = '" . (int)$product['product_id'] . "'");
+					foreach ($product_query->rows as $prodquery) {
+						$image = $prodquery['image'];
+						}
+					
 					$order_option_query = $this->db->query("SELECT * FROM " . DB_PREFIX . "order_option WHERE order_id = '" . (int)$order_id . "' AND order_product_id = '" . (int)$product['order_product_id'] . "'");
 
 					foreach ($order_option_query->rows as $option) {
@@ -566,6 +573,8 @@ class ModelCheckoutOrder extends Model {
 					$data['products'][] = array(
 						'name'     => $product['name'],
 						'model'    => $product['model'],
+						'thumb'    => $this->model_tool_image->resize($image, 60, 60),
+						'href'    => $this->url->link('product/product', 'product_id=' . $product['product_id']),
 						'option'   => $option_data,
 						'quantity' => $product['quantity'],
 						'price'    => $this->currency->format($product['price'] + ($this->config->get('config_tax') ? $product['tax'] : 0), $order_info['currency_code'], $order_info['currency_value']),

--- a/upload/catalog/view/theme/default/template/mail/order.tpl
+++ b/upload/catalog/view/theme/default/template/mail/order.tpl
@@ -81,7 +81,7 @@
     <tbody>
       <?php foreach ($products as $product) { ?>
       <tr>
-        <td style="font-size: 12px;	border-right: 1px solid #DDDDDD; border-bottom: 1px solid #DDDDDD; text-align: left; padding: 7px;"><?php echo $product['name']; ?>
+        <td style="font-size: 12px; border-right: 1px solid #DDDDDD; border-bottom: 1px solid #DDDDDD; text-align: left; padding: 7px; vertical-align: middle; text-decoration: none;"><a href="<?php echo $product['href']; ?>"><img src="<?php echo $product['thumb']; ?>" title="<?php echo $product['name']; ?>" style="float:left; margin-right: 5px;" /></a><?php echo " "; ?><a href="<?php echo $product['href']; ?>"><?php echo $product['name']; ?></a>
           <?php foreach ($product['option'] as $option) { ?>
           <br />
           &nbsp;<small> - <?php echo $option['name']; ?>: <?php echo $option['value']; ?></small>


### PR DESCRIPTION
Our customers like it if the order confirmation email includes product photos - this way, they can quickly scan the email and know the products are correct, without having to read the mail.
Product photos in order emails are good for us as well: Due to local regulations we have a high turnover of inventory and packaging staff and giving printouts of order emails containing images helps get them off the ground quicker with less training required.
By clicking the link, they can easily check product description later.
This patch adds product photo and link to the order confirmation email.
Essentially it does the job of my popular extension (9000 downloads) http://www.opencart.com/index.php?route=extension/extension/info&extension_id=7102