### PR TITLE
html.tpl

### DIFF
--- a/upload/catalog/view/theme/default/template/module/html.tpl
+++ b/upload/catalog/view/theme/default/template/module/html.tpl
@@ -1,3 +1,4 @@
 <div>
-  <h2><?php echo $heading_title; ?></h2>
-  <?php echo $html; ?></div>
+<?php if(!$heading_title){} else { ?>
+<h2><?php echo $heading_title; ?></h2>
+<?php } echo $html; ?></div>


### PR DESCRIPTION
When adding custom HTML code to your webstore via the HTML module,
if you don't need a heading title for your code, the module still adds a empty <h2></h2>, which leaves a very ugly space.

credit  to  aWeirdo  issue #2811