### PR TITLE
Fix possible issue in ebay_product.php

### DIFF
--- a/upload/catalog/model/openbay/ebay_product.php
+++ b/upload/catalog/model/openbay/ebay_product.php
@@ -248,9 +248,9 @@ class ModelOpenbayEbayProduct extends Model {
 						`minimum`               = '1',
 						`status`                = '1',
 						" . $openstock_sql . "
-						`date_available`        = 'now()',
-						`date_added`            = 'now()',
-						`date_modified`         = 'now()'
+						`date_available`        = now(),
+						`date_added`            = now(),
+						`date_modified`         = now()
 				");
 
 				$product_id = $this->db->getLastId();


### PR DESCRIPTION
There are three occurrences of the string 'now()' in the file that should probably read now() instead as 'now()' is a literal string and not the function call that the original author intended.