### PR TITLE
moved 'Stores' link from under the 'Help' dropdown to it's own dropdown.

### DIFF
--- a/upload/admin/view/template/common/header.tpl
+++ b/upload/admin/view/template/common/header.tpl
@@ -63,15 +63,18 @@
     </li>
     <li class="dropdown"><a class="dropdown-toggle" data-toggle="dropdown"><i class="fa fa-life-ring fa-lg"></i></a>
       <ul class="dropdown-menu dropdown-menu-right">
-        <li class="dropdown-header"><?php echo $text_store; ?> <i class="fa fa-shopping-cart"></i></li>
-        <?php foreach ($stores as $store) { ?>
-        <li><a href="<?php echo $store['href']; ?>" target="_blank"><?php echo $store['name']; ?></a></li>
-        <?php } ?>
-        <li class="divider"></li>
         <li class="dropdown-header"><?php echo $text_help; ?> <i class="fa fa-life-ring"></i></li>
         <li><a href="http://www.opencart.com" target="_blank"><?php echo $text_homepage; ?></a></li>
         <li><a href="http://docs.opencart.com" target="_blank"><?php echo $text_documentation; ?></a></li>
         <li><a href="http://forum.opencart.com" target="_blank"><?php echo $text_support; ?></a></li>
+      </ul>
+    </li>
+    <li class="dropdown"><a class="dropdown-toggle" data-toggle="dropdown"><i class="fa fa-shopping-cart fa-lg"></i></a>
+      <ul class="dropdown-menu dropdown-menu-right">
+        <li class="dropdown-header"><?php echo $text_store; ?> <i class="fa fa-shopping-cart"></i></li>
+        <?php foreach ($stores as $store) { ?>
+        <li><a href="<?php echo $store['href']; ?>" target="_blank"><?php echo $store['name']; ?></a></li>
+        <?php } ?>
       </ul>
     </li>
     <li><a href="<?php echo $logout; ?>"><span class="hidden-xs hidden-sm hidden-md"><?php echo $text_logout; ?></span> <i class="fa fa-sign-out fa-lg"></i></a></li>


### PR DESCRIPTION
Because, makes no sense that the links to Stores are under Help.. moved Store links to their own dropdown menu. 

![opencart-header-links](https://cloud.githubusercontent.com/assets/1043670/7023588/cb477c44-dd4f-11e4-84b9-10f949868f9e.png)
