### PR TITLE
product report total

### DIFF
--- a/upload/admin/model/report/product.php
+++ b/upload/admin/model/report/product.php
@@ -37,7 +37,7 @@ class ModelReportProduct extends Model {
 	}
 
 	public function getPurchased($data = array()) {
-		$sql = "SELECT op.name, op.model, SUM(op.quantity) AS quantity, SUM((op.total + op.tax) * op.quantity) AS total FROM " . DB_PREFIX . "order_product op LEFT JOIN `" . DB_PREFIX . "order` o ON (op.order_id = o.order_id)";
+		$sql = "SELECT op.name, op.model, SUM(op.quantity) AS quantity, SUM(op.total + (op.tax * op.quantity)) AS total FROM " . DB_PREFIX . "order_product op LEFT JOIN `" . DB_PREFIX . "order` o ON (op.order_id = o.order_id)";
 
 		if (!empty($data['filter_order_status_id'])) {
 			$sql .= " WHERE o.order_status_id = '" . (int)$data['filter_order_status_id'] . "'";


### PR DESCRIPTION
Daniel, please verify:

According to Cart/Cart  and ControllerCheckoutConfirm  the order_product table rows are populated like this:
total = cart product total = unit price * quantity
tax = unit tax amount ( see ControllerCheckoutConfirm populating$order_data['products'] ~ line 224) 

so we need to sum op.total + op.tax*op.quantity to get the order product total tax included instead of 1st adding up total + single tax

i believe (not 100% sure) that some time ago (maybe version 1.5.1~2 the tax column in order_product held the total product tax)

regards
