### PR TITLE
fix for shipping to countries with no zones

### DIFF
--- a/upload/catalog/model/localisation/zone.php
+++ b/upload/catalog/model/localisation/zone.php
@@ -14,6 +14,10 @@ class ModelLocalisationZone extends Model {
 
 			$zone_data = $query->rows;
 
+			if( count($zone_data) < 1){
+				$zone_data = array(array('zone_id' => '0000', 'country_id' => $country_id, 'name' => 'No zone', 'code' => 'XX', 'status' => '1'));
+			}
+			
 			$this->cache->set('zone.' . (int)$country_id, $zone_data);
 		}
 


### PR DESCRIPTION
Fixed problem with zone selection being required for countries without zones (Eg., Singapore).  If no zones found for country, create 'dummy' zone called No zone.