### PR TITLE
Installer & SSL repairs

### DIFF
--- a/upload/install/controller/install/step_3.php
+++ b/upload/install/controller/install/step_3.php
@@ -15,7 +15,7 @@ class ControllerInstallStep3 extends Controller {
 			$output .= 'define(\'HTTP_SERVER\', \'' . HTTP_OPENCART . '\');' . "\n\n";
 
 			$output .= '// HTTPS' . "\n";
-			$output .= 'define(\'HTTPS_SERVER\', \'' . HTTP_OPENCART . '\');' . "\n\n";
+			$output .= 'define(\'HTTPS_SERVER\', \'' . HTTPS_OPENCART . '\');' . "\n\n";
 
 			$output .= '// DIR' . "\n";
 			$output .= 'define(\'DIR_APPLICATION\', \'' . DIR_OPENCART . 'catalog/\');' . "\n";

--- a/upload/install/controller/install/step_4.php
+++ b/upload/install/controller/install/step_4.php
@@ -58,7 +58,7 @@ class ControllerInstallStep4 extends Controller {
 		
 		curl_setopt($curl, CURLOPT_POST, true);
 		curl_setopt($curl, CURLOPT_HEADER, false);
-		curl_setopt($curl, CURLOPT_URL, 'http://www.opencart.com/index.php?route=extension/json/extensions');
+		curl_setopt($curl, CURLOPT_URL, 'https://www.opencart.com/index.php?route=extension/json/extensions');
 		curl_setopt($curl, CURLOPT_USERAGENT, 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.1) Gecko/20061204 Firefox/2.0.0.1');
 		curl_setopt($curl, CURLOPT_FRESH_CONNECT, true);
 		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);

--- a/upload/install/index.php
+++ b/upload/install/index.php
@@ -29,7 +29,8 @@ function oc_route_ssl_inst($ssl_pool) {
 }
 
 define('HTTP_SERVER', $_SERVER['PROTOCOL'] . $_SERVER['HTTP_HOST'] . rtrim(dirname($_SERVER['SCRIPT_NAME']), '/.\\') . '/');
-define('HTTP_OPENCART', $_SERVER['PROTOCOL'] . $_SERVER['HTTP_HOST'] . rtrim(rtrim(dirname($_SERVER['SCRIPT_NAME']), 'install'), '/.\\') . '/');
+define('HTTP_OPENCART', 'http://' . $_SERVER['HTTP_HOST'] . rtrim(rtrim(dirname($_SERVER['SCRIPT_NAME']), 'install'), '/.\\') . '/');
+define('HTTPS_OPENCART', $_SERVER['PROTOCOL'] . $_SERVER['HTTP_HOST'] . rtrim(rtrim(dirname($_SERVER['SCRIPT_NAME']), 'install'), '/.\\') . '/');
 
 // DIR
 define('DIR_APPLICATION', str_replace('\\', '/', realpath(dirname(__FILE__))) . '/');

--- a/upload/install/index.php
+++ b/upload/install/index.php
@@ -2,11 +2,34 @@
 // Error Reporting
 error_reporting(E_ALL);
 
-// HTTP
-$protocol = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' || $_SERVER['SERVER_PORT'] == 443) ? "https://" : "http://";
+// Rewrite HTTPS index based on proxy
+$ssl_pool = array(
+	!empty($_SERVER['HTTPS']),
+	!empty($_SERVER['HTTP_X_FORWARDED_PROTO']),
+	!empty($_SERVER['HTTP_X_FORWARDED_PROTOCOL']),
+	!empty($_SERVER['HTTP_X_FORWARDED_SSL']),
+	!empty($_SERVER['HTTP_FRONT_END_HTTPS']),
+	!empty($_SERVER['HTTP_X_URL_SCHEME']),
+	!empty($_SERVER['SERVER_PORT'])
+);
 
-define('HTTP_SERVER', $protocol . $_SERVER['HTTP_HOST'] . rtrim(dirname($_SERVER['SCRIPT_NAME']), '/.\\') . '/');
-define('HTTP_OPENCART', $protocol . $_SERVER['HTTP_HOST'] . rtrim(rtrim(dirname($_SERVER['SCRIPT_NAME']), 'install'), '/.\\') . '/');
+oc_route_ssl_inst($ssl_pool);
+
+function oc_route_ssl_inst($ssl_pool) {
+	$_SERVER['HTTPS'] = false;
+	$_SERVER['PROTOCOL'] = 'http://';
+	
+	foreach ($ssl_pool as $ssl) {
+		if (isset($ssl) && ($ssl == 'https' || $ssl == 'on' || $ssl == 1 || $ssl == true || $ssl == 443)) {
+			$_SERVER['HTTPS'] = true;
+			$_SERVER['PROTOCOL'] = 'https://';
+			break;
+		}
+	}
+}
+
+define('HTTP_SERVER', $_SERVER['PROTOCOL'] . $_SERVER['HTTP_HOST'] . rtrim(dirname($_SERVER['SCRIPT_NAME']), '/.\\') . '/');
+define('HTTP_OPENCART', $_SERVER['PROTOCOL'] . $_SERVER['HTTP_HOST'] . rtrim(rtrim(dirname($_SERVER['SCRIPT_NAME']), 'install'), '/.\\') . '/');
 
 // DIR
 define('DIR_APPLICATION', str_replace('\\', '/', realpath(dirname(__FILE__))) . '/');


### PR DESCRIPTION
The installer doesn't work right behind SSL, especially if is some kinda rev proxy. Also there is no IP rewrite support for IPs behind rev proxy. Here are a few tweaks and a rework of the switches to have broader compatibility with more headers. What do you think?