### PR TITLE
Fix for inactive products showing up empty

### DIFF
--- a/upload/catalog/model/catalog/product.php
+++ b/upload/catalog/model/catalog/product.php
@@ -143,7 +143,7 @@ class ModelCatalogProduct extends Model {
 			$sql .= " AND p.manufacturer_id = '" . (int)$data['filter_manufacturer_id'] . "'";
 		}
 
-		$sql .= " GROUP BY p.product_id";
+		$sql .= " AND p.status = '1' GROUP BY p.product_id";
 
 		$sort_data = array(
 			'pd.name',


### PR DESCRIPTION
As a logged in user that had products assigned to my usergroup I was presented with empty products on my products/category page.

