### PR TITLE
Extension of config, request and session

### DIFF
--- a/upload/admin/controller/catalog/attribute.php
+++ b/upload/admin/controller/catalog/attribute.php
@@ -111,36 +111,23 @@ class ControllerCatalogAttribute extends Controller {
 	}
 
 	protected function getList() {
-		if (isset($this->request->get['sort'])) {
-			$sort = $this->request->get['sort'];
-		} else {
-			$sort = 'ad.name';
-		}
 
-		if (isset($this->request->get['order'])) {
-			$order = $this->request->get['order'];
-		} else {
-			$order = 'ASC';
-		}
-
-		if (isset($this->request->get['page'])) {
-			$page = $this->request->get['page'];
-		} else {
-			$page = 1;
-		}
+		$sort = $this->request->get->get('sort', 'ad.name');
+		$order = $this->request->get->get('order', 'ASC');
+		$page = $this->request->get->get('page', 1);
 
 		$url = '';
 
 		if (isset($this->request->get['sort'])) {
-			$url .= '&sort=' . $this->request->get['sort'];
+			$url .= '&sort=' . $sort;
 		}
 
 		if (isset($this->request->get['order'])) {
-			$url .= '&order=' . $this->request->get['order'];
+			$url .= '&order=' . $order;
 		}
 
 		if (isset($this->request->get['page'])) {
-			$url .= '&page=' . $this->request->get['page'];
+			$url .= '&page=' . $page;
 		}
 
 		$data['breadcrumbs'] = array();
@@ -202,13 +189,7 @@ class ControllerCatalogAttribute extends Controller {
 			$data['error_warning'] = '';
 		}
 
-		if (isset($this->session->data['success'])) {
-			$data['success'] = $this->session->data['success'];
-
-			unset($this->session->data['success']);
-		} else {
-			$data['success'] = '';
-		}
+		$data['success'] = $this->session->pull('success', '');
 
 		if (isset($this->request->post['selected'])) {
 			$data['selected'] = (array)$this->request->post['selected'];
@@ -225,7 +206,7 @@ class ControllerCatalogAttribute extends Controller {
 		}
 
 		if (isset($this->request->get['page'])) {
-			$url .= '&page=' . $this->request->get['page'];
+			$url .= '&page=' . $page;
 		}
 
 		$data['sort_name'] = $this->url->link('catalog/attribute', 'token=' . $this->session->data['token'] . '&sort=ad.name' . $url, 'SSL');
@@ -235,11 +216,11 @@ class ControllerCatalogAttribute extends Controller {
 		$url = '';
 
 		if (isset($this->request->get['sort'])) {
-			$url .= '&sort=' . $this->request->get['sort'];
+			$url .= '&sort=' . $sort;
 		}
 
 		if (isset($this->request->get['order'])) {
-			$url .= '&order=' . $this->request->get['order'];
+			$url .= '&order=' . $order;
 		}
 
 		$pagination = new Pagination();
@@ -398,11 +379,11 @@ class ControllerCatalogAttribute extends Controller {
 	public function autocomplete() {
 		$json = array();
 
-		if (isset($this->request->get['filter_name'])) {
+		if ($filter_name = $this->request->get->get('filter_name')) {
 			$this->load->model('catalog/attribute');
 
 			$filter_data = array(
-				'filter_name' => $this->request->get['filter_name'],
+				'filter_name' => $filter_name,
 				'start'       => 0,
 				'limit'       => 5
 			);

--- a/upload/system/library/bag.php
+++ b/upload/system/library/bag.php
@@ -1,0 +1,40 @@
+<?php
+class Bag implements ArrayAccess {
+	protected $data;
+
+	public function __construct($data = array()) {
+		$this->data = $data;
+	}
+
+	public function get($key, $default = null) {
+		return (isset($this->data[$key]) ? $this->data[$key] : $default);
+	}
+
+	public function set($key, $value) {
+		$this->data[$key] = $value;
+	}
+
+	public function has($key) {
+		return isset($this->data[$key]);
+	}
+
+	public function delete($key) {
+		unset($this->data[$key]);
+	}
+
+	public function offsetGet($key) {
+		return $this->get($key);
+	}
+
+	public function offsetSet($key, $value) {
+		$this->set($key, $value);
+	}
+
+	public function offsetExists($key) {
+		return $this->has($key);
+	}
+
+	public function offsetUnset($key) {
+		$this->delete($key);
+	}
+}

--- a/upload/system/library/config.php
+++ b/upload/system/library/config.php
@@ -1,18 +1,5 @@
 <?php
-class Config {
-	private $data = array();
-
-	public function get($key) {
-		return (isset($this->data[$key]) ? $this->data[$key] : null);
-	}
-
-	public function set($key, $value) {
-		$this->data[$key] = $value;
-	}
-
-	public function has($key) {
-		return isset($this->data[$key]);
-	}
+class Config extends Bag {
 
 	public function load($filename) {
 		$file = DIR_CONFIG . $filename . '.php';

--- a/upload/system/library/request.php
+++ b/upload/system/library/request.php
@@ -7,12 +7,12 @@ class Request {
 	public $server = array();
 
 	public function __construct() {
-		$this->get = $this->clean($_GET);
-		$this->post = $this->clean($_POST);
-		$this->request = $this->clean($_REQUEST);
-		$this->cookie = $this->clean($_COOKIE);
-		$this->files = $this->clean($_FILES);
-		$this->server = $this->clean($_SERVER);
+		$this->get = new Bag($this->clean($_GET));
+		$this->post = new Bag($this->clean($_POST));
+		$this->request = new Bag($this->clean($_REQUEST));
+		$this->cookie = new Bag($this->clean($_COOKIE));
+		$this->files = new Bag($this->clean($_FILES));
+		$this->server = new Bag($this->clean($_SERVER));
 	}
 
 	public function clean($data) {

--- a/upload/system/library/session.php
+++ b/upload/system/library/session.php
@@ -1,5 +1,5 @@
 <?php
-class Session {
+class Session extends Bag {
 	public $data = array();
 
 	public function __construct() {
@@ -21,5 +21,15 @@ class Session {
 
 	public function destroy() {
 		return session_destroy();
+	}
+
+	public function pull($key, $default = null) {
+		if (isset($this->data[$key]))
+		{
+			$value = $this->data[$key];
+			unset($this->data[$key]);
+			return $value;
+		}
+		return $default;
 	}
 }


### PR DESCRIPTION
1. Implement a Bag class which provides useful methods for internal data handling.
2. Extend Config from Bag to avoid duplicate code
3. Use Bag as storage in Request so data can be pulled with default values to avoid lots of conditions in code (example of use in `admin/controller/catalog/attribute.php`)
4. Extend Session from Bag (with backward compatibility)
5. Add `pull` method to session to get data and unset it in one call