### PR TITLE
Fix bad link to contact us on order successful page

### DIFF
--- a/upload/catalog/controller/checkout/success.php
+++ b/upload/catalog/controller/checkout/success.php
@@ -67,7 +67,7 @@ class ControllerCheckoutSuccess extends Controller {
 		$data['heading_title'] = $this->language->get('heading_title');
 
 		if ($this->customer->isLogged()) {
-			$data['text_message'] = sprintf($this->language->get('text_customer'), $this->url->link('account/account', '', 'SSL'), $this->url->link('account/order', '', 'SSL'), $this->url->link('account/download', '', 'SSL'), $this->url->link('information/contact'));
+			$data['text_message'] = sprintf($this->language->get('text_customer'), $this->url->link('account/account', '', 'SSL'), $this->url->link('account/order', '', 'SSL'), $this->url->link('information/contact'));
 		} else {
 			$data['text_message'] = sprintf($this->language->get('text_guest'), $this->url->link('information/contact'));
 		}


### PR DESCRIPTION
When an order is completed successfully as a logged in user. The "contact us" link goes to the download page in the account area. This is due to the incorrect variable being used for the contact address.