### PR TITLE
execute(...) $args array type-hinting

### DIFF
--- a/upload/system/engine/action.php
+++ b/upload/system/engine/action.php
@@ -20,7 +20,7 @@ class Action {
 		}
 	}
 
-	public function execute($registry, $args = array()) {
+	public function execute($registry, array $args = array()) {
 		// Stop any magical methods being called
 		if (substr($this->method, 0, 2) == '__') {
 			return new \Exception('Error: Calls to magic methods are not allowed!');


### PR DESCRIPTION
call_user_func_array requires the second parameter to be an array