### PR TITLE
Fix event bug in manufacturer.php

### DIFF
--- a/upload/admin/model/catalog/manufacturer.php
+++ b/upload/admin/model/catalog/manufacturer.php
@@ -53,7 +53,7 @@ class ModelCatalogManufacturer extends Model {
 
 		$this->cache->delete('manufacturer');
 
-		$this->event->trigger('post.admin.manufacturer.edit');
+		$this->event->trigger('post.admin.manufacturer.edit', $manufacturer_id);
 	}
 
 	public function deleteManufacturer($manufacturer_id) {


### PR DESCRIPTION
Including $manufacturer_id as argument for event trigger for post.admin.manufacturer.edit as per the documentation.