### PR TITLE
allow passing extra $data via render method

### DIFF
--- a/upload/system/library/template.php
+++ b/upload/system/library/template.php
@@ -16,7 +16,7 @@ class Template {
 		$this->adaptor->set($key, $value);
 	}
 
-	public function render($template) {
-		return $this->adaptor->render($template);
+	public function render($template, array $data = null) {
+		return $this->adaptor->render($template, $data);
 	}
 }

--- a/upload/system/library/template/basic.php
+++ b/upload/system/library/template/basic.php
@@ -7,11 +7,11 @@ final class Basic {
 		$this->data[$key] = $value;
 	}
 	
-	public function render($template) {
+	public function render($template, array $data = null) {
 		$file = DIR_TEMPLATE . $template;
 
 		if (file_exists($file)) {
-			extract($this->data);
+			extract($data ? array_merge($this->data, $data) : $this->data);
 
 			ob_start();
 


### PR DESCRIPTION
Hello Daniel, James. This is a very common pattern for template renderers. Think it could be useful for opencart?

what about renaming adaptor to renderer in this case?
and maybe Basic to PhpRenderer?

in the code i do not modify (merge with extra $data) the instance->data, i think this should be kept as set via the set() method and only a merged array should be sent to the extract method.