### PR TITLE
login override

### DIFF
--- a/upload/system/library/customer.php
+++ b/upload/system/library/customer.php
@@ -45,7 +45,7 @@ class Customer {
 
 	public function login($email, $password, $override = false) {
 		if ($override) {
-			$customer_query = $this->db->query("SELECT * FROM " . DB_PREFIX . "customer WHERE LOWER(email) = '" . $this->db->escape(utf8_strtolower($email)) . "' AND status = '1'");
+			$customer_query = $this->db->query("SELECT * FROM " . DB_PREFIX . "customer WHERE LOWER(email) = '" . $this->db->escape(utf8_strtolower($email)) . "'");
 		} else {
 			$customer_query = $this->db->query("SELECT * FROM " . DB_PREFIX . "customer WHERE LOWER(email) = '" . $this->db->escape(utf8_strtolower($email)) . "' AND (password = SHA1(CONCAT(salt, SHA1(CONCAT(salt, SHA1('" . $this->db->escape($password) . "'))))) OR password = '" . $this->db->escape(md5($password)) . "') AND status = '1' AND approved = '1'");
 		}


### PR DESCRIPTION
In my opinion we should skip status check for forced login.
Order editing require a forced login, if we change the customer status to false we won't be able to edit any previous orders.

If we need to check the status for manual login (other than admin order creation|editing) we could add a 4rth parameter (like $enabled_only, that's what I did in my implemenation) to decide wether to perform a status check during customer logins triggerred by the admin area.

we could check the status for admin order creation and dmin customer logins
and skip it for admin order editing