### PR TITLE
Enable Facebook Social Plugins

### DIFF
--- a/upload/catalog/view/theme/default/template/common/header.tpl
+++ b/upload/catalog/view/theme/default/template/common/header.tpl
@@ -39,6 +39,14 @@
 <?php echo $google_analytics; ?>
 </head>
 <body class="<?php echo $class; ?>">
+<div id="fb-root"></div>
+<script>(function(d, s, id) {
+  var js, fjs = d.getElementsByTagName(s)[0];
+  if (d.getElementById(id)) return;
+  js = d.createElement(s); js.id = id;
+  js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.0";
+  fjs.parentNode.insertBefore(js, fjs);
+}(document, 'script', 'facebook-jssdk'));</script>
 <nav id="top">
   <div class="container">
     <?php echo $currency; ?>


### PR DESCRIPTION
Daniel,

I know that your initial instinct will be to reject this patch immediately. However, I request you to please read on, let it simmer for a bit and then decide.

There is a wide range of popular modules that insert Facebook plugins into OpenCart shops.

Trouble is, all of them need to include the SDK in the template, especially if they go down the HTML5 or FBML route.

One issue is that just to add a module, there needs to be a modification.

Second issue is that if multiple such extensions are used, each adding the Facebook Javascript, it can lead to conflicts. Serious conflicts.

This patch adds the Facebook SDK Javascript into the Default theme supplied with core. Thus, the extensions now only need to worry about the module, and dont need to do any modifications or worry about whether FB JS has already been loaded.

Would be useful for a large proportion of OpenCart shops.