### PR TITLE
Fixed 'Notice: undefined variable session_id/key' errors

### DIFF
--- a/upload/system/library/session.php
+++ b/upload/system/library/session.php
@@ -2,7 +2,7 @@
 class Session {
 	public $data = array();
 
-	public function __construct() {
+	public function __construct($session_id = '',  $key = 'default') {
 		
 		
 		


### PR DESCRIPTION
This resolves opencart/opencart#3471