### PR TITLE
Add event object to registry. Fixes #3647

### DIFF
--- a/upload/install/index.php
+++ b/upload/install/index.php
@@ -52,6 +52,9 @@ $registry->set('document', $document);
 $session = new Session();
 $registry->set('session', $session);
 
+$event = new Event($registry);
+$registry->set('event', $event);
+
 // Upgrade
 $upgrade = false;
 


### PR DESCRIPTION
NOTE: I've only been exposed to OpenCart for a total of about 15 min. There are good chances this is not the correct fix. But it worked for me & allowed me to install OpenCart through the web interface.