### PR TITLE
Update coupon.php

### DIFF
--- a/upload/catalog/controller/checkout/coupon.php
+++ b/upload/catalog/controller/checkout/coupon.php
@@ -49,6 +49,7 @@ class ControllerCheckoutCoupon extends Controller {
 
 		if (empty($this->request->post['coupon'])) {
 			$json['error'] = $this->language->get('error_empty');
+			unset($this->session->data['coupon']);
 		} elseif ($coupon_info) {
 			$this->session->data['coupon'] = $this->request->post['coupon'];
 


### PR DESCRIPTION
Unset current coupon code if customer enters blank coupon code into field.  This allows the customer the ability to remove the coupon code from their cart.

If this is accepted, perhaps the text next to the coupon code field should be changed to mention leaving the field blank to clear a coupon from the cart.