### PR TITLE
Bug fix: if $mail->reply_to is set, use that (instead of $mail->from) in the email headers 

### DIFF
--- a/upload/system/library/mail.php
+++ b/upload/system/library/mail.php
@@ -103,7 +103,7 @@ class Mail {
 		if (!$this->reply_to) {
 			$header .= 'Reply-To: =?UTF-8?B?' . base64_encode($this->sender) . '?=' . ' <' . $this->from . '>' . $this->newline;
 		} else {
-			$header .= 'Reply-To: =?UTF-8?B?' . base64_encode($this->reply_to) . '?=' . ' <' . $this->from . '>' . $this->newline;
+			$header .= 'Reply-To: =?UTF-8?B?' . base64_encode($this->reply_to) . '?=' . ' <' . $this->reply_to . '>' . $this->newline;
 		}
 		
 		$header .= 'Return-Path: ' . $this->from . $this->newline;


### PR DESCRIPTION
If someone would ever use
```php
    $mail = new Mail();
    $mail->setReplyTo($reply_to);
    ...
    $mail->send();
```
Make sure the reply-to email address that is being set in ```$mail->setReplyTo($reply_to);``` is being used, instead of the ```$mail->from```, when creating the email headers here:
```php
$header .= 'Reply-To: =?UTF-8?B?' . base64_encode($this->reply_to) . '?=' . 
           ' <' . $this->reply_to . '>' . $this->newline;
```
Bug was introduced here https://github.com/opencart/opencart/commit/7851910af42eaaee84492ca62d2bbce34434418e

Note: although setReplyTo() is not used anywhere yet, it's very useful when sending an email on somebody else's behalf. So if one would every use it, this bug is fixed here.