### PR TITLE
Extend language get

### DIFF
--- a/upload/system/library/language.php
+++ b/upload/system/library/language.php
@@ -8,8 +8,24 @@ class Language {
 		$this->directory = $directory;
 	}
 
-	public function get($key) {
-		return (isset($this->data[$key]) ? $this->data[$key] : $key);
+	public function get($lang, $args = array(), $data = array()) {
+		$args = (array)$args;
+
+		if (is_array($lang)) {
+			foreach ($lang as $prefix => $names) {
+				foreach ($names as $name) {
+					$data[$prefix . '_' . $name] = $this->get($prefix . '_' . $name, (isset($args[$prefix][$name]) ? $args[$prefix][$name] : array()));
+				}
+			}
+		} else {
+			$data = (isset($this->data[$lang]) ? $this->data[$lang] : $lang);
+
+			if (!empty($args)) {
+				$data = vsprintf($data, $args);
+			}
+		}
+
+		return $data;
 	}
 
 	public function all() {


### PR DESCRIPTION
I try to extend language get, move sprintf form controler to language get vsprintf. And now you can add multiple value with arrays to language get.

You can use like now:
```
$data['text'] = $this->language->get('text');
```
You can add easier sprint:
```
$data['text'] = $this->language->get('text', $value);
```

Or you can add array with key prefix:
```
$data['x'] = 'x';

$lang_data['button'] = array(
	'cart',
	'wishlist',
	'compare',
	'search'
);

$args['button']['cart'] = $value;

$data = $this->language->get($lang_data, $args, $data);
```

What do you think?