### PR TITLE
Reset continue button on payment method step 5 in case of error

### DIFF
--- a/upload/catalog/view/theme/default/template/checkout/checkout.tpl
+++ b/upload/catalog/view/theme/default/template/checkout/checkout.tpl
@@ -769,6 +769,8 @@ $(document).delegate('#button-payment-method', 'click', function() {
                 if (json['error']['warning']) {
                     $('#collapse-payment-method .panel-body').prepend('<div class="alert alert-warning">' + json['error']['warning'] + '<button type="button" class="close" data-dismiss="alert">&times;</button></div>');
                 }
+
+		$('#button-payment-method').button('reset');
             } else {
                 $.ajax({
                     url: 'index.php?route=checkout/confirm',


### PR DESCRIPTION
Reproduce:
- Go to checkout page
- Stay at step 5 - Choose Payment Method
- Choose any payment methods
- Don't click on the Terms & Conditions checkbox
- Click the Continue button
You will see the warning message but the Continue button will be disabled endlessly