### PR TITLE
Fixed variable overwrite within a `foreach` loop.

### DIFF
--- a/upload/admin/controller/extension/installer.php
+++ b/upload/admin/controller/extension/installer.php
@@ -325,12 +325,12 @@ class ControllerExtensionInstaller extends Controller {
 							}
 
 							if (is_dir($file)) {
-								$list = ftp_nlist($connection, substr($destination, 0, strrpos($destination, '/')));
+								$lists = ftp_nlist($connection, substr($destination, 0, strrpos($destination, '/')));
 
 								// Basename all the directories because on some servers they don't return the fulll paths.
 								$list_data = array();
 
-								foreach ($list as $list) {
+								foreach ($lists as $list) {
 									$list_data[] = basename($list);
 								}
 


### PR DESCRIPTION
Hi guys,

I suppose this is a bug. First we're fetching a data via `ftp_nlist` function as array data.
Next we're going to loop over this variable, but in the 1st iteration this array is being overwritten by it's value.