### PR TITLE
simplified format method

### DIFF
--- a/upload/system/library/cart/currency.php
+++ b/upload/system/library/cart/currency.php
@@ -60,39 +60,27 @@ class Currency {
 			$currency = $this->code;
 		}
 
-		if ($value) {
-			$value = $value;
-		} else {
+		if (!$value) {
 			$value = $this->currencies[$currency]['value'];
 		}
 
-		if ($value) {
-			$value = (float)$number * $value;
-		} else {
-			$value = $number;
+		$amount = $value ? (float)$number * $value : (float)$number;
+		
+		$amount = round($amount, (int)$decimal_place);
+		
+		if (!$format) {
+			return $amount;
 		}
 
 		$string = '';
 
-		if (($symbol_left) && ($format)) {
+		if ($symbol_left) {
 			$string .= $symbol_left;
 		}
 
-		if ($format) {
-			$decimal_point = $this->language->get('decimal_point');
-		} else {
-			$decimal_point = '.';
-		}
+		$string .= number_format($amount, (int)$decimal_place, $this->language->get('decimal_point'), $this->language->get('thousand_point'));
 
-		if ($format) {
-			$thousand_point = $this->language->get('thousand_point');
-		} else {
-			$thousand_point = '';
-		}
-
-		$string .= number_format(round($value, (int)$decimal_place), (int)$decimal_place, $decimal_point, $thousand_point);
-
-		if (($symbol_right) && ($format)) {
+		if ($symbol_right) {
 			$string .= $symbol_right;
 		}
 


### PR DESCRIPTION
Hello Daniel/James,
please verify carefully my changes and thoughts.

1. No need to set $value = $value

2. Using $value both as the conversion parameter name and the soon-to-be formatted value name can be a little confusing. I changed it to $amount (I could have re-used $number as well)

3. If we are not returning a formatted string we could simply return the rounded value without calling number_format.

regards