### PR TITLE
Fixed issue #3116

### DIFF
--- a/upload/catalog/controller/affiliate/login.php
+++ b/upload/catalog/controller/affiliate/login.php
@@ -120,7 +120,7 @@ class ControllerAffiliateLogin extends Controller {
 
 	protected function validate() {
 		// Check how many login attempts have been made.
-		$login_info = $this->model_affiliate_affiliate->getLoginAttempts($this->request->post['email']);
+		$login_info = $this->model_account_customer->getLoginAttempts($this->request->post['email']);
 				
 		if ($login_info && ($login_info['total'] >= $this->config->get('config_login_attempts')) && strtotime('-1 hour') < strtotime($login_info['date_modified'])) {
 			$this->error['warning'] = $this->language->get('error_attempts');

--- a/upload/catalog/controller/affiliate/login.php
+++ b/upload/catalog/controller/affiliate/login.php
@@ -120,6 +120,7 @@ class ControllerAffiliateLogin extends Controller {
 
 	protected function validate() {
 		// Check how many login attempts have been made.
+        $this->load->model('account/customer');
 		$login_info = $this->model_account_customer->getLoginAttempts($this->request->post['email']);
 				
 		if ($login_info && ($login_info['total'] >= $this->config->get('config_login_attempts')) && strtotime('-1 hour') < strtotime($login_info['date_modified'])) {
@@ -137,9 +138,9 @@ class ControllerAffiliateLogin extends Controller {
 			if (!$this->affiliate->login($this->request->post['email'], $this->request->post['password'])) {
 				$this->error['warning'] = $this->language->get('error_login');
 			
-				$this->model_affiliate_affiliate->addLoginAttempt($this->request->post['email']);
+				$this->model_account_customer->addLoginAttempt($this->request->post['email']);
 			} else {
-				$this->model_affiliate_affiliate->deleteLoginAttempts($this->request->post['email']);
+				$this->model_account_customer->deleteLoginAttempts($this->request->post['email']);
 			}
 		}
 		

--- a/upload/catalog/controller/affiliate/register.php
+++ b/upload/catalog/controller/affiliate/register.php
@@ -17,7 +17,7 @@ class ControllerAffiliateRegister extends Controller {
 			$affiliate_id = $this->model_affiliate_affiliate->addAffiliate($this->request->post);
 
 			// Clear any previous login attempts in not registered.
-			$this->model_affiliate_affiliate->deleteLoginAttempts($this->request->post['email']);
+			$this->model_account_customer->deleteLoginAttempts($this->request->post['email']);
 			
 			$this->affiliate->login($this->request->post['email'], $this->request->post['password']);
 

--- a/upload/catalog/controller/affiliate/register.php
+++ b/upload/catalog/controller/affiliate/register.php
@@ -17,6 +17,7 @@ class ControllerAffiliateRegister extends Controller {
 			$affiliate_id = $this->model_affiliate_affiliate->addAffiliate($this->request->post);
 
 			// Clear any previous login attempts in not registered.
+    		$this->load->model('account/customer');
 			$this->model_account_customer->deleteLoginAttempts($this->request->post['email']);
 			
 			$this->affiliate->login($this->request->post['email'], $this->request->post['password']);


### PR DESCRIPTION
In the following controllers are used two method not belonging to the used model.
In particular:

in `catalog/controller/affiliate/register.php`:
```
// Clear any previous login attempts in not registered.
$this->model_affiliate_affiliate->deleteLoginAttempts($this->request->post['email']);
```
and
in `catalog/controller/affiliate/login.php`
```
// Check how many login attempts have been made.
$login_info = $this->model_affiliate_affiliate->getLoginAttempts($this->request->post['email']);
```

The problem is that in affiliate model (`catalog/model/affiliate/affiliate.php`) there are no methods like `deleteLoginAttempts` and `getLoginAttempts`, because they belongs to customer model (`catalog/model/account/customer.php`).