### PR TITLE
Modification to pre.order.history.add event trigger

### DIFF
--- a/upload/catalog/model/checkout/order.php
+++ b/upload/catalog/model/checkout/order.php
@@ -254,7 +254,13 @@ class ModelCheckoutOrder extends Model {
 	}
 
 	public function addOrderHistory($order_id, $order_status_id, $comment = '', $notify = false) {
-		$this->event->trigger('pre.order.history.add', $order_id);
+		$event_data = array(
+			'order_id'		=> $order_id,
+			'order_status_id'	=> $order_status_id,
+			'comment'		=> $comment,
+			'notify'		=> $notify
+		);
+		$this->event->trigger('pre.order.history.add', $event_data);
 
 		$order_info = $this->getOrder($order_id);
 


### PR DESCRIPTION
Added order_id, order_status_id, comment and notify data to the pre.order.history.add event trigger.

If accepted, the wiki would have to be updated to reflect the changes.


Joel.