### PR TITLE
Bug fix custom field sort order the catalog

### DIFF
--- a/upload/catalog/view/theme/default/template/account/address_form.tpl
+++ b/upload/catalog/view/theme/default/template/account/address_form.tpl
@@ -289,15 +289,19 @@
 <script type="text/javascript"><!--
 // Sort the custom fields
 $('.form-group[data-sort]').detach().each(function() {
-	if ($(this).attr('data-sort') >= 0 && $(this).attr('data-sort') <= $('.form-group').length) {
-		$('.form-group').eq($(this).attr('data-sort')).before(this);
+	if ($(this).attr('data-sort') >= 0 && $(this).attr('data-sort') <= $('.form-group').length-2) {
+		$('.form-group').eq(parseInt($(this).attr('data-sort'))+2).before(this);
 	}
 
-	if ($(this).attr('data-sort') > $('.form-group').length) {
+	if ($(this).attr('data-sort') > $('.form-group').length-2) {
 		$('.form-group:last').after(this);
 	}
 
-	if ($(this).attr('data-sort') < -$('.form-group').length) {
+	if ($(this).attr('data-sort') == $('.form-group').length-2) {
+		$('.form-group:last').after(this);
+	}
+
+	if ($(this).attr('data-sort') < -$('.form-group').length-2) {
 		$('.form-group:first').before(this);
 	}
 });

--- a/upload/catalog/view/theme/default/template/account/edit.tpl
+++ b/upload/catalog/view/theme/default/template/account/edit.tpl
@@ -238,6 +238,10 @@ $('.form-group[data-sort]').detach().each(function() {
 		$('.form-group:last').after(this);
 	}
 
+	if ($(this).attr('data-sort') == $('.form-group').length) {
+		$('.form-group:last').after(this);
+	}
+
 	if ($(this).attr('data-sort') < -$('.form-group').length) {
 		$('.form-group:first').before(this);
 	}

--- a/upload/catalog/view/theme/default/template/account/register.tpl
+++ b/upload/catalog/view/theme/default/template/account/register.tpl
@@ -540,6 +540,10 @@ $('#account .form-group[data-sort]').detach().each(function() {
 		$('#account .form-group:last').after(this);
 	}
 
+	if ($(this).attr('data-sort') == $('#account .form-group').length) {
+		$('#account .form-group:last').after(this);
+	}
+
 	if ($(this).attr('data-sort') < -$('#account .form-group').length) {
 		$('#account .form-group:first').before(this);
 	}
@@ -551,6 +555,10 @@ $('#address .form-group[data-sort]').detach().each(function() {
 	}
 
 	if ($(this).attr('data-sort') > $('#address .form-group').length) {
+		$('#address .form-group:last').after(this);
+	}
+
+	if ($(this).attr('data-sort') == $('#address .form-group').length) {
 		$('#address .form-group:last').after(this);
 	}
 

--- a/upload/catalog/view/theme/default/template/checkout/guest.tpl
+++ b/upload/catalog/view/theme/default/template/checkout/guest.tpl
@@ -333,6 +333,10 @@ $('#account .form-group[data-sort]').detach().each(function() {
 		$('#account .form-group:last').after(this);
 	}
 
+	if ($(this).attr('data-sort') == $('#account .form-group').length) {
+		$('#account .form-group:last').after(this);
+	}
+
 	if ($(this).attr('data-sort') < -$('#account .form-group').length) {
 		$('#account .form-group:first').before(this);
 	}
@@ -344,6 +348,10 @@ $('#address .form-group[data-sort]').detach().each(function() {
 	}
 
 	if ($(this).attr('data-sort') > $('#address .form-group').length) {
+		$('#address .form-group:last').after(this);
+	}
+
+	if ($(this).attr('data-sort') == $('#address .form-group').length) {
 		$('#address .form-group:last').after(this);
 	}
 

--- a/upload/catalog/view/theme/default/template/checkout/guest_shipping.tpl
+++ b/upload/catalog/view/theme/default/template/checkout/guest_shipping.tpl
@@ -198,15 +198,19 @@
 <script type="text/javascript"><!--
 // Sort the custom fields
 $('#collapse-shipping-address .form-group[data-sort]').detach().each(function() {
-	if ($(this).attr('data-sort') >= 0 && $(this).attr('data-sort') <= $('#collapse-shipping-address .form-group').length) {
-		$('#collapse-shipping-address .form-group').eq($(this).attr('data-sort')).before(this);
+	if ($(this).attr('data-sort') >= 0 && $(this).attr('data-sort') <= $('#collapse-shipping-address .form-group').length-2) {
+		$('#collapse-shipping-address .form-group').eq(parseInt($(this).attr('data-sort'))+2).before(this);
 	}
 
-	if ($(this).attr('data-sort') > $('#collapse-shipping-address .form-group').length) {
+	if ($(this).attr('data-sort') > $('#collapse-shipping-address .form-group').length-2) {
 		$('#collapse-shipping-address .form-group:last').after(this);
 	}
 
-	if ($(this).attr('data-sort') < -$('#collapse-shipping-address .form-group').length) {
+	if ($(this).attr('data-sort') == $('#collapse-shipping-address .form-group').length-2) {
+		$('#collapse-shipping-address .form-group:last').after(this);
+	}
+
+	if ($(this).attr('data-sort') < -$('#collapse-shipping-address .form-group').length-2) {
 		$('#collapse-shipping-address .form-group:first').before(this);
 	}
 });

--- a/upload/catalog/view/theme/default/template/checkout/payment_address.tpl
+++ b/upload/catalog/view/theme/default/template/checkout/payment_address.tpl
@@ -219,15 +219,19 @@ $('input[name=\'payment_address\']').on('change', function() {
 <script type="text/javascript"><!--
 // Sort the custom fields
 $('#collapse-payment-address .form-group[data-sort]').detach().each(function() {
-	if ($(this).attr('data-sort') >= 0 && $(this).attr('data-sort') <= $('#collapse-payment-address .form-group').length) {
-		$('#collapse-payment-address .form-group').eq($(this).attr('data-sort')).before(this);
+	if ($(this).attr('data-sort') >= 0 && $(this).attr('data-sort') <= $('#collapse-payment-address .form-group').length-2) {
+		$('#collapse-payment-address .form-group').eq(parseInt($(this).attr('data-sort'))+2).before(this);
 	}
 
-	if ($(this).attr('data-sort') > $('#collapse-payment-address .form-group').length) {
+	if ($(this).attr('data-sort') > $('#collapse-payment-address .form-group').length-2) {
 		$('#collapse-payment-address .form-group:last').after(this);
 	}
 
-	if ($(this).attr('data-sort') < -$('#collapse-payment-address .form-group').length) {
+	if ($(this).attr('data-sort') == $('#collapse-payment-address .form-group').length-2) {
+		$('#collapse-payment-address .form-group:last').after(this);
+	}
+
+	if ($(this).attr('data-sort') < -$('#collapse-payment-address .form-group').length-2) {
 		$('#collapse-payment-address .form-group:first').before(this);
 	}
 });

--- a/upload/catalog/view/theme/default/template/checkout/register.tpl
+++ b/upload/catalog/view/theme/default/template/checkout/register.tpl
@@ -323,6 +323,10 @@ $('#account .form-group[data-sort]').detach().each(function() {
 		$('#account .form-group:last').after(this);
 	}
 
+	if ($(this).attr('data-sort') == $('#account .form-group').length) {
+		$('#account .form-group:last').after(this);
+	}
+
 	if ($(this).attr('data-sort') < -$('#account .form-group').length) {
 		$('#account .form-group:first').before(this);
 	}
@@ -334,6 +338,10 @@ $('#address .form-group[data-sort]').detach().each(function() {
 	}
 
 	if ($(this).attr('data-sort') > $('#address .form-group').length) {
+		$('#address .form-group:last').after(this);
+	}
+
+	if ($(this).attr('data-sort') == $('#address .form-group').length) {
 		$('#address .form-group:last').after(this);
 	}
 

--- a/upload/catalog/view/theme/default/template/checkout/shipping_address.tpl
+++ b/upload/catalog/view/theme/default/template/checkout/shipping_address.tpl
@@ -218,15 +218,19 @@ $('input[name=\'shipping_address\']').on('change', function() {
 //--></script>
 <script type="text/javascript"><!--
 $('#collapse-shipping-address .form-group[data-sort]').detach().each(function() {
-	if ($(this).attr('data-sort') >= 0 && $(this).attr('data-sort') <= $('#collapse-shipping-address .form-group').length) {
-		$('#collapse-shipping-address .form-group').eq($(this).attr('data-sort')).before(this);
+	if ($(this).attr('data-sort') >= 0 && $(this).attr('data-sort') <= $('#collapse-shipping-address .form-group').length-2) {
+		$('#collapse-shipping-address .form-group').eq(parseInt($(this).attr('data-sort'))+2).before(this);
 	}
 
-	if ($(this).attr('data-sort') > $('#collapse-shipping-address .form-group').length) {
+	if ($(this).attr('data-sort') > $('#collapse-shipping-address .form-group').length-2) {
 		$('#collapse-shipping-address .form-group:last').after(this);
 	}
 
-	if ($(this).attr('data-sort') < -$('#collapse-shipping-address .form-group').length) {
+	if ($(this).attr('data-sort') == $('#collapse-shipping-address .form-group').length-2) {
+		$('#collapse-shipping-address .form-group:last').after(this);
+	}
+
+	if ($(this).attr('data-sort') < -$('#collapse-shipping-address .form-group').length-2) {
 		$('#collapse-shipping-address .form-group:first').before(this);
 	}
 });


### PR DESCRIPTION
- Scenario 1 (register):

If '$('#account .form-group').length' or '$('#address .form-group').length' is equal to '$(this).attr('data-sort')'

Result: hidden  custom field

- Scenario 2 (new address):

If '$('#collapse-payment-address .form-group').length' or '$('#collapse-shipping-address .form-group').length' is equal to '$(this).attr('data-sort')'

Result: hidden custom field

- Scenario 3 (new address):

There are the firstname and lastname fields, these fields are added to '$('#* .form-group').length'

Result: custom field data-sort error position