### PR TITLE
fix cart quantity input width on mobile

### DIFF
--- a/upload/catalog/view/theme/default/stylesheet/stylesheet.css
+++ b/upload/catalog/view/theme/default/stylesheet/stylesheet.css
@@ -704,3 +704,8 @@ h2.price {
 #column-right .product-layout {
 	width: 100%;
 }
+
+/* fixed mobile cart quantity input */
+.input-group .form-control[name^=quantity] {
+	min-width: 50px;
+}


### PR DESCRIPTION
I've set a minimum width on the quantity input in the cart to allow 3 characters to fit.