### PR TITLE
[pp_express] Changed the logo's width to 750px

### DIFF
--- a/upload/catalog/controller/payment/pp_express.php
+++ b/upload/catalog/controller/payment/pp_express.php
@@ -77,7 +77,7 @@ class ControllerPaymentPPExpress extends Controller {
 			'ALLOWNOTE'          => $this->config->get('pp_express_allow_note'),
 			'LOCALECODE'         => 'EN',
 			'LANDINGPAGE'        => 'Login',
-			'HDRIMG'             => $this->model_tool_image->resize($this->config->get('pp_express_logo'), 790, 90),
+			'HDRIMG'             => $this->model_tool_image->resize($this->config->get('pp_express_logo'), 750, 90),
 			'PAYFLOWCOLOR'       => $this->config->get('pp_express_page_colour'),
 			'CHANNELTYPE'        => 'Merchant'
 		);
@@ -1301,7 +1301,7 @@ class ControllerPaymentPPExpress extends Controller {
 			'NOSHIPPING'         => $shipping,
 			'LOCALECODE'         => 'EN',
 			'LANDINGPAGE'        => 'Login',
-			'HDRIMG'             => $this->model_tool_image->resize($this->config->get('pp_express_logo'), 790, 90),
+			'HDRIMG'             => $this->model_tool_image->resize($this->config->get('pp_express_logo'), 750, 90),
 			'PAYFLOWCOLOR'       => $this->config->get('pp_express_page_colour'),
 			'CHANNELTYPE'        => 'Merchant',
 			'ALLOWNOTE'          => $this->config->get('pp_express_allow_note')


### PR DESCRIPTION
According to https://www.paypal.com/uk/custom the header image size should be maximum 750x90, and the pp_express controller incorrectly sets it to 790px, which results in cropping of the image on PayPal. Changed both instances of the wrong size to the correct one.