### PR TITLE
use mt_rand() instead of rand()

### DIFF
--- a/upload/system/helper/general.php
+++ b/upload/system/helper/general.php
@@ -6,7 +6,7 @@ function token($length = 32) {
 	$token = '';
 	
 	for ($i = 0; $i < $length; $i++) {
-		$token .= $string[rand(0, strlen($string) - 1)];
+		$token .= $string[mt_rand(0, strlen($string) - 1)];
 	}	
 	
 	return $token;


### PR DESCRIPTION
As per PHP documentation, mt_rand() is a drop-in replacement for rand() with the following advantages:
- it generates better random values (using stronger algorithm)
- it is four times faster than rand()