### PR TITLE
Propper order history ordering

### DIFF
--- a/upload/admin/model/sale/order.php
+++ b/upload/admin/model/sale/order.php
@@ -391,7 +391,7 @@ class ModelSaleOrder extends Model {
 			$limit = 10;
 		}
 
-		$query = $this->db->query("SELECT oh.date_added, os.name AS status, oh.comment, oh.notify FROM " . DB_PREFIX . "order_history oh LEFT JOIN " . DB_PREFIX . "order_status os ON oh.order_status_id = os.order_status_id WHERE oh.order_id = '" . (int)$order_id . "' AND os.language_id = '" . (int)$this->config->get('config_language_id') . "' ORDER BY oh.date_added DESC LIMIT " . (int)$start . "," . (int)$limit);
+		$query = $this->db->query("SELECT oh.date_added, os.name AS status, oh.comment, oh.notify FROM " . DB_PREFIX . "order_history oh LEFT JOIN " . DB_PREFIX . "order_status os ON oh.order_status_id = os.order_status_id WHERE oh.order_id = '" . (int)$order_id . "' AND os.language_id = '" . (int)$this->config->get('config_language_id') . "' ORDER BY oh.order_history_id DESC LIMIT " . (int)$start . "," . (int)$limit);
 
 		return $query->rows;
 	}


### PR DESCRIPTION
When you add several order history (f.a. via api) it could be with a same date_added value. And OpenCart display such order history entries in a wrong order.