### PR TITLE
Prevent html content inside modules dropdown

### DIFF
--- a/upload/admin/controller/design/layout.php
+++ b/upload/admin/controller/design/layout.php
@@ -378,14 +378,14 @@ class ControllerDesignLayout extends Controller {
 
 			foreach ($modules as $module) {
 				$module_data[] = array(
-					'name' => $this->language->get('heading_title') . ' &gt; ' . $module['name'],
+					'name' => strip_tags($this->language->get('heading_title') . ' &gt; ' . $module['name']),
 					'code' => $code . '.' .  $module['module_id']
 				);
 			}
 
 			if ($this->config->has($code . '_status') || $module_data) {
 				$data['extensions'][] = array(
-					'name'   => $this->language->get('heading_title'),
+					'name'   => strip_tags($this->language->get('heading_title')),
 					'code'   => $code,
 					'module' => $module_data
 				);


### PR DESCRIPTION
Some developers include HTML content inside module heading_title language like base64 images, text decorations, etc which causes javascript conflict and blocks 'Add Module' button.