### PR TITLE
Rawurlencode for non-URL letters in image URLs

### DIFF
--- a/upload/catalog/model/tool/image.php
+++ b/upload/catalog/model/tool/image.php
@@ -34,6 +34,10 @@ class ModelToolImage extends Model {
 			}
 		}
 
+ 
++		$imagepath_parts = explode('/', $new_image);
++		$new_image = implode('/', array_map('rawurlencode', $imagepath_parts));
+
 		if ($this->request->server['HTTPS']) {
 			return $this->config->get('config_ssl') . 'image/' . $new_image;
 		} else {


### PR DESCRIPTION
Non-ASCII letters in URLs should be encoded through %-encoding (see RFC). Users with non-ASCII alphabet still use non-ASCII letters and whitespaces in images and image folders. Modern browsers is not take care of wrong image URLs, but image URLs into data feeds are still incorrect. Data feed readers raise image URL error.