### PR TITLE
Update usps.php

### DIFF
--- a/upload/catalog/model/shipping/usps.php
+++ b/upload/catalog/model/shipping/usps.php
@@ -280,6 +280,7 @@ class ModelShippingUsps extends Model {
 
 				if (isset($country[$address['iso_code_2']])) {
 					$xml  = '<IntlRateV2Request USERID="' . $this->config->get('usps_user_id') . '">';
+					$xml .= '	<Revision>2</Revision>';
 					$xml .=	'	<Package ID="1">';
 					$xml .=	'		<Pounds>' . $pounds . '</Pounds>';
 					$xml .=	'		<Ounces>' . $ounces . '</Ounces>';
@@ -302,6 +303,7 @@ class ModelShippingUsps extends Model {
 					$xml .= '		<Length>' . $this->config->get('usps_length') . '</Length>';
 					$xml .= '		<Height>' . $this->config->get('usps_height') . '</Height>';
 					$xml .= '		<Girth>' . $this->config->get('usps_girth') . '</Girth>';
+					$xml .= '		<OriginZip>' . substr($this->config->get('usps_postcode'), 0, 5) . '</OriginZip>';
 					$xml .= '		<CommercialFlag>N</CommercialFlag>';
 					$xml .=	'	</Package>';
 					$xml .=	'</IntlRateV2Request>';


### PR DESCRIPTION
As outlined in section 2.3.1 of this USPS technical document (https://www.usps.com/business/web-tools-apis/2015-may-webtools-release-notes.rtf), the <OriginZip> value is required to obtain Priority Mail International non-Flat Rate pricing and availability for Canada destinations.