### PR TITLE
getOrders query limit at wrong place

### DIFF
--- a/upload/admin/model/report/customer.php
+++ b/upload/admin/model/report/customer.php
@@ -113,6 +113,8 @@ class ModelReportCustomer extends Model {
 
 		$sql .= " GROUP BY o.order_id";
 
+		$sql = "SELECT t.customer_id, t.customer, t.email, t.customer_group, t.status, COUNT(t.order_id) AS orders, SUM(t.products) AS products, SUM(t.total) AS total FROM (" . $sql . ") AS t GROUP BY t.customer_id ORDER BY total DESC";
+
 		if (isset($data['start']) || isset($data['limit'])) {
 			if ($data['start'] < 0) {
 				$data['start'] = 0;
@@ -124,8 +126,6 @@ class ModelReportCustomer extends Model {
 
 			$sql .= " LIMIT " . (int)$data['start'] . "," . (int)$data['limit'];
 		}
-
-        $sql = "SELECT t.customer_id, t.customer, t.email, t.customer_group, t.status, COUNT(t.order_id) AS orders, SUM(t.products) AS products, SUM(t.total) AS total FROM (" . $sql . ") AS t GROUP BY t.customer_id ORDER BY total DESC";
 
 		$query = $this->db->query($sql);
 


### PR DESCRIPTION
The SQL query part where it limits the number of rows is wrongly appended in the sub query instead of at the end of the query. This produces incorrect returned results.