### PR TITLE
Adds a support for custom model to avoid core folders changing.

### DIFF
--- a/upload/system/modification.xml
+++ b/upload/system/modification.xml
@@ -15,4 +15,19 @@
       </add>
     </operation>
   </file>
+  <file path="system/engine/loader.php">
+    <operation>
+      <search trim="true"><![CDATA[$model = str_replace('../', '', (string)$model);]]></search>
+      <add position="after"><![CDATA[
+        $mod_file = DIR_MODIFICATION . ((defined('HTTP_CATALOG')) ? 'admin' : 'catalog') . '/model/' . $model . '.php';]]></add>
+    </operation>
+    <operation>
+      <search trim="true"><![CDATA[$this->registry->set('model_' . str_replace('/', '_', $model), new $class($this->registry));]]></search>
+      <add position="after"><![CDATA[
+        } elseif (file_exists($mod_file)) {
+            include_once($mod_file);
+
+            $this->registry->set('model_' . str_replace('/', '_', $model), new $class($this->registry));]]></add>
+    </operation>
+  </file>
 </modification>


### PR DESCRIPTION
Hi guys,

You made a nice modification system. So I even don't need to create any `.ocmod.xml` files to make some changes. I simply click `Refresh` button on admin area **only once** and do place my custom files under `system/storage/modification`. That's it. I can overload everything which is pretty cool.

But there's no ability to place my custom `models`.
For example, I have a custom model `ModelCatalogCustomFeature`. Why it's necessary to copy it using OCMOD to the `core` folder? Touching the core files/folders is always bad idea.

This patch enables to simply place the class file to `system/storage/modification/admin/model/catalog/custom_feature.php` (in my example) and that's it!

How the `loader.php` file [will look](https://gist.github.com/matrunchyk/1085a6750b57499119bd) after turning on a modification system.

Anyone: Actually you could always use [this OCMod](https://gist.githubusercontent.com/matrunchyk/8951e361dbad191e8eaf/raw/c9bba9b9dc15ef56f825b82292ae7fcb9478bc4e/OCMod%2520%2522Custom%2520Model%2520Support%2522) to add a support for custom models (in case if OpenCart guys will decline my proposal).

Thanks.