### PR TITLE
 DRY: don't do file_exists() for every template file

### DIFF
--- a/upload/catalog/controller/checkout/cart.php
+++ b/upload/catalog/controller/checkout/cart.php
@@ -245,11 +245,7 @@ class ControllerCheckoutCart extends Controller {
 			$data['footer'] = $this->load->controller('common/footer');
 			$data['header'] = $this->load->controller('common/header');
 
-			if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/checkout/cart.tpl')) {
-				$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/checkout/cart.tpl', $data));
-			} else {
-				$this->response->setOutput($this->load->view('default/template/checkout/cart.tpl', $data));
-			}
+			$this->response->render('checkout/cart', $data);
 		} else {
 			$data['heading_title'] = $this->language->get('heading_title');
 
@@ -268,11 +264,7 @@ class ControllerCheckoutCart extends Controller {
 			$data['footer'] = $this->load->controller('common/footer');
 			$data['header'] = $this->load->controller('common/header');
 
-			if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/error/not_found.tpl')) {
-				$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/error/not_found.tpl', $data));
-			} else {
-				$this->response->setOutput($this->load->view('default/template/error/not_found.tpl', $data));
-			}
+			$this->response->render('error/not_found', $data);
 		}
 	}
 

--- a/upload/catalog/controller/checkout/checkout.php
+++ b/upload/catalog/controller/checkout/checkout.php
@@ -87,11 +87,7 @@ class ControllerCheckoutCheckout extends Controller {
 		$data['footer'] = $this->load->controller('common/footer');
 		$data['header'] = $this->load->controller('common/header');
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/checkout/checkout.tpl')) {
-			$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/checkout/checkout.tpl', $data));
-		} else {
-			$this->response->setOutput($this->load->view('default/template/checkout/checkout.tpl', $data));
-		}
+		$this->response->render('checkout/checkout', $data);
 	}
 
 	public function country() {

--- a/upload/catalog/controller/checkout/confirm.php
+++ b/upload/catalog/controller/checkout/confirm.php
@@ -411,10 +411,6 @@ class ControllerCheckoutConfirm extends Controller {
 			$data['redirect'] = $redirect;
 		}
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/checkout/confirm.tpl')) {
-			$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/checkout/confirm.tpl', $data));
-		} else {
-			$this->response->setOutput($this->load->view('default/template/checkout/confirm.tpl', $data));
-		}
+		$this->response->render('checkout/confirm', $data);
 	}
 }

--- a/upload/catalog/controller/checkout/coupon.php
+++ b/upload/catalog/controller/checkout/coupon.php
@@ -24,11 +24,7 @@ class ControllerCheckoutCoupon extends Controller {
 				$data['redirect'] = $this->url->link('checkout/cart');
 			}
 
-			if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/checkout/coupon.tpl')) {
-				return $this->load->view($this->config->get('config_template') . '/template/checkout/coupon.tpl', $data);
-			} else {
-				return $this->load->view('default/template/checkout/coupon.tpl', $data);
-			}
+			return $this->response->compile('checkout/coupon', $data);
 		}
 	}
 

--- a/upload/catalog/controller/checkout/failure.php
+++ b/upload/catalog/controller/checkout/failure.php
@@ -42,10 +42,6 @@ class ControllerCheckoutFailure extends Controller {
 		$data['footer'] = $this->load->controller('common/footer');
 		$data['header'] = $this->load->controller('common/header');
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/common/success.tpl')) {
-			$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/common/success.tpl', $data));
-		} else {
-			$this->response->setOutput($this->load->view('default/template/common/success.tpl', $data));
-		}
+		$this->response->render('common/success', $data);
 	}
 }

--- a/upload/catalog/controller/checkout/guest.php
+++ b/upload/catalog/controller/checkout/guest.php
@@ -161,11 +161,7 @@ class ControllerCheckoutGuest extends Controller {
 			$data['shipping_address'] = true;
 		}
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/checkout/guest.tpl')) {
-			$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/checkout/guest.tpl', $data));
-		} else {
-			$this->response->setOutput($this->load->view('default/template/checkout/guest.tpl', $data));
-		}
+		$this->response->render('checkout/guest', $data);
 	}
 
 	public function save() {

--- a/upload/catalog/controller/checkout/guest_shipping.php
+++ b/upload/catalog/controller/checkout/guest_shipping.php
@@ -89,11 +89,7 @@ class ControllerCheckoutGuestShipping extends Controller {
 			$data['address_custom_field'] = array();
 		}
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/checkout/guest_shipping.tpl')) {
-			$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/checkout/guest_shipping.tpl', $data));
-		} else {
-			$this->response->setOutput($this->load->view('default/template/checkout/guest_shipping.tpl', $data));
-		}
+		$this->response->render('checkout/guest_shipping', $data);
 	}
 
 	public function save() {

--- a/upload/catalog/controller/checkout/login.php
+++ b/upload/catalog/controller/checkout/login.php
@@ -31,11 +31,7 @@ class ControllerCheckoutLogin extends Controller {
 
 		$data['forgotten'] = $this->url->link('account/forgotten', '', 'SSL');
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/checkout/login.tpl')) {
-			$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/checkout/login.tpl', $data));
-		} else {
-			$this->response->setOutput($this->load->view('default/template/checkout/login.tpl', $data));
-		}
+		$this->response->render('checkout/login', $data);
 	}
 
 	public function save() {

--- a/upload/catalog/controller/checkout/payment_address.php
+++ b/upload/catalog/controller/checkout/payment_address.php
@@ -59,11 +59,7 @@ class ControllerCheckoutPaymentAddress extends Controller {
 			$data['payment_address_custom_field'] = array();
 		}
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/checkout/payment_address.tpl')) {
-			$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/checkout/payment_address.tpl', $data));
-		} else {
-			$this->response->setOutput($this->load->view('default/template/checkout/payment_address.tpl', $data));
-		}
+		$this->response->render('checkout/payment_address', $data);
 	}
 
 	public function save() {

--- a/upload/catalog/controller/checkout/payment_method.php
+++ b/upload/catalog/controller/checkout/payment_method.php
@@ -119,11 +119,7 @@ class ControllerCheckoutPaymentMethod extends Controller {
 			$data['agree'] = '';
 		}
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/checkout/payment_method.tpl')) {
-			$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/checkout/payment_method.tpl', $data));
-		} else {
-			$this->response->setOutput($this->load->view('default/template/checkout/payment_method.tpl', $data));
-		}
+		$this->response->render('checkout/payment_method', $data);
 	}
 
 	public function save() {

--- a/upload/catalog/controller/checkout/register.php
+++ b/upload/catalog/controller/checkout/register.php
@@ -91,11 +91,7 @@ class ControllerCheckoutRegister extends Controller {
 
 		$data['shipping_required'] = $this->cart->hasShipping();
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/checkout/register.tpl')) {
-			$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/checkout/register.tpl', $data));
-		} else {
-			$this->response->setOutput($this->load->view('default/template/checkout/register.tpl', $data));
-		}
+		$this->response->render('checkout/register', $data);
 	}
 
 	public function save() {

--- a/upload/catalog/controller/checkout/reward.php
+++ b/upload/catalog/controller/checkout/reward.php
@@ -28,11 +28,7 @@ class ControllerCheckoutReward extends Controller {
 				$data['reward'] = '';
 			}
 
-			if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/checkout/reward.tpl')) {
-				return $this->load->view($this->config->get('config_template') . '/template/checkout/reward.tpl', $data);
-			} else {
-				return $this->load->view('default/template/checkout/reward.tpl', $data);
-			}
+			return $this->response->compile('checkout/reward', $data);
 		}
 	}
 

--- a/upload/catalog/controller/checkout/shipping.php
+++ b/upload/catalog/controller/checkout/shipping.php
@@ -48,11 +48,7 @@ class ControllerCheckoutShipping extends Controller {
 				$data['shipping_method'] = '';
 			}
 
-			if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/checkout/shipping.tpl')) {
-				return $this->load->view($this->config->get('config_template') . '/template/checkout/shipping.tpl', $data);
-			} else {
-				return $this->load->view('default/template/checkout/shipping.tpl', $data);
-			}
+			return $this->response->compile('checkout/shipping', $data);
 		}
 	}
 

--- a/upload/catalog/controller/checkout/shipping_address.php
+++ b/upload/catalog/controller/checkout/shipping_address.php
@@ -65,11 +65,7 @@ class ControllerCheckoutShippingAddress extends Controller {
 			$data['shipping_address_custom_field'] = array();
 		}
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/checkout/shipping_address.tpl')) {
-			$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/checkout/shipping_address.tpl', $data));
-		} else {
-			$this->response->setOutput($this->load->view('default/template/checkout/shipping_address.tpl', $data));
-		}
+		$this->response->render('checkout/shipping_address', $data);
 	}
 
 	public function save() {

--- a/upload/catalog/controller/checkout/shipping_method.php
+++ b/upload/catalog/controller/checkout/shipping_method.php
@@ -69,11 +69,7 @@ class ControllerCheckoutShippingMethod extends Controller {
 			$data['comment'] = '';
 		}
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/checkout/shipping_method.tpl')) {
-			$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/checkout/shipping_method.tpl', $data));
-		} else {
-			$this->response->setOutput($this->load->view('default/template/checkout/shipping_method.tpl', $data));
-		}
+		$this->response->render('checkout/shipping_method', $data);
 	}
 
 	public function save() {

--- a/upload/catalog/controller/checkout/success.php
+++ b/upload/catalog/controller/checkout/success.php
@@ -83,10 +83,6 @@ class ControllerCheckoutSuccess extends Controller {
 		$data['footer'] = $this->load->controller('common/footer');
 		$data['header'] = $this->load->controller('common/header');
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/common/success.tpl')) {
-			$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/common/success.tpl', $data));
-		} else {
-			$this->response->setOutput($this->load->view('default/template/common/success.tpl', $data));
-		}
+		$this->response->render('common/success', $data);
 	}
 }

--- a/upload/catalog/controller/checkout/voucher.php
+++ b/upload/catalog/controller/checkout/voucher.php
@@ -24,11 +24,7 @@ class ControllerCheckoutVoucher extends Controller {
 				$data['redirect'] = $this->url->link('checkout/cart');
 			}
 
-			if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/checkout/voucher.tpl')) {
-				return $this->load->view($this->config->get('config_template') . '/template/checkout/voucher.tpl', $data);
-			} else {
-				return $this->load->view('default/template/checkout/voucher.tpl', $data);
-			}
+			return $this->response->compile('checkout/voucher', $data);
 		}
 	}
 

--- a/upload/catalog/controller/common/cart.php
+++ b/upload/catalog/controller/common/cart.php
@@ -135,11 +135,7 @@ class ControllerCommonCart extends Controller {
 		$data['cart'] = $this->url->link('checkout/cart');
 		$data['checkout'] = $this->url->link('checkout/checkout', '', 'SSL');
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/common/cart.tpl')) {
-			return $this->load->view($this->config->get('config_template') . '/template/common/cart.tpl', $data);
-		} else {
-			return $this->load->view('default/template/common/cart.tpl', $data);
-		}
+		return $this->response->compile('common/cart', $data);
 	}
 
 	public function info() {

--- a/upload/catalog/controller/common/column_left.php
+++ b/upload/catalog/controller/common/column_left.php
@@ -61,10 +61,6 @@ class ControllerCommonColumnLeft extends Controller {
 			}
 		}
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/common/column_left.tpl')) {
-			return $this->load->view($this->config->get('config_template') . '/template/common/column_left.tpl', $data);
-		} else {
-			return $this->load->view('default/template/common/column_left.tpl', $data);
-		}
+		return $this->response->compile('common/column_left', $data);
 	}
 }

--- a/upload/catalog/controller/common/column_right.php
+++ b/upload/catalog/controller/common/column_right.php
@@ -61,10 +61,6 @@ class ControllerCommonColumnRight extends Controller {
 			}
 		}
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/common/column_right.tpl')) {
-			return $this->load->view($this->config->get('config_template') . '/template/common/column_right.tpl', $data);
-		} else {
-			return $this->load->view('default/template/common/column_right.tpl', $data);
-		}
+		return $this->response->compile('common/column_right', $data);
 	}
 }

--- a/upload/catalog/controller/common/content_bottom.php
+++ b/upload/catalog/controller/common/content_bottom.php
@@ -61,10 +61,6 @@ class ControllerCommonContentBottom extends Controller {
 			}
 		}
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/common/content_bottom.tpl')) {
-			return $this->load->view($this->config->get('config_template') . '/template/common/content_bottom.tpl', $data);
-		} else {
-			return $this->load->view('default/template/common/content_bottom.tpl', $data);
-		}
+		return $this->response->compile('common/content_bottom', $data);
 	}
 }

--- a/upload/catalog/controller/common/content_top.php
+++ b/upload/catalog/controller/common/content_top.php
@@ -61,10 +61,6 @@ class ControllerCommonContentTop extends Controller {
 			}
 		}
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/common/content_top.tpl')) {
-			return $this->load->view($this->config->get('config_template') . '/template/common/content_top.tpl', $data);
-		} else {
-			return $this->load->view('default/template/common/content_top.tpl', $data);
-		}
+		return $this->response->compile('common/content_top', $data);
 	}
 }

--- a/upload/catalog/controller/common/currency.php
+++ b/upload/catalog/controller/common/currency.php
@@ -46,11 +46,7 @@ class ControllerCommonCurrency extends Controller {
 			$data['redirect'] = $this->url->link($route, $url, $this->request->server['HTTPS']);
 		}
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/common/currency.tpl')) {
-			return $this->load->view($this->config->get('config_template') . '/template/common/currency.tpl', $data);
-		} else {
-			return $this->load->view('default/template/common/currency.tpl', $data);
-		}
+		return $this->response->compile('common/currency', $data);
 	}
 
 	public function currency() {

--- a/upload/catalog/controller/common/footer.php
+++ b/upload/catalog/controller/common/footer.php
@@ -70,10 +70,6 @@ class ControllerCommonFooter extends Controller {
 			$this->model_tool_online->whosonline($ip, $this->customer->getId(), $url, $referer);
 		}
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/common/footer.tpl')) {
-			return $this->load->view($this->config->get('config_template') . '/template/common/footer.tpl', $data);
-		} else {
-			return $this->load->view('default/template/common/footer.tpl', $data);
-		}
+		return $this->response->compile('common/footer', $data);
 	}
 }

--- a/upload/catalog/controller/common/header.php
+++ b/upload/catalog/controller/common/header.php
@@ -145,10 +145,6 @@ class ControllerCommonHeader extends Controller {
 			$data['class'] = 'common-home';
 		}
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/common/header.tpl')) {
-			return $this->load->view($this->config->get('config_template') . '/template/common/header.tpl', $data);
-		} else {
-			return $this->load->view('default/template/common/header.tpl', $data);
-		}
+		return $this->response->compile('common/header', $data);
 	}
 }

--- a/upload/catalog/controller/common/home.php
+++ b/upload/catalog/controller/common/home.php
@@ -16,10 +16,6 @@ class ControllerCommonHome extends Controller {
 		$data['footer'] = $this->load->controller('common/footer');
 		$data['header'] = $this->load->controller('common/header');
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/common/home.tpl')) {
-			$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/common/home.tpl', $data));
-		} else {
-			$this->response->setOutput($this->load->view('default/template/common/home.tpl', $data));
-		}
+		$this->response->render('common/home', $data);
 	}
 }

--- a/upload/catalog/controller/common/language.php
+++ b/upload/catalog/controller/common/language.php
@@ -45,11 +45,7 @@ class ControllerCommonLanguage extends Controller {
 			$data['redirect'] = $this->url->link($route, $url, $this->request->server['HTTPS']);
 		}
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/common/language.tpl')) {
-			return $this->load->view($this->config->get('config_template') . '/template/common/language.tpl', $data);
-		} else {
-			return $this->load->view('default/template/common/language.tpl', $data);
-		}
+		return $this->response->compile('common/language', $data);
 	}
 
 	public function language() {

--- a/upload/catalog/controller/common/maintenance.php
+++ b/upload/catalog/controller/common/maintenance.php
@@ -50,10 +50,6 @@ class ControllerCommonMaintenance extends Controller {
 		$data['header'] = $this->load->controller('common/header');
 		$data['footer'] = $this->load->controller('common/footer');
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/common/maintenance.tpl')) {
-			$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/common/maintenance.tpl', $data));
-		} else {
-			$this->response->setOutput($this->load->view('default/template/common/maintenance.tpl', $data));
-		}
+		$this->response->render('common/maintenance', $data);
 	}
 }

--- a/upload/catalog/controller/common/search.php
+++ b/upload/catalog/controller/common/search.php
@@ -11,10 +11,6 @@ class ControllerCommonSearch extends Controller {
 			$data['search'] = '';
 		}
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/common/search.tpl')) {
-			return $this->load->view($this->config->get('config_template') . '/template/common/search.tpl', $data);
-		} else {
-			return $this->load->view('default/template/common/search.tpl', $data);
-		}
+		return $this->response->compile('common/search', $data);
 	}
 }

--- a/upload/catalog/controller/error/not_found.php
+++ b/upload/catalog/controller/error/not_found.php
@@ -52,10 +52,6 @@ class ControllerErrorNotFound extends Controller {
 		$data['footer'] = $this->load->controller('common/footer');
 		$data['header'] = $this->load->controller('common/header');
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/error/not_found.tpl')) {
-			$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/error/not_found.tpl', $data));
-		} else {
-			$this->response->setOutput($this->load->view('default/template/error/not_found.tpl', $data));
-		}
+		$this->response->render('error/not_found', $data);
 	}
 }

--- a/upload/catalog/controller/information/contact.php
+++ b/upload/catalog/controller/information/contact.php
@@ -161,11 +161,7 @@ class ControllerInformationContact extends Controller {
 		$data['footer'] = $this->load->controller('common/footer');
 		$data['header'] = $this->load->controller('common/header');
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/information/contact.tpl')) {
-			$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/information/contact.tpl', $data));
-		} else {
-			$this->response->setOutput($this->load->view('default/template/information/contact.tpl', $data));
-		}
+		$this->response->render('information/contact', $data);
 	}
 
 	public function success() {
@@ -200,11 +196,7 @@ class ControllerInformationContact extends Controller {
 		$data['footer'] = $this->load->controller('common/footer');
 		$data['header'] = $this->load->controller('common/header');
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/common/success.tpl')) {
-			$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/common/success.tpl', $data));
-		} else {
-			$this->response->setOutput($this->load->view('default/template/common/success.tpl', $data));
-		}
+        $this->response->render('common/success', $data);
 	}
 
 	protected function validate() {

--- a/upload/catalog/controller/information/information.php
+++ b/upload/catalog/controller/information/information.php
@@ -44,8 +44,8 @@ class ControllerInformationInformation extends Controller {
 			$data['content_bottom'] = $this->load->controller('common/content_bottom');
 			$data['footer'] = $this->load->controller('common/footer');
 			$data['header'] = $this->load->controller('common/header');
-            
-            $this->response->render('information/information', $data);            
+
+			$this->response->render('information/information', $data);            
 		} else {
 			$data['breadcrumbs'][] = array(
 				'text' => $this->language->get('text_error'),

--- a/upload/catalog/controller/information/information.php
+++ b/upload/catalog/controller/information/information.php
@@ -44,7 +44,7 @@ class ControllerInformationInformation extends Controller {
 			$data['content_bottom'] = $this->load->controller('common/content_bottom');
 			$data['footer'] = $this->load->controller('common/footer');
 			$data['header'] = $this->load->controller('common/header');
-
+            
             $this->response->render('information/information', $data);            
 		} else {
 			$data['breadcrumbs'][] = array(

--- a/upload/catalog/controller/information/information.php
+++ b/upload/catalog/controller/information/information.php
@@ -45,11 +45,7 @@ class ControllerInformationInformation extends Controller {
 			$data['footer'] = $this->load->controller('common/footer');
 			$data['header'] = $this->load->controller('common/header');
 
-			if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/information/information.tpl')) {
-				$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/information/information.tpl', $data));
-			} else {
-				$this->response->setOutput($this->load->view('default/template/information/information.tpl', $data));
-			}
+            $this->response->render('information/information', $data);            
 		} else {
 			$data['breadcrumbs'][] = array(
 				'text' => $this->language->get('text_error'),
@@ -75,11 +71,7 @@ class ControllerInformationInformation extends Controller {
 			$data['footer'] = $this->load->controller('common/footer');
 			$data['header'] = $this->load->controller('common/header');
 
-			if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/error/not_found.tpl')) {
-				$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/error/not_found.tpl', $data));
-			} else {
-				$this->response->setOutput($this->load->view('default/template/error/not_found.tpl', $data));
-			}
+			$this->response->render('error/not_found', $data);
 		}
 	}
 

--- a/upload/catalog/controller/information/sitemap.php
+++ b/upload/catalog/controller/information/sitemap.php
@@ -100,10 +100,6 @@ class ControllerInformationSitemap extends Controller {
 		$data['footer'] = $this->load->controller('common/footer');
 		$data['header'] = $this->load->controller('common/header');
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/information/sitemap.tpl')) {
-			$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/information/sitemap.tpl', $data));
-		} else {
-			$this->response->setOutput($this->load->view('default/template/information/sitemap.tpl', $data));
-		}
+		$this->response->render('information/sitemap', $data);
 	}
 }

--- a/upload/catalog/controller/product/category.php
+++ b/upload/catalog/controller/product/category.php
@@ -362,11 +362,7 @@ class ControllerProductCategory extends Controller {
 			$data['footer'] = $this->load->controller('common/footer');
 			$data['header'] = $this->load->controller('common/header');
 
-			if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/product/category.tpl')) {
-				$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/product/category.tpl', $data));
-			} else {
-				$this->response->setOutput($this->load->view('default/template/product/category.tpl', $data));
-			}
+			$this->response->render('product/category', $data);
 		} else {
 			$url = '';
 
@@ -418,11 +414,7 @@ class ControllerProductCategory extends Controller {
 			$data['footer'] = $this->load->controller('common/footer');
 			$data['header'] = $this->load->controller('common/header');
 
-			if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/error/not_found.tpl')) {
-				$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/error/not_found.tpl', $data));
-			} else {
-				$this->response->setOutput($this->load->view('default/template/error/not_found.tpl', $data));
-			}
+			$this->response->render('error/not_found', $data);
 		}
 	}
 }

--- a/upload/catalog/controller/product/compare.php
+++ b/upload/catalog/controller/product/compare.php
@@ -153,11 +153,7 @@ class ControllerProductCompare extends Controller {
 		$data['footer'] = $this->load->controller('common/footer');
 		$data['header'] = $this->load->controller('common/header');
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/product/compare.tpl')) {
-			$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/product/compare.tpl', $data));
-		} else {
-			$this->response->setOutput($this->load->view('default/template/product/compare.tpl', $data));
-		}
+		$this->response->render('product/compare', $data);
 	}
 
 	public function add() {

--- a/upload/catalog/controller/product/manufacturer.php
+++ b/upload/catalog/controller/product/manufacturer.php
@@ -58,11 +58,7 @@ class ControllerProductManufacturer extends Controller {
 		$data['footer'] = $this->load->controller('common/footer');
 		$data['header'] = $this->load->controller('common/header');
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/product/manufacturer_list.tpl')) {
-			$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/product/manufacturer_list.tpl', $data));
-		} else {
-			$this->response->setOutput($this->load->view('default/template/product/manufacturer_list.tpl', $data));
-		}
+		$this->response->render('product/manufacturer_list', $data);
 	}
 
 	public function info() {
@@ -351,11 +347,7 @@ class ControllerProductManufacturer extends Controller {
 			$data['footer'] = $this->load->controller('common/footer');
 			$data['header'] = $this->load->controller('common/header');
 
-			if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/product/manufacturer_info.tpl')) {
-				$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/product/manufacturer_info.tpl', $data));
-			} else {
-				$this->response->setOutput($this->load->view('default/template/product/manufacturer_info.tpl', $data));
-			}
+			$this->response->render('product/manufacturer_info', $data);
 		} else {
 			$url = '';
 
@@ -403,11 +395,7 @@ class ControllerProductManufacturer extends Controller {
 			$data['content_top'] = $this->load->controller('common/content_top');
 			$data['content_bottom'] = $this->load->controller('common/content_bottom');
 
-			if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/error/not_found.tpl')) {
-				$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/error/not_found.tpl', $data));
-			} else {
-				$this->response->setOutput($this->load->view('default/template/error/not_found.tpl', $data));
-			}
+			$this->response->render('error/not_found', $data);
 		}
 	}
 }

--- a/upload/catalog/controller/product/product.php
+++ b/upload/catalog/controller/product/product.php
@@ -473,11 +473,7 @@ class ControllerProductProduct extends Controller {
 			$data['footer'] = $this->load->controller('common/footer');
 			$data['header'] = $this->load->controller('common/header');
 
-			if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/product/product.tpl')) {
-				$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/product/product.tpl', $data));
-			} else {
-				$this->response->setOutput($this->load->view('default/template/product/product.tpl', $data));
-			}
+			$this->response->render('product/product', $data);
 		} else {
 			$url = '';
 
@@ -553,11 +549,7 @@ class ControllerProductProduct extends Controller {
 			$data['footer'] = $this->load->controller('common/footer');
 			$data['header'] = $this->load->controller('common/header');
 
-			if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/error/not_found.tpl')) {
-				$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/error/not_found.tpl', $data));
-			} else {
-				$this->response->setOutput($this->load->view('default/template/error/not_found.tpl', $data));
-			}
+			$this->response->render('error/not_found', $data);
 		}
 	}
 
@@ -599,11 +591,7 @@ class ControllerProductProduct extends Controller {
 
 		$data['results'] = sprintf($this->language->get('text_pagination'), ($review_total) ? (($page - 1) * 5) + 1 : 0, ((($page - 1) * 5) > ($review_total - 5)) ? $review_total : ((($page - 1) * 5) + 5), $review_total, ceil($review_total / 5));
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/product/review.tpl')) {
-			$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/product/review.tpl', $data));
-		} else {
-			$this->response->setOutput($this->load->view('default/template/product/review.tpl', $data));
-		}
+		$this->response->render('product/review', $data);
 	}
 
 	public function write() {

--- a/upload/catalog/controller/product/search.php
+++ b/upload/catalog/controller/product/search.php
@@ -447,10 +447,6 @@ class ControllerProductSearch extends Controller {
 		$data['footer'] = $this->load->controller('common/footer');
 		$data['header'] = $this->load->controller('common/header');
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/product/search.tpl')) {
-			$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/product/search.tpl', $data));
-		} else {
-			$this->response->setOutput($this->load->view('default/template/product/search.tpl', $data));
-		}
+		$this->response->render('product/search', $data);
 	}
 }

--- a/upload/catalog/controller/product/special.php
+++ b/upload/catalog/controller/product/special.php
@@ -268,10 +268,6 @@ class ControllerProductSpecial extends Controller {
 		$data['footer'] = $this->load->controller('common/footer');
 		$data['header'] = $this->load->controller('common/header');
 
-		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/product/special.tpl')) {
-			$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/product/special.tpl', $data));
-		} else {
-			$this->response->setOutput($this->load->view('default/template/product/special.tpl', $data));
-		}
+		$this->response->render('product/special', $data);
 	}
 }

--- a/upload/index.php
+++ b/upload/index.php
@@ -116,6 +116,7 @@ $registry->set('request', $request);
 $response = new Response();
 $response->addHeader('Content-Type: text/html; charset=utf-8');
 $response->setCompression($config->get('config_compression'));
+$response->setTemplate($config->get('config_template'));
 $registry->set('response', $response);
 
 // Cache

--- a/upload/system/library/response.php
+++ b/upload/system/library/response.php
@@ -3,6 +3,7 @@ class Response {
 	private $headers = array();
 	private $level = 0;
 	private $output;
+	private $template;
 
 	public function addHeader($header) {
 		$this->headers[] = $header;
@@ -72,4 +73,21 @@ class Response {
 			echo $output;
 		}
 	}
+    
+    public function setTemplate($template) {
+        $this->template = $template;       
+    }
+    
+    public function render($path, $data) {
+        $this->setOutput($this->compile($path, $data));
+    }
+    
+    public function compile($path, $data) {
+        $loader = new Loader(null);
+        if (file_exists(DIR_TEMPLATE . $this->template . '/template/' . $path . '.tpl')) {
+			return $loader->view($this->template . '/template/' . $path . '.tpl', $data);
+		} else {
+			return $loader->view('default/template/'.$path.'.tpl', $data);
+		}        
+    }
 }


### PR DESCRIPTION
In every controller, this is used to render the page:
```php        
if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/foo/bar.tpl')) {
    $this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/foo/bar.tpl', $data));
} else {
    $this->response->setOutput($this->load->view('default/template/foo/bar.tpl', $data));
}   
```
This can also be done with:
```php
$this->response->render('foo/bar', $data);
```

And for partials, this is used every time:
```php
if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/foo/bar.tpl')) {
    return $this->load->view($this->config->get('config_template') . '/template/foo/bar.tpl', $data);
} else {
    return $this->load->view('default/template/foo/bar.tpl', $data);
}                     
```
It's easier to read/write with this syntax:
```php
return $this->response->compile('foo/bar', $data);
```
It does exactly the same, but with [a few extra lines of code](https://github.com/steefdw/opencart/commit/717188838a953b0d4202517afe3a92e490b2be45), we could have more readable code AND remove (169x4=) 676 lines of code. It's used in 132 files (169 occurrences).

In this PR, I cleaned 39 files, so 93 files (122 occurrences) to go. After this improvement is implemented, I will clean those as well.

This proposal does not replace functionality, but adds to it. So you could still use the current way of setting the template file.