### PR TITLE
never met condition

### DIFF
--- a/upload/system/library/tax.php
+++ b/upload/system/library/tax.php
@@ -111,19 +111,15 @@ final class Tax {
 
 		if (isset($this->tax_rates[$tax_class_id])) {
 			foreach ($this->tax_rates[$tax_class_id] as $tax_rate) {
-				if (isset($tax_rate_data[$tax_rate['tax_rate_id']])) {
-					$amount = $tax_rate_data[$tax_rate['tax_rate_id']]['amount'];
-				} else {
-					$amount = 0;
-				}
+				$amount = 0;
 
 				if ($tax_rate['type'] == 'F') {
-					$amount += $tax_rate['rate'];
+					$amount = $tax_rate['rate'];
 				} elseif ($tax_rate['type'] == 'P') {
-					$amount += ($value / 100 * $tax_rate['rate']);
+					$amount = ($value / 100 * $tax_rate['rate']);
 				}
 
-				$tax_rate_data[$tax_rate['tax_rate_id']] = array(
+				$tax_rate_data[$tax_rate_id] = array(
 					'tax_rate_id' => $tax_rate['tax_rate_id'],
 					'name'        => $tax_rate['name'],
 					'rate'        => $tax_rate['rate'],


### PR DESCRIPTION
Please verify:
the condition in line 113
```php
if (isset($tax_rate_data[$tax_rate['tax_rate_id']])) {
//...
}
```
is never met.

the loop can be written as
```php
foreach ($this->tax_rates[$tax_class_id] as $tax_rate_id => $tax_rate) {
//...
}
```
the keys are $tax_rate['tax_rate_id'] and the same key will be never called again.

The class tax doesn't support having the same tax rate set more than once (with different "based") for the same tax class, because the keys are the tax rates' ids. To support that we need to add a new level in the tax_rates property as for instance:
```php
$this->tax_rates[$tax_class_id][$based][$tax_rate_id] = $tax_rate;
//instead of just
$this->tax_rates[$tax_class_id][$tax_rate_id] = $tax_rate; // current implementation
```

the getRates loop would look like
```php
foreach ($this->tax_rates[$tax_class_id] as $based => $tax_rates) {
    foreach ($tax_rates as $tax_rate_id => $tax_rate) {
        //...now we can check if isset($tax_rate_data[$tax_rate['tax_rate_id']])
    }
}
```

the set(Shipping|Payment|Store)Method should be changed accordingly:
```php
$this->tax_rates[$rate['tax_class_id']][$based][$rate['tax_rate_id']] = array(
//...
```