### PR TITLE
Added template service

### DIFF
--- a/upload/index.php
+++ b/upload/index.php
@@ -241,6 +241,9 @@ $registry->set('encryption', new Encryption($config->get('config_encryption')));
 // OpenBay Pro
 $registry->set('openbay', new Openbay($registry));
 
+// Template
+$registry->set('template', new Template($registry));
+
 // Event
 $event = new Event($registry);
 $registry->set('event', $event);

--- a/upload/system/engine/registry.php
+++ b/upload/system/engine/registry.php
@@ -13,4 +13,16 @@ final class Registry {
 	public function has($key) {
 		return isset($this->data[$key]);
 	}
+
+	public function __get($key) {
+		return $this->get($key);
+	}
+
+	public function __set($key, $value) {
+		$this->set($key, $value);
+	}
+
+	public function __isset($key) {
+		return $this->has($key);
+	}
 }

--- a/upload/system/library/template.php
+++ b/upload/system/library/template.php
@@ -1,5 +1,20 @@
 <?php
 class Template {
+	private $registry;
+
+	public function __construct($registry) {
+		$this->registry = $registry;
+	}
+
+	public function render($filename, $data) {
+		if (file_exists(DIR_TEMPLATE . $this->registry->config->get('config_template') . '/template/common/' . $filename)) {
+			$this->registry->response->setOutput($this->registry->load->view($this->registry->config->get('config_template') . '/template/common/' . $filename, $data));
+		} else {
+			$this->registry->response->setOutput($this->registry->load->view('default/template/common/' . $filename, $data));
+		}
+	}
+
+/*
 	private $data = array();
 
   public function __construct($driver) {
@@ -36,4 +51,5 @@ class Template {
 			exit();
 		}
 	}
+*/
 }

--- a/upload/system/library/template.php
+++ b/upload/system/library/template.php
@@ -6,11 +6,11 @@ class Template {
 		$this->registry = $registry;
 	}
 
-	public function render($filename, $data) {
-		if (file_exists(DIR_TEMPLATE . $this->registry->config->get('config_template') . '/template/common/' . $filename)) {
-			$this->registry->response->setOutput($this->registry->load->view($this->registry->config->get('config_template') . '/template/common/' . $filename, $data));
+	public function render($path, $data) {
+		if (file_exists(DIR_TEMPLATE . $this->registry->config->get('config_template') . '/template/' . $path)) {
+			$this->registry->response->setOutput($this->registry->load->view($this->registry->config->get('config_template') . '/template/' . $path, $data));
 		} else {
-			$this->registry->response->setOutput($this->registry->load->view('default/template/common/' . $filename, $data));
+			$this->registry->response->setOutput($this->registry->load->view('default/template/' . $path, $data));
 		}
 	}
 


### PR DESCRIPTION
Right now this piece of code:

```php
		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/common/success.tpl')) {
			$this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/common/success.tpl', $data));
		} else {
			$this->response->setOutput($this->load->view('default/template/common/success.tpl', $data));
		}
```

can be replaced with:

```php
$this->template->render('common/success.tpl', $data);
```

in every frontend controller.