### PR TITLE
Fix issue #3069

### DIFF
--- a/upload/catalog/model/fraud/maxmind.php
+++ b/upload/catalog/model/fraud/maxmind.php
@@ -3,9 +3,7 @@ class ModelFraudMaxMind extends Model {
 	public function check($data) {
 		$risk_score = 0;
 
-		$fraud_info = $this->getFraud($data['order_id']);
-
-		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "maxmind` WHERE order_id = '" . (int)$order_id . "'");
+		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "maxmind` WHERE order_id = '" . (int)$data['order_id'] . "'");
 		
 		if ($query->num_rows) {
 			$risk_score = $query->row['risk_score'];


### PR DESCRIPTION
`getFraud` method was still invoked, but the method does not exists anymore by commit https://github.com/opencart/opencart/commit/a0f3a115fce8dd9b55e121af2e4a464316b540a2 .

`query` SQL is generated using `order_id` variable, but it does not exists (it was the `getFraud` parameter). Replaced with the correct one.