### PR TITLE
Fix wrong modified controller/model/view being loaded

### DIFF
--- a/upload/system/startup.php
+++ b/upload/system/startup.php
@@ -66,7 +66,7 @@ if (isset($_SERVER['HTTPS']) && (($_SERVER['HTTPS'] == 'on') || ($_SERVER['HTTPS
 
 // Modification Override
 function modification($filename) {
-	if (!defined('DIR_CATALOG')) {
+	if (defined('DIR_CATALOG')) {
 		$file = DIR_MODIFICATION . 'catalog/' . substr($filename, strlen(DIR_APPLICATION));
 	} else {
 		$file = DIR_MODIFICATION . 'admin/' .  substr($filename, strlen(DIR_APPLICATION));


### PR DESCRIPTION
In the modification function !defined('DIR_CATALOG') can cause an admin controller/model/view to be loaded instead of the catalog controller/model/view it should be if (defined('DIR_CATALOG'))