### PR TITLE
performance improvement lazy loading rates

### DIFF
--- a/upload/system/library/tax.php
+++ b/upload/system/library/tax.php
@@ -2,6 +2,8 @@
 final class Tax {
 	private $tax_rates = array();
 
+	private $address = array();
+
 	private $initialized = false;
 
 	/**
@@ -13,34 +15,20 @@ final class Tax {
 		$this->config = $registry->get('config');
 		$this->db = $registry->get('db');
 		$this->session = $registry->get('session');
-	}
-	
-	private function initialize() {
-        	if ($this->initialized) {
-            		return;
-        	}
 
-		if (empty($this->is_set['shipping'])) {
-			if (isset($this->session->data['shipping_address'])) {
-				$this->setShippingAddress($this->session->data['shipping_address']['country_id'], $this->session->data['shipping_address']['zone_id']);
-			} elseif ($this->config->get('config_tax_default') == 'shipping') {
-				$this->setShippingAddress($this->config->get('config_country_id'), $this->config->get('config_zone_id'));
-			}
+		if (isset($this->session->data['shipping_address'])) {
+			$this->setShippingAddress($this->session->data['shipping_address']['country_id'], $this->session->data['shipping_address']['zone_id']);
+		} elseif ($this->config->get('config_tax_default') == 'shipping') {
+			$this->setShippingAddress($this->config->get('config_country_id'), $this->config->get('config_zone_id'));
 		}
 
-		if (empty($this->is_set['payment'])) {
-			if (isset($this->session->data['payment_address'])) {
-				$this->setPaymentAddress($this->session->data['payment_address']['country_id'], $this->session->data['payment_address']['zone_id']);
-			} elseif ($this->config->get('config_tax_default') == 'payment') {
-				$this->setPaymentAddress($this->config->get('config_country_id'), $this->config->get('config_zone_id'));
-			}
+		if (isset($this->session->data['payment_address'])) {
+			$this->setPaymentAddress($this->session->data['payment_address']['country_id'], $this->session->data['payment_address']['zone_id']);
+		} elseif ($this->config->get('config_tax_default') == 'payment') {
+			$this->setPaymentAddress($this->config->get('config_country_id'), $this->config->get('config_zone_id'));
 		}
 
-		if (empty($this->is_set['store'])) {
-			$this->setStoreAddress($this->config->get('config_country_id'), $this->config->get('config_zone_id'));
-		}
-
-		$this->initialized = true;
+		$this->setStoreAddress($this->config->get('config_country_id'), $this->config->get('config_zone_id'));
 	}
 
 	public function setShippingAddress($country_id, $zone_id) {
@@ -56,19 +44,38 @@ final class Tax {
 	}
 
 	private function setAddress($based, $country_id, $zone_id) {
-		$tax_query = $this->db->query("SELECT tr1.tax_class_id, tr2.tax_rate_id, tr2.name, tr2.rate, tr2.type, tr1.priority FROM " . DB_PREFIX . "tax_rule tr1 LEFT JOIN " . DB_PREFIX . "tax_rate tr2 ON (tr1.tax_rate_id = tr2.tax_rate_id) INNER JOIN " . DB_PREFIX . "tax_rate_to_customer_group tr2cg ON (tr2.tax_rate_id = tr2cg.tax_rate_id) LEFT JOIN " . DB_PREFIX . "zone_to_geo_zone z2gz ON (tr2.geo_zone_id = z2gz.geo_zone_id) LEFT JOIN " . DB_PREFIX . "geo_zone gz ON (tr2.geo_zone_id = gz.geo_zone_id) WHERE tr1.based = '{$based}' AND tr2cg.customer_group_id = '" . (int)$this->config->get('config_customer_group_id') . "' AND z2gz.country_id = '" . (int)$country_id . "' AND (z2gz.zone_id = '0' OR z2gz.zone_id = '" . (int)$zone_id . "') ORDER BY tr1.priority ASC");
+		$this->address[$based] = array('store', $country_id, $zone_id);
+		$this->refresh();
+	}
+	
+	private function initialize() {
+		if (!$this->initialized) {
+			$address_types = array('shipping', 'payment', 'store');
 
-		foreach ($tax_query->rows as $result) {
-			$this->tax_rates[$result['tax_class_id']][$result['tax_rate_id']] = array(
-				'tax_rate_id' => $result['tax_rate_id'],
-				'name'        => $result['name'],
-				'rate'        => $result['rate'],
-				'type'        => $result['type'],
-				'priority'    => $result['priority']
-			);
+			foreach ($address_types as $based ) {
+				$country_id = $this->address[$based]['country_id'];
+				$zone_id    = $this->address[$based]['zone_id'];
+
+				$tax_query = $this->db->query("SELECT tr1.tax_class_id, tr2.tax_rate_id, tr2.name, tr2.rate, tr2.type, tr1.priority FROM " . DB_PREFIX . "tax_rule tr1 LEFT JOIN " . DB_PREFIX . "tax_rate tr2 ON (tr1.tax_rate_id = tr2.tax_rate_id) INNER JOIN " . DB_PREFIX . "tax_rate_to_customer_group tr2cg ON (tr2.tax_rate_id = tr2cg.tax_rate_id) LEFT JOIN " . DB_PREFIX . "zone_to_geo_zone z2gz ON (tr2.geo_zone_id = z2gz.geo_zone_id) LEFT JOIN " . DB_PREFIX . "geo_zone gz ON (tr2.geo_zone_id = gz.geo_zone_id) WHERE tr1.based = '{$based}' AND tr2cg.customer_group_id = '" . (int)$this->config->get('config_customer_group_id') . "' AND z2gz.country_id = '" . (int)$country_id . "' AND (z2gz.zone_id = '0' OR z2gz.zone_id = '" . (int)$zone_id . "') ORDER BY tr1.priority ASC");
+
+				foreach ($tax_query->rows as $result) {
+					$this->tax_rates[$result['tax_class_id']][$result['tax_rate_id']] = array(
+						'tax_rate_id' => $result['tax_rate_id'],
+						'name'        => $result['name'],
+						'rate'        => $result['rate'],
+						'type'        => $result['type'],
+						'priority'    => $result['priority']
+					);
+				}
+			}
+
+			$this->initialized = true;
 		}
-
-		$this->is_set[$based] = true;
+	}
+	
+	private function refresh() {
+		$this->tax_rates = array();
+		$this->initialized = false;
 	}
 
 	public function calculate($value, $tax_class_id, $calculate = true) {

--- a/upload/system/library/tax.php
+++ b/upload/system/library/tax.php
@@ -39,7 +39,10 @@ final class Tax {
 	}
 
 	private function setAddress($based, $country_id, $zone_id) {
-		$this->address[$based] = array((int)$country_id, (int)$zone_id);
+		$this->address[$based] = array(
+			'country_id' => (int)$country_id, 
+			'zone_id'    => (int)$zone_id,
+		);
 		$this->refresh();
 	}
 	

--- a/upload/system/library/tax.php
+++ b/upload/system/library/tax.php
@@ -4,6 +4,9 @@ final class Tax {
 
 	private $ready = null;
 
+	/**
+	 * Making sure that prepare() does not overwrite setAddress() calls settings if/when called after that.
+	 */
 	private $is_set = array();
 
 	public function __construct($registry) {

--- a/upload/system/library/tax.php
+++ b/upload/system/library/tax.php
@@ -2,56 +2,51 @@
 final class Tax {
 	private $tax_rates = array();
 
+	private $ready = array();
+
 	public function __construct($registry) {
 		$this->config = $registry->get('config');
 		$this->db = $registry->get('db');
 		$this->session = $registry->get('session');
-
-		if (isset($this->session->data['shipping_address'])) {
-			$this->setShippingAddress($this->session->data['shipping_address']['country_id'], $this->session->data['shipping_address']['zone_id']);
-		} elseif ($this->config->get('config_tax_default') == 'shipping') {
-			$this->setShippingAddress($this->config->get('config_country_id'), $this->config->get('config_zone_id'));
-		}
-
-		if (isset($this->session->data['payment_address'])) {
-			$this->setPaymentAddress($this->session->data['payment_address']['country_id'], $this->session->data['payment_address']['zone_id']);
-		} elseif ($this->config->get('config_tax_default') == 'payment') {
-			$this->setPaymentAddress($this->config->get('config_country_id'), $this->config->get('config_zone_id'));
-		}
-
-		$this->setStoreAddress($this->config->get('config_country_id'), $this->config->get('config_zone_id'));
 	}
-
-	public function setShippingAddress($country_id, $zone_id) {
-		$tax_query = $this->db->query("SELECT tr1.tax_class_id, tr2.tax_rate_id, tr2.name, tr2.rate, tr2.type, tr1.priority FROM " . DB_PREFIX . "tax_rule tr1 LEFT JOIN " . DB_PREFIX . "tax_rate tr2 ON (tr1.tax_rate_id = tr2.tax_rate_id) INNER JOIN " . DB_PREFIX . "tax_rate_to_customer_group tr2cg ON (tr2.tax_rate_id = tr2cg.tax_rate_id) LEFT JOIN " . DB_PREFIX . "zone_to_geo_zone z2gz ON (tr2.geo_zone_id = z2gz.geo_zone_id) LEFT JOIN " . DB_PREFIX . "geo_zone gz ON (tr2.geo_zone_id = gz.geo_zone_id) WHERE tr1.based = 'shipping' AND tr2cg.customer_group_id = '" . (int)$this->config->get('config_customer_group_id') . "' AND z2gz.country_id = '" . (int)$country_id . "' AND (z2gz.zone_id = '0' OR z2gz.zone_id = '" . (int)$zone_id . "') ORDER BY tr1.priority ASC");
-
-		foreach ($tax_query->rows as $result) {
-			$this->tax_rates[$result['tax_class_id']][$result['tax_rate_id']] = array(
-				'tax_rate_id' => $result['tax_rate_id'],
-				'name'        => $result['name'],
-				'rate'        => $result['rate'],
-				'type'        => $result['type'],
-				'priority'    => $result['priority']
-			);
+	
+	private function prepare()
+	{
+		if (empty($this->ready['shipping'])) {
+			if (isset($this->session->data['shipping_address'])) {
+				$this->setShippingAddress($this->session->data['shipping_address']['country_id'], $this->session->data['shipping_address']['zone_id']);
+			} elseif ($this->config->get('config_tax_default') == 'shipping') {
+				$this->setShippingAddress($this->config->get('config_country_id'), $this->config->get('config_zone_id'));
+			}
 		}
+
+		if (empty($this->ready['payment'])) {
+			if (isset($this->session->data['payment_address'])) {
+				$this->setPaymentAddress($this->session->data['payment_address']['country_id'], $this->session->data['payment_address']['zone_id']);
+			} elseif ($this->config->get('config_tax_default') == 'payment') {
+				$this->setPaymentAddress($this->config->get('config_country_id'), $this->config->get('config_zone_id'));
+			}
+		}
+
+		if (empty($this->ready['store'])) {
+			$this->setStoreAddress($this->config->get('config_country_id'), $this->config->get('config_zone_id'));
+		}
+	}
+	
+	public function setShippingAddress($country_id, $zone_id) {
+		$this->setAddress('shipping', $country_id, $zone_id);;
 	}
 
 	public function setPaymentAddress($country_id, $zone_id) {
-		$tax_query = $this->db->query("SELECT tr1.tax_class_id, tr2.tax_rate_id, tr2.name, tr2.rate, tr2.type, tr1.priority FROM " . DB_PREFIX . "tax_rule tr1 LEFT JOIN " . DB_PREFIX . "tax_rate tr2 ON (tr1.tax_rate_id = tr2.tax_rate_id) INNER JOIN " . DB_PREFIX . "tax_rate_to_customer_group tr2cg ON (tr2.tax_rate_id = tr2cg.tax_rate_id) LEFT JOIN " . DB_PREFIX . "zone_to_geo_zone z2gz ON (tr2.geo_zone_id = z2gz.geo_zone_id) LEFT JOIN " . DB_PREFIX . "geo_zone gz ON (tr2.geo_zone_id = gz.geo_zone_id) WHERE tr1.based = 'payment' AND tr2cg.customer_group_id = '" . (int)$this->config->get('config_customer_group_id') . "' AND z2gz.country_id = '" . (int)$country_id . "' AND (z2gz.zone_id = '0' OR z2gz.zone_id = '" . (int)$zone_id . "') ORDER BY tr1.priority ASC");
-
-		foreach ($tax_query->rows as $result) {
-			$this->tax_rates[$result['tax_class_id']][$result['tax_rate_id']] = array(
-				'tax_rate_id' => $result['tax_rate_id'],
-				'name'        => $result['name'],
-				'rate'        => $result['rate'],
-				'type'        => $result['type'],
-				'priority'    => $result['priority']
-			);
-		}
+		$this->setAddress('payment', $country_id, $zone_id);
 	}
 
 	public function setStoreAddress($country_id, $zone_id) {
-		$tax_query = $this->db->query("SELECT tr1.tax_class_id, tr2.tax_rate_id, tr2.name, tr2.rate, tr2.type, tr1.priority FROM " . DB_PREFIX . "tax_rule tr1 LEFT JOIN " . DB_PREFIX . "tax_rate tr2 ON (tr1.tax_rate_id = tr2.tax_rate_id) INNER JOIN " . DB_PREFIX . "tax_rate_to_customer_group tr2cg ON (tr2.tax_rate_id = tr2cg.tax_rate_id) LEFT JOIN " . DB_PREFIX . "zone_to_geo_zone z2gz ON (tr2.geo_zone_id = z2gz.geo_zone_id) LEFT JOIN " . DB_PREFIX . "geo_zone gz ON (tr2.geo_zone_id = gz.geo_zone_id) WHERE tr1.based = 'store' AND tr2cg.customer_group_id = '" . (int)$this->config->get('config_customer_group_id') . "' AND z2gz.country_id = '" . (int)$country_id . "' AND (z2gz.zone_id = '0' OR z2gz.zone_id = '" . (int)$zone_id . "') ORDER BY tr1.priority ASC");
+		$this->setAddress('store', $country_id, $zone_id);
+	}
+
+	private function setAddress($based, $country_id, $zone_id) {
+		$tax_query = $this->db->query("SELECT tr1.tax_class_id, tr2.tax_rate_id, tr2.name, tr2.rate, tr2.type, tr1.priority FROM " . DB_PREFIX . "tax_rule tr1 LEFT JOIN " . DB_PREFIX . "tax_rate tr2 ON (tr1.tax_rate_id = tr2.tax_rate_id) INNER JOIN " . DB_PREFIX . "tax_rate_to_customer_group tr2cg ON (tr2.tax_rate_id = tr2cg.tax_rate_id) LEFT JOIN " . DB_PREFIX . "zone_to_geo_zone z2gz ON (tr2.geo_zone_id = z2gz.geo_zone_id) LEFT JOIN " . DB_PREFIX . "geo_zone gz ON (tr2.geo_zone_id = gz.geo_zone_id) WHERE tr1.based = '{$based}' AND tr2cg.customer_group_id = '" . (int)$this->config->get('config_customer_group_id') . "' AND z2gz.country_id = '" . (int)$country_id . "' AND (z2gz.zone_id = '0' OR z2gz.zone_id = '" . (int)$zone_id . "') ORDER BY tr1.priority ASC");
 
 		foreach ($tax_query->rows as $result) {
 			$this->tax_rates[$result['tax_class_id']][$result['tax_rate_id']] = array(
@@ -62,8 +57,10 @@ final class Tax {
 				'priority'    => $result['priority']
 			);
 		}
-	}
 
+		$this->ready[$based] = true;
+	}
+	
 	public function calculate($value, $tax_class_id, $calculate = true) {
 		if ($tax_class_id && $calculate) {
 			$amount = 0;
@@ -107,6 +104,8 @@ final class Tax {
 	}
 
 	public function getRates($value, $tax_class_id) {
+		$this->prepare();
+		
 		$tax_rate_data = array();
 
 		if (isset($this->tax_rates[$tax_class_id])) {
@@ -137,6 +136,7 @@ final class Tax {
 	}
 
 	public function has($tax_class_id) {
+		$this->prepare();
 		return isset($this->taxes[$tax_class_id]);
 	}
 }

--- a/upload/system/library/tax.php
+++ b/upload/system/library/tax.php
@@ -45,11 +45,9 @@ final class Tax {
 	
 	private function initialize() {
 		if (!$this->initialized) {
-			$address_types = array('shipping', 'payment', 'store');
-
-			foreach ($address_types as $based) {
-				$country_id = $this->address[$based]['country_id'];
-				$zone_id    = $this->address[$based]['zone_id'];
+			foreach ($this->address as $based => $address) {
+				$country_id = $address['country_id'];
+				$zone_id    = $address['zone_id'];
 
 				$tax_query = $this->db->query("SELECT tr1.tax_class_id, tr2.tax_rate_id, tr2.name, tr2.rate, tr2.type, tr1.priority FROM " . DB_PREFIX . "tax_rule tr1 LEFT JOIN " . DB_PREFIX . "tax_rate tr2 ON (tr1.tax_rate_id = tr2.tax_rate_id) INNER JOIN " . DB_PREFIX . "tax_rate_to_customer_group tr2cg ON (tr2.tax_rate_id = tr2cg.tax_rate_id) LEFT JOIN " . DB_PREFIX . "zone_to_geo_zone z2gz ON (tr2.geo_zone_id = z2gz.geo_zone_id) LEFT JOIN " . DB_PREFIX . "geo_zone gz ON (tr2.geo_zone_id = gz.geo_zone_id) WHERE tr1.based = '{$based}' AND tr2cg.customer_group_id = '" . (int)$this->config->get('config_customer_group_id') . "' AND z2gz.country_id = '" . (int)$country_id . "' AND (z2gz.zone_id = '0' OR z2gz.zone_id = '" . (int)$zone_id . "') ORDER BY tr1.priority ASC");
 

--- a/upload/system/library/tax.php
+++ b/upload/system/library/tax.php
@@ -2,7 +2,7 @@
 final class Tax {
 	private $tax_rates = array();
 
-	private $initialized = null;
+	private $initialized = false;
 
 	/**
 	 * Making sure that initialize() does not overwrite setAddress() calls settings if/when called after that.

--- a/upload/system/library/tax.php
+++ b/upload/system/library/tax.php
@@ -15,12 +15,11 @@ final class Tax {
 		$this->session = $registry->get('session');
 	}
 	
-	private function prepare()
-	{
+	private function prepare() {
         	if ($this->ready) {
             		return;
         	}
-       
+
 		if (empty($this->is_set['shipping'])) {
 			if (isset($this->session->data['shipping_address'])) {
 				$this->setShippingAddress($this->session->data['shipping_address']['country_id'], $this->session->data['shipping_address']['zone_id']);
@@ -43,7 +42,7 @@ final class Tax {
 
 		$this->ready = true;
 	}
-	
+
 	public function setShippingAddress($country_id, $zone_id) {
 		$this->setAddress('shipping', $country_id, $zone_id);
 	}
@@ -71,7 +70,7 @@ final class Tax {
 
 		$this->is_set[$based] = true;
 	}
-	
+
 	public function calculate($value, $tax_class_id, $calculate = true) {
 		if ($tax_class_id && $calculate) {
 			$amount = 0;

--- a/upload/system/library/tax.php
+++ b/upload/system/library/tax.php
@@ -2,7 +2,9 @@
 final class Tax {
 	private $tax_rates = array();
 
-	private $ready = array();
+	private $ready = null;
+
+	private $is_set = array();
 
 	public function __construct($registry) {
 		$this->config = $registry->get('config');
@@ -12,7 +14,11 @@ final class Tax {
 	
 	private function prepare()
 	{
-		if (empty($this->ready['shipping'])) {
+        	if ($this->ready) {
+            		return;
+        	}
+       
+		if (empty($this->is_set['shipping'])) {
 			if (isset($this->session->data['shipping_address'])) {
 				$this->setShippingAddress($this->session->data['shipping_address']['country_id'], $this->session->data['shipping_address']['zone_id']);
 			} elseif ($this->config->get('config_tax_default') == 'shipping') {
@@ -20,7 +26,7 @@ final class Tax {
 			}
 		}
 
-		if (empty($this->ready['payment'])) {
+		if (empty($this->is_set['payment'])) {
 			if (isset($this->session->data['payment_address'])) {
 				$this->setPaymentAddress($this->session->data['payment_address']['country_id'], $this->session->data['payment_address']['zone_id']);
 			} elseif ($this->config->get('config_tax_default') == 'payment') {
@@ -28,13 +34,15 @@ final class Tax {
 			}
 		}
 
-		if (empty($this->ready['store'])) {
+		if (empty($this->is_set['store'])) {
 			$this->setStoreAddress($this->config->get('config_country_id'), $this->config->get('config_zone_id'));
 		}
+
+		$this->ready = true;
 	}
 	
 	public function setShippingAddress($country_id, $zone_id) {
-		$this->setAddress('shipping', $country_id, $zone_id);;
+		$this->setAddress('shipping', $country_id, $zone_id);
 	}
 
 	public function setPaymentAddress($country_id, $zone_id) {
@@ -58,7 +66,7 @@ final class Tax {
 			);
 		}
 
-		$this->ready[$based] = true;
+		$this->is_set[$based] = true;
 	}
 	
 	public function calculate($value, $tax_class_id, $calculate = true) {

--- a/upload/system/library/tax.php
+++ b/upload/system/library/tax.php
@@ -141,7 +141,7 @@ final class Tax {
 				}
 
 				$tax_rate_data[$tax_rate_id] = array(
-					'tax_rate_id' => $tax_rate['tax_rate_id'],
+					'tax_rate_id' => $tax_rate_id,
 					'name'        => $tax_rate['name'],
 					'rate'        => $tax_rate['rate'],
 					'type'        => $tax_rate['type'],

--- a/upload/system/library/tax.php
+++ b/upload/system/library/tax.php
@@ -43,11 +43,14 @@ final class Tax {
 			'country_id' => (int)$country_id, 
 			'zone_id'    => (int)$zone_id,
 		);
+
 		$this->refresh();
 	}
 	
 	private function initialize() {
 		if (!$this->initialized) {
+			$this->tax_rates = array();
+
 			foreach ($this->address as $based => $address) {
 				$country_id = $address['country_id'];
 				$zone_id    = $address['zone_id'];
@@ -72,8 +75,7 @@ final class Tax {
 		}
 	}
 	
-	private function refresh() {
-		$this->tax_rates = array();
+	public function refresh() {
 		$this->initialized = false;
 	}
 
@@ -125,9 +127,9 @@ final class Tax {
 		$tax_rate_data = array();
 
 		if (isset($this->tax_rates[$tax_class_id])) {
-			foreach ($this->tax_rates[$tax_class_id] as $tax_rate) {
-				if (isset($tax_rate_data[$tax_rate['tax_rate_id']])) {
-					$amount = $tax_rate_data[$tax_rate['tax_rate_id']]['amount'];
+			foreach ($this->tax_rates[$tax_class_id] as $tax_rate_id => $tax_rate) {
+				if (isset($tax_rate_data[$tax_rate_id])) {
+					$amount = $tax_rate_data[$tax_rate_id]['amount'];
 				} else {
 					$amount = 0;
 				}
@@ -138,12 +140,12 @@ final class Tax {
 					$amount += ($value / 100 * $tax_rate['rate']);
 				}
 
-				$tax_rate_data[$tax_rate['tax_rate_id']] = array(
+				$tax_rate_data[$tax_rate_id] = array(
 					'tax_rate_id' => $tax_rate['tax_rate_id'],
 					'name'        => $tax_rate['name'],
 					'rate'        => $tax_rate['rate'],
 					'type'        => $tax_rate['type'],
-					'amount'      => $amount
+					'amount'      => $amount,
 				);
 			}
 		}

--- a/upload/system/library/tax.php
+++ b/upload/system/library/tax.php
@@ -44,7 +44,7 @@ final class Tax {
 	}
 
 	private function setAddress($based, $country_id, $zone_id) {
-		$this->address[$based] = array($country_id, $zone_id);
+		$this->address[$based] = array((int)$country_id, (int)$zone_id);
 		$this->refresh();
 	}
 	
@@ -59,12 +59,15 @@ final class Tax {
 				$tax_query = $this->db->query("SELECT tr1.tax_class_id, tr2.tax_rate_id, tr2.name, tr2.rate, tr2.type, tr1.priority FROM " . DB_PREFIX . "tax_rule tr1 LEFT JOIN " . DB_PREFIX . "tax_rate tr2 ON (tr1.tax_rate_id = tr2.tax_rate_id) INNER JOIN " . DB_PREFIX . "tax_rate_to_customer_group tr2cg ON (tr2.tax_rate_id = tr2cg.tax_rate_id) LEFT JOIN " . DB_PREFIX . "zone_to_geo_zone z2gz ON (tr2.geo_zone_id = z2gz.geo_zone_id) LEFT JOIN " . DB_PREFIX . "geo_zone gz ON (tr2.geo_zone_id = gz.geo_zone_id) WHERE tr1.based = '{$based}' AND tr2cg.customer_group_id = '" . (int)$this->config->get('config_customer_group_id') . "' AND z2gz.country_id = '" . (int)$country_id . "' AND (z2gz.zone_id = '0' OR z2gz.zone_id = '" . (int)$zone_id . "') ORDER BY tr1.priority ASC");
 
 				foreach ($tax_query->rows as $result) {
-					$this->tax_rates[$result['tax_class_id']][$result['tax_rate_id']] = array(
-						'tax_rate_id' => $result['tax_rate_id'],
+					$tax_class_id = (int)$result['tax_class_id'];
+					$tax_rate_id  = (int)$result['tax_rate_id'];
+
+					$this->tax_rates[$tax_class_id][$tax_rate_id] = array(
+						'tax_rate_id' => $tax_rate_id,
 						'name'        => $result['name'],
-						'rate'        => $result['rate'],
+						'rate'        => (float) $result['rate'],
 						'type'        => $result['type'],
-						'priority'    => $result['priority']
+						'priority'    => (int) $result['priority'],
 					);
 				}
 			}

--- a/upload/system/library/tax.php
+++ b/upload/system/library/tax.php
@@ -52,7 +52,7 @@ final class Tax {
 		if (!$this->initialized) {
 			$address_types = array('shipping', 'payment', 'store');
 
-			foreach ($address_types as $based ) {
+			foreach ($address_types as $based) {
 				$country_id = $this->address[$based]['country_id'];
 				$zone_id    = $this->address[$based]['zone_id'];
 

--- a/upload/system/library/tax.php
+++ b/upload/system/library/tax.php
@@ -44,7 +44,7 @@ final class Tax {
 	}
 
 	private function setAddress($based, $country_id, $zone_id) {
-		$this->address[$based] = array('store', $country_id, $zone_id);
+		$this->address[$based] = array($country_id, $zone_id);
 		$this->refresh();
 	}
 	

--- a/upload/system/library/tax.php
+++ b/upload/system/library/tax.php
@@ -2,10 +2,10 @@
 final class Tax {
 	private $tax_rates = array();
 
-	private $ready = null;
+	private $initialized = null;
 
 	/**
-	 * Making sure that prepare() does not overwrite setAddress() calls settings if/when called after that.
+	 * Making sure that initialize() does not overwrite setAddress() calls settings if/when called after that.
 	 */
 	private $is_set = array();
 
@@ -15,8 +15,8 @@ final class Tax {
 		$this->session = $registry->get('session');
 	}
 	
-	private function prepare() {
-        	if ($this->ready) {
+	private function initialize() {
+        	if ($this->initialized) {
             		return;
         	}
 
@@ -40,7 +40,7 @@ final class Tax {
 			$this->setStoreAddress($this->config->get('config_country_id'), $this->config->get('config_zone_id'));
 		}
 
-		$this->ready = true;
+		$this->initialized = true;
 	}
 
 	public function setShippingAddress($country_id, $zone_id) {
@@ -114,7 +114,7 @@ final class Tax {
 	}
 
 	public function getRates($value, $tax_class_id) {
-		$this->prepare();
+		$this->initialize();
 		
 		$tax_rate_data = array();
 
@@ -146,7 +146,7 @@ final class Tax {
 	}
 
 	public function has($tax_class_id) {
-		$this->prepare();
+		$this->initialize();
 		return isset($this->taxes[$tax_class_id]);
 	}
 }

--- a/upload/system/library/tax.php
+++ b/upload/system/library/tax.php
@@ -6,11 +6,6 @@ final class Tax {
 
 	private $initialized = false;
 
-	/**
-	 * Making sure that initialize() does not overwrite setAddress() calls settings if/when called after that.
-	 */
-	private $is_set = array();
-
 	public function __construct($registry) {
 		$this->config = $registry->get('config');
 		$this->db = $registry->get('db');


### PR DESCRIPTION
Not every route needs tax calculations (ajax generated zone/country listing, product review creation, login, logout)
By moving tax rates loading out of the constructors we can avoid (3) unused database query for those routes.

also, refactored setters....they are basically one method with a parameter ($based)