### PR TITLE
Fix for db wrapper not passing the $params argument to the mpdo driver…

### DIFF
--- a/upload/system/library/db.php
+++ b/upload/system/library/db.php
@@ -12,8 +12,8 @@ class DB {
 		}
 	}
 
-	public function query($sql) {
-		return $this->adaptor->query($sql);
+	public function query($sql, $params = array()) {
+		return $this->adaptor->query($sql, $params);
 	}
 
 	public function escape($value) {


### PR DESCRIPTION
The PDO driver expects the $params argument but since the wrapper only passing the $sql argument makes it generaly useless, this PR does not affect any other driver's behavior.