### PR TITLE
Encryption is not required for 'File' type option

### DIFF
--- a/upload/catalog/controller/payment/pp_express.php
+++ b/upload/catalog/controller/payment/pp_express.php
@@ -953,19 +953,13 @@ class ControllerPaymentPPExpress extends Controller {
 				$option_data = array();
 
 				foreach ($product['option'] as $option) {
-					if ($option['type'] != 'file') {
-						$value = $option['option_value'];
-					} else {
-						$value = $this->encryption->decrypt($option['option_value']);
-					}
-
 					$option_data[] = array(
 						'product_option_id'       => $option['product_option_id'],
 						'product_option_value_id' => $option['product_option_value_id'],
 						'option_id'               => $option['option_id'],
 						'option_value_id'         => $option['option_value_id'],
 						'name'                    => $option['name'],
-						'value'                   => $value,
+						'value'                   => $option['value'],
 						'type'                    => $option['type']
 					);
 				}


### PR DESCRIPTION
In PayPal Express module 'expressComplete' function, there's no need to decrypt the 'File' type option or to return the file name because this data is to be saved into the order table in the database, not for view display. So the raw upload 'code' should be saved instead.