### PR TITLE
Change SEO Keyword Text to SEO URL

### DIFF
--- a/upload/admin/language/english/catalog/product.php
+++ b/upload/admin/language/english/catalog/product.php
@@ -30,7 +30,7 @@ $_['entry_description']      = 'Description';
 $_['entry_meta_title'] 	     = 'Meta Tag Title';
 $_['entry_meta_keyword'] 	 = 'Meta Tag Keywords';
 $_['entry_meta_description'] = 'Meta Tag Description';
-$_['entry_keyword']          = 'SEO Keyword';
+$_['entry_keyword']          = 'SEO URL';
 $_['entry_model']            = 'Model';
 $_['entry_sku']              = 'SKU';
 $_['entry_upc']              = 'UPC';
@@ -81,7 +81,7 @@ $_['entry_layout']           = 'Layout Override';
 $_['entry_recurring']        = 'Recurring Profile';
 
 // Help
-$_['help_keyword']           = 'Do not use spaces, instead replace spaces with - and make sure the keyword is globally unique.';
+$_['help_keyword']           = 'Do not use spaces, instead replace spaces with - and make sure the SEO URL is globally unique.';
 $_['help_sku']               = 'Stock Keeping Unit';
 $_['help_upc']               = 'Universal Product Code';
 $_['help_ean']               = 'European Article Number';


### PR DESCRIPTION
The term "SEO Keyword" has been causing a lot of confusion for OpenCart shop owners.  I've lost count the number of times I've worked on a customer's site only to find their SEO Keyword field stuffed with Google keywords.

It's pretty obvious why they believe that the SEO Keyword field is to input Google keywords. If you Google the term "SEO Keyword" the results are all related to Google keywords, and nothing to do with SEO friendly URLs.

I am proposing that we finally eliminate this issue by changing the field text to read "SEO URL".

This will lessen the issues of shop owners using the field for Google keywords.  It also now makes the field text correspond with the system setting "Use SEO URLs", so it's easier to identify that the two fields work together.

Joel.