### PR TITLE
Added global variables to templates

### DIFF
--- a/upload/system/engine/loader.php
+++ b/upload/system/engine/loader.php
@@ -77,12 +77,12 @@ final class Loader {
 			exit();
 		}
 
-		if (isset($data['url']) || isset($data['lng']) || isset($data['load']) || isset($data['request'])) {
-			trigger_error('Error: you must not override url, lng, load and request parameters in the $data array!');
+		if (isset($data['router']) || isset($data['lng']) || isset($data['load']) || isset($data['request'])) {
+			trigger_error('Error: you must not override router, lng, load and request parameters in the $data array!');
 			exit();
 		}
 
-		$data['url'] = $this->registry->get('url');
+		$data['router'] = $this->registry->get('url');
 		$data['lng'] = $this->registry->get('language');
 		$data['load'] = $this->registry->get('load');
 		$data['request'] = $this->registry->get('request');

--- a/upload/system/engine/loader.php
+++ b/upload/system/engine/loader.php
@@ -72,20 +72,30 @@ final class Loader {
 
 		$file = DIR_TEMPLATE . $template;
 
-		if (file_exists($file)) {
-			extract($data);
-
-			ob_start();
-
-			require($file);
-
-			$output = ob_get_contents();
-
-			ob_end_clean();
-		} else {
+		if (!file_exists($file)) {
 			trigger_error('Error: Could not load template ' . $file . '!');
 			exit();
 		}
+
+		if (isset($data['url']) || isset($data['lng']) || isset($data['load']) || isset($data['request'])) {
+			trigger_error('Error: you must not override url, lng, load and request parameters in the $data array!');
+			exit();
+		}
+
+		$data['url'] = $this->registry->get('url');
+		$data['lng'] = $this->registry->get('language');
+		$data['load'] = $this->registry->get('load');
+		$data['request'] = $this->registry->get('request');
+
+		extract($data);
+
+		ob_start();
+
+		require($file);
+
+		$output = ob_get_contents();
+
+		ob_end_clean();
 
 		// $this->event->trigger('post.view.' . str_replace('/', '.', $template), $output);
 

--- a/upload/system/library/request.php
+++ b/upload/system/library/request.php
@@ -15,6 +15,14 @@ class Request {
 		$this->server = $this->clean($_SERVER);
 	}
 
+	public function post($key, $default = '')	{
+		return isset($this->post[$key]) ? $this->post[$key] : $default;
+	}
+
+	public function get($key, $default = '')	{
+		return isset($this->get[$key]) ? $this->get[$key] : $default;
+	}
+
 	public function clean($data) {
 		if (is_array($data)) {
 			foreach ($data as $key => $value) {


### PR DESCRIPTION
* Language global variable (```$lng```). There is no more need to set ```$data``` with language strings: language string can be retrieved in the template by calling ```$lng->get('language_string')```. So all code pieces like ```$data['entry_email'] = $this->language->get('entry_email');``` can be removed from controllers.
* Request service global variable(```$request```). POST and GET variables can be retrieved directly in the template by calling ```$request->post('variable_name', 'default_value');``` or just ```$request->post('variable_name')```. All code pieces like below can be removed from controllers:
```php
if (isset($this->request->post['email'])) {
    $data['email'] = $this->request->post['email'];
} else {
    $data['email'] = '';
}
```

And in the templates it could be used like:
```php
<input type="text" name="email" value="<?= $request->post('email') ?>" />
```

So construction like ```<?= $request->post('email') ?>``` or ```<?= $request->get('email') ?>``` can be used.

* Url service global variable (```$router```). I remaned it from ```$url``` global variable to keep paypal modules work well. Now urls can be generated righ in the templates:
```php
<?= $router->link('account/forgotten', '', 'SSL') ?>
```

* Loader service global variable (```$loader```). Now columns, header, footer and even any controller can be loaded right into template. Example: ```$load->controller('common/content_bottom') ```