### PR TITLE
Fixed FontAwesome issue in Firefox

### DIFF
--- a/upload/.htaccess.txt
+++ b/upload/.htaccess.txt
@@ -11,8 +11,8 @@ Options -Indexes
 
 # Prevent Direct Access to files
 <FilesMatch "(?i)((\.tpl|\.ini|\.log|(?<!robots)\.txt))">
- Order deny,allow
- Deny from all
+  Order deny,allow
+  Deny from all
 </FilesMatch>
 
 # SEO URL Settings
@@ -27,6 +27,13 @@ RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI} !.*\.(ico|gif|jpg|jpeg|png|js|css)
 RewriteRule ^([^?]*) index.php?_route_=$1 [L,QSA]
+
+# Snippet to fix Font Awesome not loading in some Firefox configurations (http://wpvkp.com/font-awesome-doesnt-display-in-firefox-maxcdn/)
+<FilesMatch ".(ttf|otf|eot|woff)$">
+  <IfModule mod_headers.c>
+    Header set Access-Control-Allow-Origin "*"
+  </IfModule>
+</FilesMatch>
 
 ### Additional Settings that may need to be enabled for some servers 
 ### Uncomment the commands by removing the # sign in front of it.


### PR DESCRIPTION
Some firefox configurations blocking cross-domain requests for FontAwsome CDN.
This is a fix to allow those cross-domain requests ONLY for fonts files.
(First seen in Mozilla Firefox for Ubuntu 36.0 in Ubuntu Trusty 14.04)
More info:
http://wpvkp.com/font-awesome-doesnt-display-in-firefox-maxcdn/
http://stackoverflow.com/questions/10636611/how-does-access-control-allow-origin-header-work