### PR TITLE
$action, $error, $pre_action elements typehinting

### DIFF
--- a/upload/system/engine/front.php
+++ b/upload/system/engine/front.php
@@ -25,7 +25,7 @@ final class Front {
 			}
 		}
 
-		while ($action) {
+		while ($action instanceof Action) {
 			$action = $this->execute($action);
 		}
 	}

--- a/upload/system/engine/front.php
+++ b/upload/system/engine/front.php
@@ -8,17 +8,17 @@ final class Front {
 		$this->registry = $registry;
 	}
 	
-	public function addPreAction($pre_action) {
+	public function addPreAction(Action $pre_action) {
 		$this->pre_action[] = $pre_action;
 	}
 	
-	public function dispatch($action, $error) {
+	public function dispatch(Action $action, Action $error) {
 		$this->error = $error;
 
 		foreach ($this->pre_action as $pre_action) {
 			$result = $this->execute($pre_action);
 
-			if ($result) {
+			if ($result instanceof Action) {
 				$action = $result;
 
 				break;
@@ -30,19 +30,20 @@ final class Front {
 		}
 	}
 
-	private function execute($action) {
+	private function execute(Action $action) {
 		$result = $action->execute($this->registry);
 
-		if (is_object($result)) {
-			$action = $result;
-		} elseif ($result === false) {
+		if ($result instanceof Action) {
+			return $result;
+		} 
+		
+		if ($result === false) {
 			$action = $this->error;
-
-			$this->error = '';
-		} else {
-			$action = '';	
+			$this->error = null;
+			
+			return $action;
 		}
-
-		return $action;
+		
+		return null;
 	}
 }


### PR DESCRIPTION
Hello Daniel, James

please verify

- i believe it would be better to typehint methods and have conditionals with `instanceof Action`.
- when defaulting $error and $action i believe it would be better to set them `null` instead of empty string as they are expected to be objects
- renaming $error to $error_action would make the code a little clearer about the role of the $error property

(btw i also usually typehint the $registry dependency with Registry in constructors)

...as usual this is just a suggestion (based on changes i already made in my implementation), feel free to close this pr at once if not interested...

kind regards