### PR TITLE
Fix invalid reference to $option['option_value']

### DIFF
--- a/upload/catalog/controller/payment/pp_express.php
+++ b/upload/catalog/controller/payment/pp_express.php
@@ -466,9 +466,9 @@ class ControllerPaymentPPExpress extends Controller {
 
 			foreach ($product['option'] as $option) {
 				if ($option['type'] != 'file') {
-					$value = $option['option_value'];
+					$value = $option['value'];
 				} else {
-					$filename = $this->encryption->decrypt($option['option_value']);
+					$filename = $this->encryption->decrypt($option['value']);
 
 					$value = utf8_substr($filename, 0, utf8_strrpos($filename, '.'));
 				}
@@ -954,9 +954,9 @@ class ControllerPaymentPPExpress extends Controller {
 
 				foreach ($product['option'] as $option) {
 					if ($option['type'] != 'file') {
-						$value = $option['option_value'];
+						$value = $option['value'];
 					} else {
-						$value = $this->encryption->decrypt($option['option_value']);
+						$value = $this->encryption->decrypt($option['value']);
 					}
 
 					$option_data[] = array(


### PR DESCRIPTION
When checking out via paypal express with a product in the cart that contains an option (and is not a file). There is an undefined indexed error for $option['option_value'].