### PR TITLE
Search descriptions for individual words, like names

### DIFF
--- a/upload/catalog/model/catalog/product.php
+++ b/upload/catalog/model/catalog/product.php
@@ -110,11 +110,15 @@ class ModelCatalogProduct extends Model {
 				}
 
 				if ($implode) {
-					$sql .= " " . implode(" AND ", $implode) . "";
+					$sql .= " (" . implode(" AND ", $implode) . ")";
 				}
 
-				if (!empty($data['filter_description'])) {
-					$sql .= " OR pd.description LIKE '%" . $this->db->escape($data['filter_name']) . "%'";
+				if (!empty($data['filter_description']) && $implode) {
+					$implode = array();
+					foreach ($words as $word) {
+						$implode[] = "pd.description LIKE '%" . $this->db->escape($word) . "%'";
+					}
+					$sql .= " OR (" . implode(" AND ", $implode) . ")";
 				}
 			}
 


### PR DESCRIPTION
This was confusingly inconsistent.

Completely untested.  I don't have a PHP environment; just fixing this for a friend who tripped over it.

I think you'll still get bogus SQL here if `filter_name` is set to whitespace and `filter_tag` is non-empty, but I don't think that can happen, at least not from `product/search`.