### PR TITLE
DRY: less isset(this-request->get['foo'])

### DIFF
--- a/upload/catalog/controller/information/information.php
+++ b/upload/catalog/controller/information/information.php
@@ -12,12 +12,7 @@ class ControllerInformationInformation extends Controller {
 			'href' => $this->url->link('common/home')
 		);
 
-		if (isset($this->request->get['information_id'])) {
-			$information_id = (int)$this->request->get['information_id'];
-		} else {
-			$information_id = 0;
-		}
-
+		$information_id = (int)$this->request->get('information_id', 0);		
 		$information_info = $this->model_catalog_information->getInformation($information_id);
 
 		if ($information_info) {

--- a/upload/catalog/controller/product/category.php
+++ b/upload/catalog/controller/product/category.php
@@ -9,35 +9,11 @@ class ControllerProductCategory extends Controller {
 
 		$this->load->model('tool/image');
 
-		if (isset($this->request->get['filter'])) {
-			$filter = $this->request->get['filter'];
-		} else {
-			$filter = '';
-		}
-
-		if (isset($this->request->get['sort'])) {
-			$sort = $this->request->get['sort'];
-		} else {
-			$sort = 'p.sort_order';
-		}
-
-		if (isset($this->request->get['order'])) {
-			$order = $this->request->get['order'];
-		} else {
-			$order = 'ASC';
-		}
-
-		if (isset($this->request->get['page'])) {
-			$page = $this->request->get['page'];
-		} else {
-			$page = 1;
-		}
-
-		if (isset($this->request->get['limit'])) {
-			$limit = $this->request->get['limit'];
-		} else {
-			$limit = $this->config->get('config_product_limit');
-		}
+		$filter = $this->request->get('filter', '');
+		$sort = $this->request->get('sort', 'p.sort_order');
+		$order = $this->request->get('order', 'ASC');
+		$page = $this->request->get('page', 1);
+		$limit = $this->request->get('limit', $this->config->get('config_product_limit'));
 
 		$data['breadcrumbs'] = array();
 

--- a/upload/system/library/request.php
+++ b/upload/system/library/request.php
@@ -28,4 +28,8 @@ class Request {
 
 		return $data;
 	}
+        
+	public function get($key, $default = null) {
+		return (isset($this->get[$key]) ? $this->get[$key] : $default);
+	}        
 }


### PR DESCRIPTION
Because this is used VERY often in the codebase:
```php
if (isset(this-request->get['foo'])) {
	$bar = $this-request->get['foo'];
} else {
	$bar = 'baz';
}	
```
...why not use:
```php
$bar = $this->request->get('foo', 'baz');
```

It does exactly the same, but with these extra [3 lines of code](https://github.com/steefdw/opencart/commit/bb985e6e4c88ea770a7f8ad24f5d97e6fbe5b13b), we could have more [readable code](https://github.com/steefdw/opencart/commit/cd95152334ee4a9c89bd1ca49ffcef90d0d65478) AND remove +1000 lines of code.

This proposal does not replace functionality, but adds to it:
* ```isset($this->request->get['foo']``` can still be used for stuff like:
```php
	if (isset($this->request->get['foo'])) {
		$url .= '&foo=' . $this->request->get['foo'];
	}
```	
* but ```$this->request->get('foo', 'baz')``` is more readable (and preferred IMHO) than:
```php
	if (isset(this-request->get['foo'])) {
		$bar = $this-request->get['foo'];
	} else {
		$bar = 'baz';
	}	
```	