### PR TITLE
Maxmind Fraud Module: getFraud, order_id and maxmind_key fix

### DIFF
--- a/upload/catalog/model/fraud/maxmind.php
+++ b/upload/catalog/model/fraud/maxmind.php
@@ -3,7 +3,7 @@ class ModelFraudMaxMind extends Model {
 	public function check($data) {
 		$risk_score = 0;
 
-		$fraud_info = $this->getFraud($data['order_id']);
+		$order_id = $data['order_id'];
 
 		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "maxmind` WHERE order_id = '" . (int)$order_id . "'");
 		
@@ -25,7 +25,7 @@ class ModelFraudMaxMind extends Model {
 			$request .= '&country=' . urlencode($data['payment_country']);
 			$request .= '&domain=' . urlencode(utf8_substr(strrchr($data['email'], '@'), 1));
 			$request .= '&custPhone=' . urlencode($data['telephone']);
-			$request .= '&license_key=' . urlencode($this->config->get('config_fraud_key'));
+			$request .= '&license_key=' . urlencode($this->config->get('maxmind_key'));
 
 			if ($data['shipping_method']) {
 				$request .= '&shipAddr=' . urlencode($data['shipping_address_1']);
@@ -60,7 +60,6 @@ class ModelFraudMaxMind extends Model {
 			$risk_score = 0;
 
 			if ($response) {
-				$order_id = $data['order_id'];
 				$customer_id = $data['customer_id'];
 
 				$data = array();


### PR DESCRIPTION
I've found a couple of errors while testing this fraud module with a live license key. The fixes are below:

Fixed fatal error: call to undefined method, caused by the getFraud() method.
Fixed undefined index notice by moving the order_id declaration to the right place, so the query in Line 8 would work properly.
Changed config_fraud_key to maxmind_key, to represent recent changes in the config key.

It's all been tested, and orders run through the fraud service properly now.

Before:
![before](https://cloud.githubusercontent.com/assets/7793991/9157449/f5534c72-3ef5-11e5-9c87-420c63397241.png)

After:
![after](https://cloud.githubusercontent.com/assets/7793991/9157448/f551b236-3ef5-11e5-9cb4-3695e07b0a95.png)