### PR TITLE
Feature no zones

### DIFF
--- a/upload/admin/controller/localisation/country.php
+++ b/upload/admin/controller/localisation/country.php
@@ -276,6 +276,7 @@ class ControllerLocalisationCountry extends Controller {
 		$data['entry_iso_code_3'] = $this->language->get('entry_iso_code_3');
 		$data['entry_address_format'] = $this->language->get('entry_address_format');
 		$data['entry_postcode_required'] = $this->language->get('entry_postcode_required');
+		$data['entry_use_zones'] = $this->language->get('entry_use_zones');
 		$data['entry_status'] = $this->language->get('entry_status');
 
 		$data['help_address_format'] = $this->language->get('help_address_format');
@@ -371,6 +372,14 @@ class ControllerLocalisationCountry extends Controller {
 			$data['postcode_required'] = $country_info['postcode_required'];
 		} else {
 			$data['postcode_required'] = 0;
+		}
+
+		if (isset($this->request->post['use_zones'])) {
+			$data['use_zones'] = $this->request->post['use_zones'];
+		} elseif (!empty($country_info)) {
+			$data['use_zones'] = $country_info['use_zones'];
+		} else {
+			$data['use_zones'] = 0;
 		}
 
 		if (isset($this->request->post['status'])) {

--- a/upload/admin/language/english/localisation/country.php
+++ b/upload/admin/language/english/localisation/country.php
@@ -20,6 +20,7 @@ $_['entry_iso_code_2']        = 'ISO Code (2)';
 $_['entry_iso_code_3']        = 'ISO Code (3)';
 $_['entry_address_format']    = 'Address Format';
 $_['entry_postcode_required'] = 'Postcode Required';
+$_['entry_use_zones'] = 'Use/show zones';
 $_['entry_status']            = 'Status';
 
 // Help

--- a/upload/admin/language/english/localisation/country.php
+++ b/upload/admin/language/english/localisation/country.php
@@ -20,7 +20,7 @@ $_['entry_iso_code_2']        = 'ISO Code (2)';
 $_['entry_iso_code_3']        = 'ISO Code (3)';
 $_['entry_address_format']    = 'Address Format';
 $_['entry_postcode_required'] = 'Postcode Required';
-$_['entry_use_zones'] = 'Use/show zones';
+$_['entry_use_zones']         = 'Use/show zones';
 $_['entry_status']            = 'Status';
 
 // Help

--- a/upload/admin/model/localisation/country.php
+++ b/upload/admin/model/localisation/country.php
@@ -1,13 +1,13 @@
 <?php
 class ModelLocalisationCountry extends Model {
 	public function addCountry($data) {
-		$this->db->query("INSERT INTO " . DB_PREFIX . "country SET name = '" . $this->db->escape($data['name']) . "', iso_code_2 = '" . $this->db->escape($data['iso_code_2']) . "', iso_code_3 = '" . $this->db->escape($data['iso_code_3']) . "', address_format = '" . $this->db->escape($data['address_format']) . "', postcode_required = '" . (int)$data['postcode_required'] . "', status = '" . (int)$data['status'] . "'");
+		$this->db->query("INSERT INTO " . DB_PREFIX . "country SET name = '" . $this->db->escape($data['name']) . "', iso_code_2 = '" . $this->db->escape($data['iso_code_2']) . "', iso_code_3 = '" . $this->db->escape($data['iso_code_3']) . "', address_format = '" . $this->db->escape($data['address_format']) . "', postcode_required = '" . (int)$data['postcode_required'] . "', use_zones = '" . (int)$data['use_zones'] . "', status = '" . (int)$data['status'] . "'");
 
 		$this->cache->delete('country');
 	}
 
 	public function editCountry($country_id, $data) {
-		$this->db->query("UPDATE " . DB_PREFIX . "country SET name = '" . $this->db->escape($data['name']) . "', iso_code_2 = '" . $this->db->escape($data['iso_code_2']) . "', iso_code_3 = '" . $this->db->escape($data['iso_code_3']) . "', address_format = '" . $this->db->escape($data['address_format']) . "', postcode_required = '" . (int)$data['postcode_required'] . "', status = '" . (int)$data['status'] . "' WHERE country_id = '" . (int)$country_id . "'");
+		$this->db->query("UPDATE " . DB_PREFIX . "country SET name = '" . $this->db->escape($data['name']) . "', iso_code_2 = '" . $this->db->escape($data['iso_code_2']) . "', iso_code_3 = '" . $this->db->escape($data['iso_code_3']) . "', address_format = '" . $this->db->escape($data['address_format']) . "', postcode_required = '" . (int)$data['postcode_required'] . "', use_zones = '" . (int)$data['use_zones'] . "', status = '" . (int)$data['status'] . "' WHERE country_id = '" . (int)$country_id . "'");
 
 		$this->cache->delete('country');
 	}

--- a/upload/admin/view/template/localisation/country_form.tpl
+++ b/upload/admin/view/template/localisation/country_form.tpl
@@ -76,6 +76,29 @@
             </div>
           </div>
           <div class="form-group">
+            <label class="col-sm-2 control-label"><?php echo $entry_use_zones; ?></label>
+            <div class="col-sm-10">
+              <label class="radio-inline">
+                <?php if ($use_zones) { ?>
+                <input type="radio" name="use_zones" value="1" checked="checked" />
+                <?php echo $text_yes; ?>
+                <?php } else { ?>
+                <input type="radio" name="use_zones" value="1" />
+                <?php echo $text_yes; ?>
+                <?php } ?>
+              </label>
+              <label class="radio-inline">
+                <?php if (!$use_zones) { ?>
+                <input type="radio" name="use_zones" value="0" checked="checked" />
+                <?php echo $text_no; ?>
+                <?php } else { ?>
+                <input type="radio" name="use_zones" value="0" />
+                <?php echo $text_no; ?>
+                <?php } ?>
+              </label>
+            </div>
+          </div>
+          <div class="form-group">
             <label class="col-sm-2 control-label" for="input-status"><?php echo $entry_status; ?></label>
             <div class="col-sm-10">
               <select name="status" id="input-status" class="form-control">

--- a/upload/catalog/controller/account/account.php
+++ b/upload/catalog/controller/account/account.php
@@ -96,6 +96,7 @@ class ControllerAccountAccount extends Controller {
 				'iso_code_3'        => $country_info['iso_code_3'],
 				'address_format'    => $country_info['address_format'],
 				'postcode_required' => $country_info['postcode_required'],
+				'use_zones'         => $country_info['use_zones'],
 				'zone'              => $this->model_localisation_zone->getZonesByCountryId($this->request->get['country_id']),
 				'status'            => $country_info['status']
 			);

--- a/upload/catalog/controller/checkout/checkout.php
+++ b/upload/catalog/controller/checkout/checkout.php
@@ -111,6 +111,7 @@ class ControllerCheckoutCheckout extends Controller {
 				'iso_code_3'        => $country_info['iso_code_3'],
 				'address_format'    => $country_info['address_format'],
 				'postcode_required' => $country_info['postcode_required'],
+				'use_zones'         => $country_info['use_zones'],
 				'zone'              => $this->model_localisation_zone->getZonesByCountryId($this->request->get['country_id']),
 				'status'            => $country_info['status']
 			);

--- a/upload/catalog/controller/checkout/register.php
+++ b/upload/catalog/controller/checkout/register.php
@@ -175,7 +175,7 @@ class ControllerCheckoutRegister extends Controller {
 				$json['error']['country'] = $this->language->get('error_country');
 			}
 
-			if (!isset($this->request->post['zone_id']) || $this->request->post['zone_id'] == '') {
+			if ($country_info && $country_info['use_zones'] && (!isset($this->request->post['zone_id']) || $this->request->post['zone_id'] == '')) {
 				$json['error']['zone'] = $this->language->get('error_zone');
 			}
 

--- a/upload/catalog/controller/checkout/shipping_address.php
+++ b/upload/catalog/controller/checkout/shipping_address.php
@@ -159,7 +159,7 @@ class ControllerCheckoutShippingAddress extends Controller {
 					$json['error']['country'] = $this->language->get('error_country');
 				}
 
-				if (!isset($this->request->post['zone_id']) || $this->request->post['zone_id'] == '') {
+				if ($country_info && $country_info['use_zones'] && (!isset($this->request->post['zone_id']) || $this->request->post['zone_id'] == '')) {
 					$json['error']['zone'] = $this->language->get('error_zone');
 				}
 

--- a/upload/catalog/view/theme/default/template/account/address_form.tpl
+++ b/upload/catalog/view/theme/default/template/account/address_form.tpl
@@ -389,7 +389,8 @@ $('select[name=\'country_id\']').on('change', function() {
 
 			html = '<option value=""><?php echo $text_select; ?></option>';
 
-			if (json['zone'] && json['zone'] != '') {
+			if (json['zone'] && json['zone'] != '' && json['use_zones'] == '1') {
+				$('select[name=\'zone_id\']').parent().parent().show();
 				for (i = 0; i < json['zone'].length; i++) {
 					html += '<option value="' + json['zone'][i]['zone_id'] + '"';
 
@@ -401,6 +402,7 @@ $('select[name=\'country_id\']').on('change', function() {
 				}
 			} else {
 				html += '<option value="0" selected="selected"><?php echo $text_none; ?></option>';
+				$('select[name=\'zone_id\']').parent().parent().hide();
 			}
 
 			$('select[name=\'zone_id\']').html(html);

--- a/upload/catalog/view/theme/default/template/account/register.tpl
+++ b/upload/catalog/view/theme/default/template/account/register.tpl
@@ -687,7 +687,6 @@ $('select[name=\'country_id\']').on('change', function() {
 			} else {
 				html += '<option value="0" selected="selected"><?php echo $text_none; ?></option>';
 				$('select[name=\'zone_id\']').parent().parent().hide();
-				console.log(json['zone']);
 			}
 
 			$('select[name=\'zone_id\']').html(html);

--- a/upload/catalog/view/theme/default/template/account/register.tpl
+++ b/upload/catalog/view/theme/default/template/account/register.tpl
@@ -672,8 +672,9 @@ $('select[name=\'country_id\']').on('change', function() {
 			}
 
 			html = '<option value=""><?php echo $text_select; ?></option>';
-
-			if (json['zone'] && json['zone'] != '') {
+			
+			if (json['zone'] && json['zone'] != '' && json['use_zones'] == '1') {
+				$('select[name=\'zone_id\']').parent().parent().show();
 				for (i = 0; i < json['zone'].length; i++) {
 					html += '<option value="' + json['zone'][i]['zone_id'] + '"';
 
@@ -685,6 +686,8 @@ $('select[name=\'country_id\']').on('change', function() {
 				}
 			} else {
 				html += '<option value="0" selected="selected"><?php echo $text_none; ?></option>';
+				$('select[name=\'zone_id\']').parent().parent().hide();
+				console.log(json['zone']);
 			}
 
 			$('select[name=\'zone_id\']').html(html);

--- a/upload/catalog/view/theme/default/template/checkout/guest.tpl
+++ b/upload/catalog/view/theme/default/template/checkout/guest.tpl
@@ -465,7 +465,8 @@ $('#collapse-payment-address select[name=\'country_id\']').on('change', function
 
 			html = '<option value=""><?php echo $text_select; ?></option>';
 
-			if (json['zone'] && json['zone'] != '') {
+			if (json['zone'] && json['zone'] != '' && json['use_zones'] == '1') {
+				$('#collapse-shipping-address select[name=\'zone_id\']').parent().show();
 				for (i = 0; i < json['zone'].length; i++) {
 					html += '<option value="' + json['zone'][i]['zone_id'] + '"';
 
@@ -477,6 +478,7 @@ $('#collapse-payment-address select[name=\'country_id\']').on('change', function
 				}
 			} else {
 				html += '<option value="0" selected="selected"><?php echo $text_none; ?></option>';
+				$('#collapse-shipping-address select[name=\'zone_id\']').parent().hide();
 			}
 
 			$('#collapse-payment-address select[name=\'zone_id\']').html(html);

--- a/upload/catalog/view/theme/default/template/checkout/guest_shipping.tpl
+++ b/upload/catalog/view/theme/default/template/checkout/guest_shipping.tpl
@@ -298,7 +298,8 @@ $('#collapse-shipping-address select[name=\'country_id\']').on('change', functio
 
 			html = '<option value=""><?php echo $text_select; ?></option>';
 
-			if (json['zone'] && json['zone'] != '') {
+			if (json['zone'] && json['zone'] != '' && json['use_zones'] == '1') {
+				$('#collapse-shipping-address select[name=\'zone_id\']').parent().parent().show();
 				for (i = 0; i < json['zone'].length; i++) {
 					html += '<option value="' + json['zone'][i]['zone_id'] + '"';
 
@@ -310,6 +311,7 @@ $('#collapse-shipping-address select[name=\'country_id\']').on('change', functio
 				}
 			} else {
 				html += '<option value="0" selected="selected"><?php echo $text_none; ?></option>';
+				$('#collapse-shipping-address select[name=\'zone_id\']').parent().parent().hide();
 			}
 
 			$('#collapse-shipping-address select[name=\'zone_id\']').html(html);

--- a/upload/catalog/view/theme/default/template/checkout/payment_address.tpl
+++ b/upload/catalog/view/theme/default/template/checkout/payment_address.tpl
@@ -320,7 +320,7 @@ $('#collapse-payment-address select[name=\'country_id\']').on('change', function
 			html = '<option value=""><?php echo $text_select; ?></option>';
 
 			if (json['zone'] && json['zone'] != '' && json['use_zones'] == '1') {
-				$('select[name=\'zone_id\']').parent().parent().show();
+				$('#collapse-payment-address select[name=\'zone_id\']').parent().parent().show();
 				for (i = 0; i < json['zone'].length; i++) {
 					html += '<option value="' + json['zone'][i]['zone_id'] + '"';
 
@@ -332,7 +332,7 @@ $('#collapse-payment-address select[name=\'country_id\']').on('change', function
 				}
 			} else {
 				html += '<option value="0" selected="selected"><?php echo $text_none; ?></option>';
-				$('select[name=\'zone_id\']').parent().parent().hide();
+				$('#collapse-payment-address select[name=\'zone_id\']').parent().parent().hide();
 			}
 
 			$('#collapse-payment-address select[name=\'zone_id\']').html(html);

--- a/upload/catalog/view/theme/default/template/checkout/payment_address.tpl
+++ b/upload/catalog/view/theme/default/template/checkout/payment_address.tpl
@@ -319,7 +319,8 @@ $('#collapse-payment-address select[name=\'country_id\']').on('change', function
 
 			html = '<option value=""><?php echo $text_select; ?></option>';
 
-			if (json['zone'] && json['zone'] != '') {
+			if (json['zone'] && json['zone'] != '' && json['use_zones'] == '1') {
+				$('select[name=\'zone_id\']').parent().parent().show();
 				for (i = 0; i < json['zone'].length; i++) {
 					html += '<option value="' + json['zone'][i]['zone_id'] + '"';
 
@@ -331,6 +332,7 @@ $('#collapse-payment-address select[name=\'country_id\']').on('change', function
 				}
 			} else {
 				html += '<option value="0" selected="selected"><?php echo $text_none; ?></option>';
+				$('select[name=\'zone_id\']').parent().parent().hide();
 			}
 
 			$('#collapse-payment-address select[name=\'zone_id\']').html(html);

--- a/upload/catalog/view/theme/default/template/checkout/register.tpl
+++ b/upload/catalog/view/theme/default/template/checkout/register.tpl
@@ -452,7 +452,8 @@ $('#collapse-payment-address select[name=\'country_id\']').on('change', function
 
 			html = '<option value=""><?php echo $text_select; ?></option>';
 
-			if (json['zone'] && json['zone'] != '') {
+			if (json['zone'] && json['zone'] != '' && json['use_zones'] == '1') {
+				$('select[name=\'zone_id\']').parent().show();
 				for (i = 0; i < json['zone'].length; i++) {
 					html += '<option value="' + json['zone'][i]['zone_id'] + '"';
 
@@ -464,6 +465,7 @@ $('#collapse-payment-address select[name=\'country_id\']').on('change', function
 				}
 			} else {
 				html += '<option value="0" selected="selected"><?php echo $text_none; ?></option>';
+				$('select[name=\'zone_id\']').parent().hide();
 			}
 
 			$('#collapse-payment-address select[name=\'zone_id\']').html(html);

--- a/upload/catalog/view/theme/default/template/checkout/register.tpl
+++ b/upload/catalog/view/theme/default/template/checkout/register.tpl
@@ -453,7 +453,7 @@ $('#collapse-payment-address select[name=\'country_id\']').on('change', function
 			html = '<option value=""><?php echo $text_select; ?></option>';
 
 			if (json['zone'] && json['zone'] != '' && json['use_zones'] == '1') {
-				$('select[name=\'zone_id\']').parent().show();
+				$('#collapse-payment-address select[name=\'zone_id\']').parent().show();
 				for (i = 0; i < json['zone'].length; i++) {
 					html += '<option value="' + json['zone'][i]['zone_id'] + '"';
 
@@ -465,7 +465,7 @@ $('#collapse-payment-address select[name=\'country_id\']').on('change', function
 				}
 			} else {
 				html += '<option value="0" selected="selected"><?php echo $text_none; ?></option>';
-				$('select[name=\'zone_id\']').parent().hide();
+				$('#collapse-payment-address select[name=\'zone_id\']').parent().hide();
 			}
 
 			$('#collapse-payment-address select[name=\'zone_id\']').html(html);

--- a/upload/catalog/view/theme/default/template/checkout/shipping_address.tpl
+++ b/upload/catalog/view/theme/default/template/checkout/shipping_address.tpl
@@ -318,7 +318,8 @@ $('#collapse-shipping-address select[name=\'country_id\']').on('change', functio
 
 			html = '<option value=""><?php echo $text_select; ?></option>';
 
-			if (json['zone'] && json['zone'] != '') {
+			if (json['zone'] && json['zone'] != '' && json['use_zones'] == '1') {
+				$('select[name=\'zone_id\']').parent().parent().show();
 				for (i = 0; i < json['zone'].length; i++) {
 					html += '<option value="' + json['zone'][i]['zone_id'] + '"';
 
@@ -330,6 +331,7 @@ $('#collapse-shipping-address select[name=\'country_id\']').on('change', functio
 				}
 			} else {
 				html += '<option value="0" selected="selected"><?php echo $text_none; ?></option>';
+				$('select[name=\'zone_id\']').parent().parent().hide();
 			}
 
 			$('#collapse-shipping-address select[name=\'zone_id\']').html(html);

--- a/upload/catalog/view/theme/default/template/checkout/shipping_address.tpl
+++ b/upload/catalog/view/theme/default/template/checkout/shipping_address.tpl
@@ -319,7 +319,7 @@ $('#collapse-shipping-address select[name=\'country_id\']').on('change', functio
 			html = '<option value=""><?php echo $text_select; ?></option>';
 
 			if (json['zone'] && json['zone'] != '' && json['use_zones'] == '1') {
-				$('select[name=\'zone_id\']').parent().parent().show();
+				$('#collapse-shipping-address select[name=\'zone_id\']').parent().parent().show();
 				for (i = 0; i < json['zone'].length; i++) {
 					html += '<option value="' + json['zone'][i]['zone_id'] + '"';
 
@@ -331,7 +331,7 @@ $('#collapse-shipping-address select[name=\'country_id\']').on('change', functio
 				}
 			} else {
 				html += '<option value="0" selected="selected"><?php echo $text_none; ?></option>';
-				$('select[name=\'zone_id\']').parent().parent().hide();
+				$('#collapse-shipping-address select[name=\'zone_id\']').parent().parent().hide();
 			}
 
 			$('#collapse-shipping-address select[name=\'zone_id\']').html(html);

--- a/upload/install/opencart.sql
+++ b/upload/install/opencart.sql
@@ -641,6 +641,7 @@ CREATE TABLE IF NOT EXISTS `oc_country` (
   `iso_code_3` varchar(3) NOT NULL,
   `address_format` text NOT NULL,
   `postcode_required` tinyint(1) NOT NULL,
+  `use_zones` tinyint(1) NOT NULL DEFAULT '1',
   `status` tinyint(1) NOT NULL DEFAULT '1',
   PRIMARY KEY (`country_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;


### PR DESCRIPTION
This feature hides "Zone" -selection input from the forms in the following places:
   - My Account -> Address book -> Add or edit address
   - Checkout -> Register OR Guest checkout (for both payment and delivery address)
   - Register

When either one of these are met:
   - When in Admin area System-> Localisation -> Countries -> insert_country_name -> "Show/use zones" is set to false (new feature as well)
   - When country has no zones

Adds a new column to country -table, opencart.sql changed accordingly.

I created this feature is since at least in Finland we don't really use the Zones (lääni) for anything (same goes to at least Sweden that I know of), the basic address is composed of Post code + City (or postal area) + street address, so asking for Zone is kind of stupid here, and gives a little unprofessional image of the seller here in Finland. 

More about the subject I found from the forums:
http://forum.opencart.com/viewtopic.php?f=20&t=25808

This is my first pull request ever, so please let me know if there is something more I need to do, or some commits weren't on point. I did my best testing the features, but I didn't ran the automated tests that were provided.

ps. By the way I was rather pleasantly surprised about the high quality of the code/structure, keep up the good work :)