### PR TITLE
Fixed Early Reset Button Glitch

### DIFF
--- a/upload/catalog/view/theme/default/template/checkout/checkout.tpl
+++ b/upload/catalog/view/theme/default/template/checkout/checkout.tpl
@@ -428,6 +428,7 @@ $(document).delegate('#button-payment-address', 'click', function() {
 
 // Shipping Address
 $(document).delegate('#button-shipping-address', 'click', function() {
+	var wait_more = 0;
     $.ajax({
         url: 'index.php?route=checkout/shipping_address/save',
         type: 'post',
@@ -437,7 +438,9 @@ $(document).delegate('#button-shipping-address', 'click', function() {
 			$('#button-shipping-address').button('loading');
 	    },
         complete: function() {
-			$('#button-shipping-address').button('reset');
+			if (wait_more == 0){
+				$('#button-shipping-address').button('reset');
+				}
         },
         success: function(json) {
             $('.alert, .text-danger').remove();
@@ -462,9 +465,16 @@ $(document).delegate('#button-shipping-address', 'click', function() {
 				// Highlight any found errors
 				$('.text-danger').parent().parent().addClass('has-error');
             } else {
+				wait_more = 1;
                 $.ajax({
                     url: 'index.php?route=checkout/shipping_method',
                     dataType: 'html',
+					beforeSend: function() {
+						$('#button-shipping-address').button('loading');
+					},
+					complete: function() {
+						$('#button-shipping-address').button('reset');
+					},
                     success: function(html) {
                         $('#collapse-shipping-method .panel-body').html(html);
 
@@ -511,6 +521,7 @@ $(document).delegate('#button-shipping-address', 'click', function() {
 
 // Guest
 $(document).delegate('#button-guest', 'click', function() {
+	var wait_more = 0;
     $.ajax({
         url: 'index.php?route=checkout/guest/save',
         type: 'post',
@@ -520,7 +531,9 @@ $(document).delegate('#button-guest', 'click', function() {
        		$('#button-guest').button('loading');
 	    },
         complete: function() {
-			$('#button-guest').button('reset');
+			if (wait_more == 0){
+				$('#button-guest').button('reset');
+			}
         },
         success: function(json) {
             $('.alert, .text-danger').remove();
@@ -549,9 +562,16 @@ $(document).delegate('#button-guest', 'click', function() {
                 var shipping_address = $('#collapse-payment-address input[name=\'shipping_address\']:checked').prop('value');
 
                 if (shipping_address) {
+					wait_more = 1;
                     $.ajax({
                         url: 'index.php?route=checkout/shipping_method',
                         dataType: 'html',
+						beforeSend: function() {
+							$('#button-guest').button('loading');
+						},
+						complete: function() {
+							$('#button-guest').button('reset');
+						},
                         success: function(html) {
 							// Add the shipping address
                             $.ajax({
@@ -628,6 +648,7 @@ $(document).delegate('#button-guest', 'click', function() {
 
 // Guest Shipping
 $(document).delegate('#button-guest-shipping', 'click', function() {
+	var wait_more = 0;
     $.ajax({
         url: 'index.php?route=checkout/guest_shipping/save',
         type: 'post',
@@ -637,7 +658,9 @@ $(document).delegate('#button-guest-shipping', 'click', function() {
         	$('#button-guest-shipping').button('loading');
 		},
         complete: function() {
-			$('#button-guest-shipping').button('reset');
+			if (wait_more == 0){
+				$('#button-guest-shipping').button('reset');
+			}
         },
         success: function(json) {
             $('.alert, .text-danger').remove();
@@ -662,9 +685,16 @@ $(document).delegate('#button-guest-shipping', 'click', function() {
 				// Highlight any found errors
 				$('.text-danger').parent().addClass('has-error');
             } else {
+				wait_more = 1;
                 $.ajax({
                     url: 'index.php?route=checkout/shipping_method',
                     dataType: 'html',
+					beforeSend: function() {
+						$('#button-guest-shipping').button('loading');
+					},
+					complete: function() {
+						$('#button-guest-shipping').button('reset');
+					},
                     success: function(html) {
                         $('#collapse-shipping-method .panel-body').html(html);
 


### PR DESCRIPTION
On checkout process, when you go from step 2 to step 4 (or step 3 to step 4) and you get the shipping module information, the main ajax complete() function execute before the success() function in the child ajax call, thus, when you press the "next" button on checkout page, you will see a "Loading" message as expected, but the button will go to the reset state ("Next" text) before all the shipping method data appear. Most of the time this is not a problem if you are dealing with fixed data for shipping (instant data), but if your shipping module call a website in order to get real onlines prices, this may take almost 5 seconds, so the user will experiment a 5 seconds delay between the moment in which the button goes to reset state ("next" text) and the update of the shipping data. (Most of the time, the user may think that the "Next" button doesn't work and hence  press it again)
The proposed change adds an extra wait, that rely on the child ajax call in order to update the button to the reset state, so the user now will see the "Loading" state of the button all the time until shipping data is displayed. If any error occur, the system will work as usual.
This is a small fix, but it is big from the user experience point of view.