### PR TITLE
Add `use Cart\User` namespace/class

### DIFF
--- a/upload/catalog/controller/common/maintenance.php
+++ b/upload/catalog/controller/common/maintenance.php
@@ -1,4 +1,6 @@
 <?php
+use Cart\User;
+
 class ControllerCommonMaintenance extends Controller {
 	public function index() {
 		if ($this->config->get('config_maintenance')) {


### PR DESCRIPTION
Hi guys,

Please merge this fix.
It fixes `PHP Fatal error:  Class 'User' not found in .../catalog/controller/common/maintenance.php on line 16`.

[Here](https://github.com/opencart/opencart/blob/master/upload/catalog/controller/common/maintenance.php#L16) is user a `User` class which has not been imported.

Thanks.