### PR TITLE
shared zone listing controller

### DIFF
--- a/upload/catalog/controller/localisation/zone.php
+++ b/upload/catalog/controller/localisation/zone.php
@@ -1,0 +1,3 @@
+<?php
+class ControllerLocalisationZone extends Controller {
+}

--- a/upload/catalog/controller/localisation/zone.php
+++ b/upload/catalog/controller/localisation/zone.php
@@ -1,3 +1,28 @@
 <?php
 class ControllerLocalisationZone extends Controller {
+	public function index() {
+		$json = array();
+
+		$this->load->model('localisation/country');
+
+		$country_info = $this->model_localisation_country->getCountry($this->request->get['country_id']);
+
+		if ($country_info) {
+			$this->load->model('localisation/zone');
+
+			$json = array(
+				'country_id'        => $country_info['country_id'],
+				'name'              => $country_info['name'],
+				'iso_code_2'        => $country_info['iso_code_2'],
+				'iso_code_3'        => $country_info['iso_code_3'],
+				'address_format'    => $country_info['address_format'],
+				'postcode_required' => $country_info['postcode_required'],
+				'zone'              => $this->model_localisation_zone->getZonesByCountryId($this->request->get['country_id']),
+				'status'            => $country_info['status']
+			);
+		}
+
+		$this->response->addHeader('Content-Type: application/json');
+		$this->response->setOutput(json_encode($json));  
+	}
 }


### PR DESCRIPTION
I suggest using a single shared controller action for filling zone select form fields.

As of now we have the same method in
catalog/controller/
   account/account
   affiliate/edit
   affiliate/register
   checkout/checkout
   checkout/shipping

```js
//ajax call, $.ajax, load() ....
url: 'index.php?route=localisation/zone&country_id=' + country_id
//...
```
