### PR TITLE
allow custom default config value

### DIFF
--- a/upload/system/library/config.php
+++ b/upload/system/library/config.php
@@ -2,8 +2,8 @@
 class Config {
 	private $data = array();
 
-	public function get($key) {
-		return (isset($this->data[$key]) ? $this->data[$key] : null);
+	public function get($key, $default = null) {
+		return (isset($this->data[$key]) ? $this->data[$key] : $default);
 	}
 
 	public function set($key, $value) {


### PR DESCRIPTION
- it allows to set an in-loco default value thus saving more lines of code (checking for null value and acting on that)
- it allows to have a consistent default value for instance for serialized data by specifying an empty array