### PR TITLE
Convert Limit to Integer

### DIFF
--- a/upload/catalog/controller/product/category.php
+++ b/upload/catalog/controller/product/category.php
@@ -34,9 +34,9 @@ class ControllerProductCategory extends Controller {
 		}
 
 		if (isset($this->request->get['limit'])) {
-			$limit = $this->request->get['limit'];
+			$limit = (int)$this->request->get['limit'];
 		} else {
-			$limit = $this->config->get('config_product_limit');
+			$limit = (int)$this->config->get('config_product_limit');
 		}
 
 		$data['breadcrumbs'] = array();

--- a/upload/catalog/controller/product/category.php
+++ b/upload/catalog/controller/product/category.php
@@ -36,7 +36,7 @@ class ControllerProductCategory extends Controller {
 		if (isset($this->request->get['limit'])) {
 			$limit = (int)$this->request->get['limit'];
 		} else {
-			$limit = (int)$this->config->get('config_product_limit');
+			$limit = $this->config->get('config_product_limit');
 		}
 
 		$data['breadcrumbs'] = array();

--- a/upload/catalog/controller/product/manufacturer.php
+++ b/upload/catalog/controller/product/manufacturer.php
@@ -99,9 +99,9 @@ class ControllerProductManufacturer extends Controller {
 		}
 
 		if (isset($this->request->get['limit'])) {
-			$limit = $this->request->get['limit'];
+			$limit = (int)$this->request->get['limit'];
 		} else {
-			$limit = $this->config->get('config_product_limit');
+			$limit = (int)$this->config->get('config_product_limit');
 		}
 
 		$data['breadcrumbs'] = array();

--- a/upload/catalog/controller/product/search.php
+++ b/upload/catalog/controller/product/search.php
@@ -60,7 +60,7 @@ class ControllerProductSearch extends Controller {
 		}
 
 		if (isset($this->request->get['limit'])) {
-			$limit = $this->request->get['limit'];
+			$limit = (int)$this->request->get['limit'];
 		} else {
 			$limit = $this->config->get('config_product_limit');
 		}

--- a/upload/catalog/controller/product/special.php
+++ b/upload/catalog/controller/product/special.php
@@ -26,7 +26,7 @@ class ControllerProductSpecial extends Controller {
 		}
 
 		if (isset($this->request->get['limit'])) {
-			$limit = $this->request->get['limit'];
+			$limit = (int)$this->request->get['limit'];
 		} else {
 			$limit = $this->config->get('config_product_limit');
 		}


### PR DESCRIPTION
Converted limit from GET to be an integer.  This is to avoid customers overriding the limit value in the URL triggering a division by zero error.

This is similar to @eka7a pull request except updated for the latest master.