### PR TITLE
Add "required" asterisk to locale field

### DIFF
--- a/upload/admin/view/template/localisation/language_form.tpl
+++ b/upload/admin/view/template/localisation/language_form.tpl
@@ -43,7 +43,7 @@
               <?php } ?>
             </div>
           </div>
-          <div class="form-group">
+          <div class="form-group required">
             <label class="col-sm-2 control-label required" for="input-locale"><span data-toggle="tooltip" title="<?php echo $help_locale; ?>"><?php echo $entry_locale; ?></span></label>
             <div class="col-sm-10">
               <input type="text" name="locale" value="<?php echo $locale; ?>" placeholder="<?php echo $entry_locale; ?>" id="input-locale" class="form-control" />


### PR DESCRIPTION
The Locale field throws a "Locale required" error if you don't fill it in, so I have added a required flag in the form.
![locale](https://cloud.githubusercontent.com/assets/1152470/9006319/3941c92c-37da-11e5-9b93-31946bc01e5f.png)
