### PR TITLE
[pp_express] Added an ID tag to the logo's hidden input

### DIFF
--- a/upload/admin/view/template/payment/pp_express.tpl
+++ b/upload/admin/view/template/payment/pp_express.tpl
@@ -386,7 +386,7 @@
 			  <div class="form-group">
 				<label class="col-sm-2 control-label" for="input-image"><span data-toggle="tooltip" title="<?php echo $help_logo; ?>"><?php echo $entry_logo; ?></span></label>
 				<div class="col-sm-10"><a href="" id="thumb-image" data-toggle="image" class="img-thumbnail"><img src="<?php echo $thumb; ?>" alt="" title="" data-placeholder="<?php echo $placeholder; ?>" /></a>
-				  <input type="hidden" name="pp_express_logo" value="<?php echo $pp_express_logo; ?>" />
+				  <input type="hidden" name="pp_express_logo" value="<?php echo $pp_express_logo; ?>" id="input-logo" />
 				</div>
 			  </div>
 			</div>


### PR DESCRIPTION
Adding a logo on the Checkout tab of the PayPal Express module was not working (it was not saving the image URL to the database), because of the lack of ID tag on the logo's hidden input field. Added it, and now it works properly.