### PR TITLE
No more isset on request

### DIFF
--- a/upload/system/library/request.php
+++ b/upload/system/library/request.php
@@ -28,4 +28,28 @@ class Request {
 
 		return $data;
 	}
+
+	public function post($key, $default = null) {
+		return isset($this->post[$key]) ? $this->post[$key] : $default;
+	}
+
+	public function get($key, $default = null) {
+		return isset($this->get[$key]) ? $this->get[$key] : $default;
+	}
+
+	public function request($key, $default = null) {
+		return isset($this->request[$key]) ? $this->request[$key] : $default;
+	}
+
+	public function cookie($key, $default = null) {
+		return isset($this->cookie[$key]) ? $this->cookie[$key] : $default;
+	}
+
+	public function files($key, $default = null) {
+		return isset($this->files[$key]) ? $this->files[$key] : $default;
+	}
+
+	public function server($key, $default = null) {
+		return isset($this->server[$key]) ? $this->server[$key] : $default;
+	}
 }


### PR DESCRIPTION
Helper to help pick up the values without the need to check the position in the array exists or not, and still you can have a value if there is no default.

Example:

```php
$telephone = $this->request->post('telephone', false);
```