### PR TITLE
Fix order not disappearing from the list after order delete

### DIFF
--- a/upload/admin/view/template/sale/order_list.tpl
+++ b/upload/admin/view/template/sale/order_list.tpl
@@ -320,6 +320,7 @@ $('button[id^=\'button-delete\']').on('click', function(e) {
 
 				if (json['success']) {
 					$('#content > .container-fluid').prepend('<div class="alert alert-success"><i class="fa fa-check-circle"></i> ' + json['success'] + ' <button type="button" class="close" data-dismiss="alert">&times;</button></div>');
+                    $(node).closest('tr').remove();
 				}
 			},
 			error: function(xhr, ajaxOptions, thrownError) {


### PR DESCRIPTION
Hi @danielkerr, this commit fixes a small issue — when a user deletes an order (which is done by AJAX) the order list is not to be refreshed (a correspondent table row is still remains on the table)