### PR TITLE
Full path disclosure due to Undefined index

### DIFF
--- a/upload/admin/controller/common/login.php
+++ b/upload/admin/controller/common/login.php
@@ -101,19 +101,7 @@ class ControllerCommonLogin extends Controller {
 	}
 
 	public function check() {
-		$route = '';
-
-		if (isset($this->request->get['route'])) {
-			$part = explode('/', $this->request->get['route']);
-
-			if (isset($part[0])) {
-				$route .= $part[0];
-			}
-
-			if (isset($part[1])) {
-				$route .= '/' . $part[1];
-			}
-		}
+		$route = isset($this->request->get['route']) ? $this->request->get['route'] : '';
 
 		$ignore = array(
 			'common/login',

--- a/upload/admin/controller/error/not_found.php
+++ b/upload/admin/controller/error/not_found.php
@@ -13,12 +13,12 @@ class ControllerErrorNotFound extends Controller {
 
 		$data['breadcrumbs'][] = array(
 			'text' => $this->language->get('text_home'),
-			'href' => $this->url->link('common/dashboard', array_key_exists('token', $this->session->data) ? 'token=' . $this->session->data['token'] : '', 'SSL')
+			'href' => $this->url->link('common/dashboard', 'token=' . $this->session->data['token'], 'SSL')
 		);
 
 		$data['breadcrumbs'][] = array(
 			'text' => $this->language->get('heading_title'),
-			'href' => $this->url->link('error/not_found', array_key_exists('token', $this->session->data) ? 'token=' . $this->session->data['token'] : '', 'SSL')
+			'href' => $this->url->link('error/not_found', 'token=' . $this->session->data['token'], 'SSL')
 		);
 
 		$data['header'] = $this->load->controller('common/header');

--- a/upload/admin/controller/error/not_found.php
+++ b/upload/admin/controller/error/not_found.php
@@ -13,12 +13,12 @@ class ControllerErrorNotFound extends Controller {
 
 		$data['breadcrumbs'][] = array(
 			'text' => $this->language->get('text_home'),
-			'href' => $this->url->link('common/dashboard', 'token=' . $this->session->data['token'], 'SSL')
+			'href' => $this->url->link('common/dashboard', array_key_exists('token', $this->session->data) ? 'token=' . $this->session->data['token'] : '', 'SSL')
 		);
 
 		$data['breadcrumbs'][] = array(
 			'text' => $this->language->get('heading_title'),
-			'href' => $this->url->link('error/not_found', 'token=' . $this->session->data['token'], 'SSL')
+			'href' => $this->url->link('error/not_found', array_key_exists('token', $this->session->data) ? 'token=' . $this->session->data['token'] : '', 'SSL')
 		);
 
 		$data['header'] = $this->load->controller('common/header');


### PR DESCRIPTION
In admin panel, if you are not logged in, and generate a `404 Not Found` error with something like `<youdomain>/admin/index.php?route=common/login/XXX` an `Undefined index` warning will appears leading to `Full Path Disclosure` issue.