### PR TITLE
Fixed issue #2722

### DIFF
--- a/upload/admin/model/sale/order.php
+++ b/upload/admin/model/sale/order.php
@@ -177,23 +177,23 @@ class ModelSaleOrder extends Model {
 			$sql .= " WHERE o.order_status_id > '0'";
 		}
 
-		if (!empty($data['filter_order_id'])) {
+		if (isset($data['filter_order_id'])) {
 			$sql .= " AND o.order_id = '" . (int)$data['filter_order_id'] . "'";
 		}
 
-		if (!empty($data['filter_customer'])) {
+		if (isset($data['filter_customer'])) {
 			$sql .= " AND CONCAT(o.firstname, ' ', o.lastname) LIKE '%" . $this->db->escape($data['filter_customer']) . "%'";
 		}
 
-		if (!empty($data['filter_date_added'])) {
+		if (isset($data['filter_date_added'])) {
 			$sql .= " AND DATE(o.date_added) = DATE('" . $this->db->escape($data['filter_date_added']) . "')";
 		}
 
-		if (!empty($data['filter_date_modified'])) {
+		if (isset($data['filter_date_modified'])) {
 			$sql .= " AND DATE(o.date_modified) = DATE('" . $this->db->escape($data['filter_date_modified']) . "')";
 		}
 
-		if (!empty($data['filter_total'])) {
+		if (isset($data['filter_total'])) {
 			$sql .= " AND o.total = '" . (float)$data['filter_total'] . "'";
 		}
 
@@ -274,7 +274,7 @@ class ModelSaleOrder extends Model {
 	public function getTotalOrders($data = array()) {
 		$sql = "SELECT COUNT(*) AS total FROM `" . DB_PREFIX . "order`";
 
-		if (!empty($data['filter_order_status'])) {
+		if (isset($data['filter_order_status'])) {
 			$implode = array();
 
 			$order_statuses = explode(',', $data['filter_order_status']);
@@ -290,23 +290,23 @@ class ModelSaleOrder extends Model {
 			$sql .= " WHERE order_status_id > '0'";
 		}
 
-		if (!empty($data['filter_order_id'])) {
+		if (isset($data['filter_order_id'])) {
 			$sql .= " AND order_id = '" . (int)$data['filter_order_id'] . "'";
 		}
 
-		if (!empty($data['filter_customer'])) {
+		if (isset($data['filter_customer'])) {
 			$sql .= " AND CONCAT(firstname, ' ', lastname) LIKE '%" . $this->db->escape($data['filter_customer']) . "%'";
 		}
 
-		if (!empty($data['filter_date_added'])) {
+		if (isset($data['filter_date_added'])) {
 			$sql .= " AND DATE(date_added) = DATE('" . $this->db->escape($data['filter_date_added']) . "')";
 		}
 
-		if (!empty($data['filter_date_modified'])) {
+		if (isset($data['filter_date_modified'])) {
 			$sql .= " AND DATE(date_modified) = DATE('" . $this->db->escape($data['filter_date_modified']) . "')";
 		}
 
-		if (!empty($data['filter_total'])) {
+		if (isset($data['filter_total'])) {
 			$sql .= " AND total = '" . (float)$data['filter_total'] . "'";
 		}
 


### PR DESCRIPTION
When filtering orders, if argument is '0', the `empty` method returns `true` and the query returns wrong results. I changed it with the `isset` method which returns the right boolean.

You can easily reproduce the issue filtering by *order ID*: If you type 0 you will have all the orders as results.