### PR TITLE
Dynamicly add admin main menu through Event

### DIFF
--- a/upload/admin/controller/common/menu.php
+++ b/upload/admin/controller/common/menu.php
@@ -3,211 +3,510 @@ class ControllerCommonMenu extends Controller {
 	public function index() {
 		$this->load->language('common/menu');
 
-		$data['text_analytics'] = $this->language->get('text_analytics');
-		$data['text_affiliate'] = $this->language->get('text_affiliate');
-		$data['text_api'] = $this->language->get('text_api');
-		$data['text_attribute'] = $this->language->get('text_attribute');
-		$data['text_attribute_group'] = $this->language->get('text_attribute_group');
-		$data['text_backup'] = $this->language->get('text_backup');
-		$data['text_banner'] = $this->language->get('text_banner');
-		$data['text_captcha'] = $this->language->get('text_captcha');
-		$data['text_catalog'] = $this->language->get('text_catalog');
-		$data['text_category'] = $this->language->get('text_category');
-		$data['text_confirm'] = $this->language->get('text_confirm');
-		$data['text_contact'] = $this->language->get('text_contact');
-		$data['text_country'] = $this->language->get('text_country');
-		$data['text_coupon'] = $this->language->get('text_coupon');
-		$data['text_currency'] = $this->language->get('text_currency');
-		$data['text_customer'] = $this->language->get('text_customer');
-		$data['text_customer_group'] = $this->language->get('text_customer_group');
-		$data['text_customer_field'] = $this->language->get('text_customer_field');
-		$data['text_custom_field'] = $this->language->get('text_custom_field');
-		$data['text_sale'] = $this->language->get('text_sale');
-		$data['text_paypal'] = $this->language->get('text_paypal');
-		$data['text_paypal_search'] = $this->language->get('text_paypal_search');
-		$data['text_design'] = $this->language->get('text_design');
-		$data['text_download'] = $this->language->get('text_download');
-		$data['text_error_log'] = $this->language->get('text_error_log');
-		$data['text_extension'] = $this->language->get('text_extension');
-		$data['text_feed'] = $this->language->get('text_feed');
-		$data['text_fraud'] = $this->language->get('text_fraud');
-		$data['text_filter'] = $this->language->get('text_filter');
-		$data['text_geo_zone'] = $this->language->get('text_geo_zone');
-		$data['text_dashboard'] = $this->language->get('text_dashboard');
-		$data['text_help'] = $this->language->get('text_help');
-		$data['text_information'] = $this->language->get('text_information');
-		$data['text_installer'] = $this->language->get('text_installer');
-		$data['text_language'] = $this->language->get('text_language');
-		$data['text_layout'] = $this->language->get('text_layout');
-		$data['text_localisation'] = $this->language->get('text_localisation');
-		$data['text_location'] = $this->language->get('text_location');
-		$data['text_marketing'] = $this->language->get('text_marketing');
-		$data['text_modification'] = $this->language->get('text_modification');
-		$data['text_manufacturer'] = $this->language->get('text_manufacturer');
-		$data['text_module'] = $this->language->get('text_module');
-		$data['text_option'] = $this->language->get('text_option');
-		$data['text_order'] = $this->language->get('text_order');
-		$data['text_order_status'] = $this->language->get('text_order_status');
-		$data['text_opencart'] = $this->language->get('text_opencart');
-		$data['text_payment'] = $this->language->get('text_payment');
-		$data['text_product'] = $this->language->get('text_product');
-		$data['text_reports'] = $this->language->get('text_reports');
-		$data['text_report_sale_order'] = $this->language->get('text_report_sale_order');
-		$data['text_report_sale_tax'] = $this->language->get('text_report_sale_tax');
-		$data['text_report_sale_shipping'] = $this->language->get('text_report_sale_shipping');
-		$data['text_report_sale_return'] = $this->language->get('text_report_sale_return');
-		$data['text_report_sale_coupon'] = $this->language->get('text_report_sale_coupon');
-		$data['text_report_sale_return'] = $this->language->get('text_report_sale_return');
-		$data['text_report_product_viewed'] = $this->language->get('text_report_product_viewed');
-		$data['text_report_product_purchased'] = $this->language->get('text_report_product_purchased');
-		$data['text_report_customer_activity'] = $this->language->get('text_report_customer_activity');
-		$data['text_report_customer_online'] = $this->language->get('text_report_customer_online');
-		$data['text_report_customer_order'] = $this->language->get('text_report_customer_order');
-		$data['text_report_customer_reward'] = $this->language->get('text_report_customer_reward');
-		$data['text_report_customer_credit'] = $this->language->get('text_report_customer_credit');
-		$data['text_report_customer_order'] = $this->language->get('text_report_customer_order');
-		$data['text_report_affiliate'] = $this->language->get('text_report_affiliate');
-		$data['text_report_affiliate_activity'] = $this->language->get('text_report_affiliate_activity');
-		$data['text_review'] = $this->language->get('text_review');
-		$data['text_return'] = $this->language->get('text_return');
-		$data['text_return_action'] = $this->language->get('text_return_action');
-		$data['text_return_reason'] = $this->language->get('text_return_reason');
-		$data['text_return_status'] = $this->language->get('text_return_status');
-		$data['text_shipping'] = $this->language->get('text_shipping');
-		$data['text_setting'] = $this->language->get('text_setting');
-		$data['text_stock_status'] = $this->language->get('text_stock_status');
-		$data['text_system'] = $this->language->get('text_system');
-		$data['text_tax'] = $this->language->get('text_tax');
-		$data['text_tax_class'] = $this->language->get('text_tax_class');
-		$data['text_tax_rate'] = $this->language->get('text_tax_rate');
-		$data['text_theme'] = $this->language->get('text_theme');
-		$data['text_tools'] = $this->language->get('text_tools');
-		$data['text_total'] = $this->language->get('text_total');
-		$data['text_upload'] = $this->language->get('text_upload');
-		$data['text_tracking'] = $this->language->get('text_tracking');
-		$data['text_user'] = $this->language->get('text_user');
-		$data['text_user_group'] = $this->language->get('text_user_group');
-		$data['text_users'] = $this->language->get('text_users');
-		$data['text_voucher'] = $this->language->get('text_voucher');
-		$data['text_voucher_theme'] = $this->language->get('text_voucher_theme');
-		$data['text_weight_class'] = $this->language->get('text_weight_class');
-		$data['text_length_class'] = $this->language->get('text_length_class');
-		$data['text_zone'] = $this->language->get('text_zone');
-		$data['text_recurring'] = $this->language->get('text_recurring');
-		$data['text_order_recurring'] = $this->language->get('text_order_recurring');
-		$data['text_openbay_extension'] = $this->language->get('text_openbay_extension');
-		$data['text_openbay_dashboard'] = $this->language->get('text_openbay_dashboard');
-		$data['text_openbay_orders'] = $this->language->get('text_openbay_orders');
-		$data['text_openbay_items'] = $this->language->get('text_openbay_items');
-		$data['text_openbay_ebay'] = $this->language->get('text_openbay_ebay');
-		$data['text_openbay_etsy'] = $this->language->get('text_openbay_etsy');
-		$data['text_openbay_amazon'] = $this->language->get('text_openbay_amazon');
-		$data['text_openbay_amazonus'] = $this->language->get('text_openbay_amazonus');
-		$data['text_openbay_settings'] = $this->language->get('text_openbay_settings');
-		$data['text_openbay_links'] = $this->language->get('text_openbay_links');
-		$data['text_openbay_report_price'] = $this->language->get('text_openbay_report_price');
-		$data['text_openbay_order_import'] = $this->language->get('text_openbay_order_import');
+		$navigations = array();
 
-		$data['analytics'] = $this->url->link('extension/analytics', 'token=' . $this->session->data['token'], true);
-		$data['home'] = $this->url->link('common/dashboard', 'token=' . $this->session->data['token'], true);
-		$data['affiliate'] = $this->url->link('marketing/affiliate', 'token=' . $this->session->data['token'], true);
-		$data['api'] = $this->url->link('user/api', 'token=' . $this->session->data['token'], true);
-		$data['attribute'] = $this->url->link('catalog/attribute', 'token=' . $this->session->data['token'], true);
-		$data['attribute_group'] = $this->url->link('catalog/attribute_group', 'token=' . $this->session->data['token'], true);
-		$data['backup'] = $this->url->link('tool/backup', 'token=' . $this->session->data['token'], true);
-		$data['banner'] = $this->url->link('design/banner', 'token=' . $this->session->data['token'], true);
-		$data['captcha'] = $this->url->link('extension/captcha', 'token=' . $this->session->data['token'], true);
-		$data['category'] = $this->url->link('catalog/category', 'token=' . $this->session->data['token'], true);
-		$data['country'] = $this->url->link('localisation/country', 'token=' . $this->session->data['token'], true);
-		$data['contact'] = $this->url->link('marketing/contact', 'token=' . $this->session->data['token'], true);
-		$data['coupon'] = $this->url->link('marketing/coupon', 'token=' . $this->session->data['token'], true);
-		$data['currency'] = $this->url->link('localisation/currency', 'token=' . $this->session->data['token'], true);
-		$data['customer'] = $this->url->link('customer/customer', 'token=' . $this->session->data['token'], true);
-		$data['customer_fields'] = $this->url->link('customer/customer_field', 'token=' . $this->session->data['token'], true);
-		$data['customer_group'] = $this->url->link('customer/customer_group', 'token=' . $this->session->data['token'], true);
-		$data['custom_field'] = $this->url->link('customer/custom_field', 'token=' . $this->session->data['token'], true);
-		$data['download'] = $this->url->link('catalog/download', 'token=' . $this->session->data['token'], true);
-		$data['error_log'] = $this->url->link('tool/error_log', 'token=' . $this->session->data['token'], true);
-		$data['feed'] = $this->url->link('extension/feed', 'token=' . $this->session->data['token'], true);
-		$data['filter'] = $this->url->link('catalog/filter', 'token=' . $this->session->data['token'], true);
-		$data['fraud'] = $this->url->link('extension/fraud', 'token=' . $this->session->data['token'], true);
-		$data['geo_zone'] = $this->url->link('localisation/geo_zone', 'token=' . $this->session->data['token'], true);
-		$data['information'] = $this->url->link('catalog/information', 'token=' . $this->session->data['token'], true);
-		$data['installer'] = $this->url->link('extension/installer', 'token=' . $this->session->data['token'], true);
-		$data['language'] = $this->url->link('localisation/language', 'token=' . $this->session->data['token'], true);
-		$data['layout'] = $this->url->link('design/layout', 'token=' . $this->session->data['token'], true);
-		$data['location'] = $this->url->link('localisation/location', 'token=' . $this->session->data['token'], true);
-		$data['modification'] = $this->url->link('extension/modification', 'token=' . $this->session->data['token'], true);
-		$data['manufacturer'] = $this->url->link('catalog/manufacturer', 'token=' . $this->session->data['token'], true);
-		$data['marketing'] = $this->url->link('marketing/marketing', 'token=' . $this->session->data['token'], true);
-		$data['module'] = $this->url->link('extension/module', 'token=' . $this->session->data['token'], true);
-		$data['option'] = $this->url->link('catalog/option', 'token=' . $this->session->data['token'], true);
-		$data['order'] = $this->url->link('sale/order', 'token=' . $this->session->data['token'], true);
-		$data['order_status'] = $this->url->link('localisation/order_status', 'token=' . $this->session->data['token'], true);
-		$data['payment'] = $this->url->link('extension/payment', 'token=' . $this->session->data['token'], true);
-		$data['paypal_search'] = $this->url->link('payment/pp_express/search', 'token=' . $this->session->data['token'], true);
-		$data['product'] = $this->url->link('catalog/product', 'token=' . $this->session->data['token'], true);
-		$data['report_sale_order'] = $this->url->link('report/sale_order', 'token=' . $this->session->data['token'], true);
-		$data['report_sale_tax'] = $this->url->link('report/sale_tax', 'token=' . $this->session->data['token'], true);
-		$data['report_sale_shipping'] = $this->url->link('report/sale_shipping', 'token=' . $this->session->data['token'], true);
-		$data['report_sale_return'] = $this->url->link('report/sale_return', 'token=' . $this->session->data['token'], true);
-		$data['report_sale_coupon'] = $this->url->link('report/sale_coupon', 'token=' . $this->session->data['token'], true);
-		$data['report_product_viewed'] = $this->url->link('report/product_viewed', 'token=' . $this->session->data['token'], true);
-		$data['report_product_purchased'] = $this->url->link('report/product_purchased', 'token=' . $this->session->data['token'], true);
-		$data['report_customer_activity'] = $this->url->link('report/customer_activity', 'token=' . $this->session->data['token'], true);
-		$data['report_customer_online'] = $this->url->link('report/customer_online', 'token=' . $this->session->data['token'], true);
-		$data['report_customer_order'] = $this->url->link('report/customer_order', 'token=' . $this->session->data['token'], true);
-		$data['report_customer_reward'] = $this->url->link('report/customer_reward', 'token=' . $this->session->data['token'], true);
-		$data['report_customer_credit'] = $this->url->link('report/customer_credit', 'token=' . $this->session->data['token'], true);
-		$data['report_marketing'] = $this->url->link('report/marketing', 'token=' . $this->session->data['token'], true);
-		$data['report_affiliate'] = $this->url->link('report/affiliate', 'token=' . $this->session->data['token'], true);
-		$data['report_affiliate_activity'] = $this->url->link('report/affiliate_activity', 'token=' . $this->session->data['token'], true);
-		$data['review'] = $this->url->link('catalog/review', 'token=' . $this->session->data['token'], true);
-		$data['return'] = $this->url->link('sale/return', 'token=' . $this->session->data['token'], true);
-		$data['return_action'] = $this->url->link('localisation/return_action', 'token=' . $this->session->data['token'], true);
-		$data['return_reason'] = $this->url->link('localisation/return_reason', 'token=' . $this->session->data['token'], true);
-		$data['return_status'] = $this->url->link('localisation/return_status', 'token=' . $this->session->data['token'], true);
-		$data['shipping'] = $this->url->link('extension/shipping', 'token=' . $this->session->data['token'], true);
-		$data['setting'] = $this->url->link('setting/store', 'token=' . $this->session->data['token'], true);
-		$data['stock_status'] = $this->url->link('localisation/stock_status', 'token=' . $this->session->data['token'], true);
-		$data['tax_class'] = $this->url->link('localisation/tax_class', 'token=' . $this->session->data['token'], true);
-		$data['tax_rate'] = $this->url->link('localisation/tax_rate', 'token=' . $this->session->data['token'], true);
-		$data['theme'] = $this->url->link('extension/theme', 'token=' . $this->session->data['token'], true);
-		$data['total'] = $this->url->link('extension/total', 'token=' . $this->session->data['token'], true);
-		$data['upload'] = $this->url->link('tool/upload', 'token=' . $this->session->data['token'], true);
-		$data['user'] = $this->url->link('user/user', 'token=' . $this->session->data['token'], true);
-		$data['user_group'] = $this->url->link('user/user_permission', 'token=' . $this->session->data['token'], true);
-		$data['voucher'] = $this->url->link('sale/voucher', 'token=' . $this->session->data['token'], true);
-		$data['voucher_theme'] = $this->url->link('sale/voucher_theme', 'token=' . $this->session->data['token'], true);
-		$data['weight_class'] = $this->url->link('localisation/weight_class', 'token=' . $this->session->data['token'], true);
-		$data['length_class'] = $this->url->link('localisation/length_class', 'token=' . $this->session->data['token'], true);
-		$data['zone'] = $this->url->link('localisation/zone', 'token=' . $this->session->data['token'], true);
-		$data['recurring'] = $this->url->link('catalog/recurring', 'token=' . $this->session->data['token'], true);
-		$data['order_recurring'] = $this->url->link('sale/recurring', 'token=' . $this->session->data['token'], true);
-
-		$data['openbay_show_menu'] = $this->config->get('openbaypro_menu');
-		$data['openbay_link_extension'] = $this->url->link('extension/openbay', 'token=' . $this->session->data['token'], true);
-		$data['openbay_link_orders'] = $this->url->link('extension/openbay/orderlist', 'token=' . $this->session->data['token'], true);
-		$data['openbay_link_items'] = $this->url->link('extension/openbay/items', 'token=' . $this->session->data['token'], true);
-		$data['openbay_link_ebay'] = $this->url->link('openbay/ebay', 'token=' . $this->session->data['token'], true);
-		$data['openbay_link_ebay_settings'] = $this->url->link('openbay/ebay/settings', 'token=' . $this->session->data['token'], true);
-		$data['openbay_link_ebay_links'] = $this->url->link('openbay/ebay/viewitemlinks', 'token=' . $this->session->data['token'], true);
-		$data['openbay_link_etsy'] = $this->url->link('openbay/etsy', 'token=' . $this->session->data['token'], true);
-		$data['openbay_link_etsy_settings'] = $this->url->link('openbay/etsy/settings', 'token=' . $this->session->data['token'], true);
-		$data['openbay_link_etsy_links'] = $this->url->link('openbay/etsy_product/links', 'token=' . $this->session->data['token'], true);
-		$data['openbay_link_ebay_orderimport'] = $this->url->link('openbay/ebay/vieworderimport', 'token=' . $this->session->data['token'], true);
-		$data['openbay_link_amazon'] = $this->url->link('openbay/amazon', 'token=' . $this->session->data['token'], true);
-		$data['openbay_link_amazon_settings'] = $this->url->link('openbay/amazon/settings', 'token=' . $this->session->data['token'], true);
-		$data['openbay_link_amazon_links'] = $this->url->link('openbay/amazon/itemlinks', 'token=' . $this->session->data['token'], true);
-		$data['openbay_link_amazonus'] = $this->url->link('openbay/amazonus', 'token=' . $this->session->data['token'], true);
-		$data['openbay_link_amazonus_settings'] = $this->url->link('openbay/amazonus/settings', 'token=' . $this->session->data['token'], true);
-		$data['openbay_link_amazonus_links'] = $this->url->link('openbay/amazonus/itemlinks', 'token=' . $this->session->data['token'], true);
-		$data['openbay_markets'] = array(
-			'ebay' => $this->config->get('ebay_status'),
-			'amazon' => $this->config->get('openbay_amazon_status'),
-			'amazonus' => $this->config->get('openbay_amazonus_status'),
-			'etsy' => $this->config->get('etsy_status'),
+		$navigations[] = array(
+			'title'		=> $this->language->get('text_dashboard'),
+			'url'		=> $this->url->link('common/dashboard', 'token=' . $this->session->data['token'], true),
+			'id'		=> 'dashboard',
+			'icon'		=> 'dashboard'
 		);
+		$navigations['catalog'] = array(
+			'title'		=> $this->language->get('text_catalog'),
+			'url'		=> '',
+			'id'		=> 'catalog',
+			'class'		=> '',
+			'icon'		=> 'tags',
+			'child'		=> array()
+		);
+		$navigations['catalog']['child'][] = array(
+			'title'		=> $this->language->get('text_category'),
+			'url'		=> $this->url->link('catalog/category', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['catalog']['child'][] = array(
+			'title'		=> $this->language->get('text_product'),
+			'url'		=> $this->url->link('catalog/product', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['catalog']['child'][] = array(
+			'title'		=> $this->language->get('text_recurring'),
+			'url'		=> $this->url->link('catalog/recurring', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['catalog']['child'][] = array(
+			'title'		=> $this->language->get('text_filter'),
+			'url'		=> $this->url->link('catalog/filter', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['catalog']['child']['attribute'] = array(
+			'title'		=> $this->language->get('text_attribute'),
+			'child'		=> array()
+		);
+		$navigations['catalog']['child']['attribute']['child'][] = array(
+			'title'		=> $this->language->get('text_attribute'),
+			'url'		=> $this->url->link('catalog/attribute', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['catalog']['child']['attribute']['child'][] = array(
+			'title'		=> $this->language->get('text_attribute_group'),
+			'url'		=> $this->url->link('catalog/attribute_group', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['catalog']['child'][] = array(
+			'title'		=> $this->language->get('text_option'),
+			'url'		=> $this->url->link('catalog/option', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['catalog']['child'][] = array(
+			'title'		=> $this->language->get('text_manufacturer'),
+			'url'		=> $this->url->link('catalog/manufacturer', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['catalog']['child'][] = array(
+			'title'		=> $this->language->get('text_download'),
+			'url'		=> $this->url->link('catalog/download', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['catalog']['child'][] = array(
+			'title'		=> $this->language->get('text_review'),
+			'url'		=> $this->url->link('catalog/review', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['catalog']['child'][] = array(
+			'title'		=> $this->language->get('text_information'),
+			'url'		=> $this->url->link('catalog/information', 'token=' . $this->session->data['token'], true)
+		);
+
+		$navigations['extension'] = array(
+			'title'		=> $this->language->get('text_extension'),
+			'id'		=> 'catalog',
+			'icon'		=> 'puzzle-piece',
+			'child'		=> array()
+		);
+		$navigations['extension']['child'][] = array(
+			'title'		=> $this->language->get('text_installer'),
+			'url'		=> $this->url->link('extension/installer', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['extension']['child'][] = array(
+			'title'		=> $this->language->get('text_modification'),
+			'url'		=> $this->url->link('extension/modification', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['extension']['child'][] = array(
+			'title'		=> $this->language->get('text_theme'),
+			'url'		=> $this->url->link('extension/theme', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['extension']['child'][] = array(
+			'title'		=> $this->language->get('text_module'),
+			'url'		=> $this->url->link('extension/module', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['extension']['child'][] = array(
+			'title'		=> $this->language->get('text_payment'),
+			'url'		=> $this->url->link('extension/payment', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['extension']['child'][] = array(
+			'title'		=> $this->language->get('text_shipping'),
+			'url'		=> $this->url->link('extension/shipping', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['extension']['child'][] = array(
+			'title'		=> $this->language->get('text_total'),
+			'url'		=> $this->url->link('extension/total', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['extension']['child'][] = array(
+			'title'		=> $this->language->get('text_fraud'),
+			'url'		=> $this->url->link('extension/fraud', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['extension']['child'][] = array(
+			'title'		=> $this->language->get('text_analytics'),
+			'url'		=> $this->url->link('extension/analytics', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['extension']['child'][] = array(
+			'title'		=> $this->language->get('text_captcha'),
+			'url'		=> $this->url->link('extension/captcha', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['extension']['child'][] = array(
+			'title'		=> $this->language->get('text_feed'),
+			'url'		=> $this->url->link('extension/feed', 'token=' . $this->session->data['token'], true)
+		);
+		if ($this->config->get('openbaypro_menu')) {
+			$navigations['extension']['child']['openbay'] = array(
+				'title'		=> $this->language->get('text_openbay_extension'),
+				'child'		=> array()
+			);
+			$navigations['extension']['child']['openbay']['child'][] = array(
+				'title'		=> $this->language->get('text_openbay_dashboard'),
+				'url'		=> $this->url->link('extension/openbay', 'token=' . $this->session->data['token'], true)
+			);
+			$navigations['extension']['child']['openbay']['child'][] = array(
+				'title'		=> $this->language->get('text_openbay_orders'),
+				'url'		=> $this->url->link('extension/openbay/orderlist', 'token=' . $this->session->data['token'], true)
+			);
+			$navigations['extension']['child']['openbay']['child'][] = array(
+				'title'		=> $this->language->get('text_openbay_items'),
+				'url'		=> $this->url->link('extension/openbay/items', 'token=' . $this->session->data['token'], true)
+			);
+			if ($this->config->get('ebay_status')) {
+				$navigations['extension']['child']['openbay']['child']['ebay'] = array(
+					'title'		=> $this->language->get('text_openbay_ebay'),
+					'child'		=> array()
+				);
+				$navigations['extension']['child']['openbay']['child']['ebay']['child'][] = array(
+					'title'		=> $this->language->get('text_openbay_dashboard'),
+					'url'		=> $this->url->link('openbay/ebay', 'token=' . $this->session->data['token'], true)
+				);
+				$navigations['extension']['child']['openbay']['child']['ebay']['child'][] = array(
+					'title'		=> $this->language->get('text_openbay_settings'),
+					'url'		=> $this->url->link('openbay/ebay/settings', 'token=' . $this->session->data['token'], true)
+				);
+				$navigations['extension']['child']['openbay']['child']['ebay']['child'][] = array(
+					'title'		=> $this->language->get('text_openbay_links'),
+					'url'		=> $this->url->link('openbay/ebay/viewitemlinks', 'token=' . $this->session->data['token'], true)
+				);
+				$navigations['extension']['child']['openbay']['child']['ebay']['child'][] = array(
+					'title'		=> $this->language->get('text_openbay_order_import'),
+					'url'		=> $this->url->link('openbay/ebay/vieworderimport', 'token=' . $this->session->data['token'], true)
+				);
+			}
+			if ($this->config->get('openbay_amazon_status')) {
+				$navigations['extension']['child']['openbay']['child']['amazon'] = array(
+					'title'		=> $this->language->get('text_openbay_amazon'),
+					'child'		=> array()
+				);
+				$navigations['extension']['child']['openbay']['child']['amazon']['child'][] = array(
+					'title'		=> $this->language->get('text_openbay_dashboard'),
+					'url'		=> $this->url->link('openbay/amazon', 'token=' . $this->session->data['token'], true)
+				);
+				$navigations['extension']['child']['openbay']['child']['amazon']['child'][] = array(
+					'title'		=> $this->language->get('text_openbay_settings'),
+					'url'		=> $this->url->link('openbay/amazon/settings', 'token=' . $this->session->data['token'], true)
+				);
+				$navigations['extension']['child']['openbay']['child']['amazon']['child'][] = array(
+					'title'		=> $this->language->get('text_openbay_links'),
+					'url'		=> $this->url->link('openbay/amazon/itemlinks', 'token=' . $this->session->data['token'], true)
+				);
+			}
+			if ($this->config->get('openbay_amazonus_status')) {
+				$navigations['extension']['child']['openbay']['child']['amazonus'] = array(
+					'title'		=> $this->language->get('text_openbay_amazonus'),
+					'child'		=> array()
+				);
+				$navigations['extension']['child']['openbay']['child']['amazonus']['child'][] = array(
+					'title'		=> $this->language->get('text_openbay_dashboard'),
+					'url'		=> $this->url->link('openbay/amazonus', 'token=' . $this->session->data['token'], true)
+				);
+				$navigations['extension']['child']['openbay']['child']['amazonus']['child'][] = array(
+					'title'		=> $this->language->get('text_openbay_settings'),
+					'url'		=> $this->url->link('openbay/amazonus/settings', 'token=' . $this->session->data['token'], true)
+				);
+				$navigations['extension']['child']['openbay']['child']['amazonus']['child'][] = array(
+					'title'		=> $this->language->get('text_openbay_links'),
+					'url'		=> $this->url->link('openbay/amazonus/itemlinks', 'token=' . $this->session->data['token'], true)
+				);
+			}
+			if ($this->config->get('etsy_status')) {
+				$navigations['extension']['child']['openbay']['child']['etsy'] = array(
+					'title'		=> $this->language->get('text_openbay_etsy'),
+					'child'		=> array()
+				);
+				$navigations['extension']['child']['openbay']['child']['etsy']['child'][] = array(
+					'title'		=> $this->language->get('text_openbay_dashboard'),
+					'url'		=> $this->url->link('openbay/etsy', 'token=' . $this->session->data['token'], true)
+				);
+				$navigations['extension']['child']['openbay']['child']['etsy']['child'][] = array(
+					'title'		=> $this->language->get('text_openbay_settings'),
+					'url'		=> $this->url->link('openbay/etsy/settings', 'token=' . $this->session->data['token'], true)
+				);
+				$navigations['extension']['child']['openbay']['child']['etsy']['child'][] = array(
+					'title'		=> $this->language->get('text_openbay_links'),
+					'url'		=> $this->url->link('openbay/etsy/itemlinks', 'token=' . $this->session->data['token'], true)
+				);
+			}
+		}
+
+		$navigations['design'] = array(
+			'title'		=> $this->language->get('text_design'),
+			'id'		=> 'design',
+			'icon'		=> 'television',
+			'child'		=> array()
+		);
+		$navigations['design']['child'][] = array(
+			'title'		=> $this->language->get('text_layout'),
+			'url'		=> $this->url->link('design/layout', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['design']['child'][] = array(
+			'title'		=> $this->language->get('text_banner'),
+			'url'		=> $this->url->link('design/banner', 'token=' . $this->session->data['token'], true)
+		);
+
+		$navigations['sale'] = array(
+			'title'		=> $this->language->get('text_sale'),
+			'id'		=> 'sale',
+			'icon'		=> 'shopping-cart',
+			'child'		=> array()
+		);
+		$navigations['sale']['child'][] = array(
+			'title'		=> $this->language->get('text_order'),
+			'url'		=> $this->url->link('sale/order', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['sale']['child'][] = array(
+			'title'		=> $this->language->get('text_recurring'),
+			'url'		=> $this->url->link('sale/recurring', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['sale']['child'][] = array(
+			'title'		=> $this->language->get('text_return'),
+			'url'		=> $this->url->link('sale/return', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['sale']['child']['voucher'] = array(
+			'title'		=> $this->language->get('text_return'),
+			'child'		=> array()
+		);
+		$navigations['sale']['child']['voucher']['child'][] = array(
+			'title'		=> $this->language->get('text_voucher'),
+			'url'		=> $this->url->link('sale/voucher', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['sale']['child']['voucher']['child'][] = array(
+			'title'		=> $this->language->get('text_voucher_theme'),
+			'url'		=> $this->url->link('sale/voucher_theme', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['sale']['child']['paypal'] = array(
+			'title'		=> $this->language->get('text_paypal'),
+			'child'		=> array()
+		);
+		$navigations['sale']['child']['paypal']['child'][] = array(
+			'title'		=> $this->language->get('text_paypal_search'),
+			'url'		=> $this->url->link('payment/pp_express/search', 'token=' . $this->session->data['token'], true)
+		);
+
+		$navigations['customer'] = array(
+			'title'		=> $this->language->get('text_customer'),
+			'id'		=> 'customer',
+			'icon'		=> 'user',
+			'child'		=> array()
+		);
+		$navigations['customer']['child'][] = array(
+			'title'		=> $this->language->get('text_customer'),
+			'url'		=> $this->url->link('customer/customer_group', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['customer']['child'][] = array(
+			'title'		=> $this->language->get('text_customer_group'),
+			'url'		=> $this->url->link('customer/customer_group', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['customer']['child'][] = array(
+			'title'		=> $this->language->get('text_custom_field'),
+			'url'		=> $this->url->link('customer/custom_field', 'token=' . $this->session->data['token'], true)
+		);
+
+		$navigations['marketing'] = array(
+			'title'		=> $this->language->get('text_marketing'),
+			'id'		=> 'marketing',
+			'icon'		=> 'share-alt',
+			'child'		=> array()
+		);
+		$navigations['marketing']['child'][] = array(
+			'title'		=> $this->language->get('text_marketing'),
+			'url'		=> $this->url->link('marketing/marketing', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['marketing']['child'][] = array(
+			'title'		=> $this->language->get('text_affiliate'),
+			'url'		=> $this->url->link('marketing/affiliate', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['marketing']['child'][] = array(
+			'title'		=> $this->language->get('text_coupon'),
+			'url'		=> $this->url->link('marketing/coupon', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['marketing']['child'][] = array(
+			'title'		=> $this->language->get('text_contact'),
+			'url'		=> $this->url->link('marketing/contact', 'token=' . $this->session->data['token'], true)
+		);
+
+		$navigations['system'] = array(
+			'title'		=> $this->language->get('text_system'),
+			'id'		=> 'system',
+			'icon'		=> 'cog',
+			'child'		=> array()
+		);
+		$navigations['system']['child'][] = array(
+			'title'		=> $this->language->get('text_setting'),
+			'url'		=> $this->url->link('setting/store', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['system']['child']['users'] = array(
+			'title'		=> $this->language->get('text_users'),
+			'child'		=> array()
+		);
+		$navigations['system']['child']['users']['child'][] = array(
+			'title'		=> $this->language->get('text_user'),
+			'url'		=> $this->url->link('user/user', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['system']['child']['users']['child'][] = array(
+			'title'		=> $this->language->get('text_user_group'),
+			'url'		=> $this->url->link('user/user_permission', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['system']['child']['users']['child'][] = array(
+			'title'		=> $this->language->get('text_api'),
+			'url'		=> $this->url->link('user/api', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['system']['child']['localisation'] = array(
+			'title'		=> $this->language->get('text_localisation'),
+			'child'		=> array()
+		);
+		$navigations['system']['child']['localisation']['child'][] = array(
+			'title'		=> $this->language->get('text_location'),
+			'url'		=> $this->url->link('localisation/location', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['system']['child']['localisation']['child'][] = array(
+			'title'		=> $this->language->get('text_language'),
+			'url'		=> $this->url->link('localisation/language', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['system']['child']['localisation']['child'][] = array(
+			'title'		=> $this->language->get('text_currency'),
+			'url'		=> $this->url->link('localisation/currency', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['system']['child']['localisation']['child'][] = array(
+			'title'		=> $this->language->get('text_stock_status'),
+			'url'		=> $this->url->link('localisation/stock_status', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['system']['child']['localisation']['child'][] = array(
+			'title'		=> $this->language->get('text_order_status'),
+			'url'		=> $this->url->link('localisation/order_status', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['system']['child']['localisation']['child']['return'] = array(
+			'title'		=> $this->language->get('text_return'),
+			'child'		=> array()
+		);
+		$navigations['system']['child']['localisation']['child']['return']['child'][] = array(
+			'title'		=> $this->language->get('text_return_status'),
+			'url'		=> $this->url->link('localisation/return_status', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['system']['child']['localisation']['child']['return']['child'][] = array(
+			'title'		=> $this->language->get('text_return_action'),
+			'url'		=> $this->url->link('localisation/return_action', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['system']['child']['localisation']['child']['return']['child'][] = array(
+			'title'		=> $this->language->get('text_return_reason'),
+			'url'		=> $this->url->link('localisation/return_reason', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['system']['child']['localisation']['child'][] = array(
+			'title'		=> $this->language->get('text_country'),
+			'url'		=> $this->url->link('localisation/country', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['system']['child']['localisation']['child'][] = array(
+			'title'		=> $this->language->get('text_zone'),
+			'url'		=> $this->url->link('localisation/zone', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['system']['child']['localisation']['child'][] = array(
+			'title'		=> $this->language->get('text_geo_zone'),
+			'url'		=> $this->url->link('localisation/geo_zone', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['system']['child']['localisation']['child']['tax'] = array(
+			'title'		=> $this->language->get('text_tax'),
+			'child'		=> array()
+		);
+		$navigations['system']['child']['localisation']['child']['tax']['child'][] = array(
+			'title'		=> $this->language->get('text_tax_class'),
+			'url'		=> $this->url->link('localisation/tax_class', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['system']['child']['localisation']['child']['tax']['child'][] = array(
+			'title'		=> $this->language->get('text_tax_rate'),
+			'url'		=> $this->url->link('localisation/tax_rate', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['system']['child']['localisation']['child'][] = array(
+			'title'		=> $this->language->get('text_length_class'),
+			'url'		=> $this->url->link('localisation/length_class', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['system']['child']['localisation']['child'][] = array(
+			'title'		=> $this->language->get('text_weight_class'),
+			'url'		=> $this->url->link('localisation/weight_class', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['system']['child']['tools'] = array(
+			'title'		=> $this->language->get('text_tools'),
+			'child'		=> array()
+		);
+		$navigations['system']['child']['tools']['child'][] = array(
+			'title'		=> $this->language->get('text_upload'),
+			'url'		=> $this->url->link('tool/upload', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['system']['child']['tools']['child'][] = array(
+			'title'		=> $this->language->get('text_backup'),
+			'url'		=> $this->url->link('tool/backup', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['system']['child']['tools']['child'][] = array(
+			'title'		=> $this->language->get('text_error_log'),
+			'url'		=> $this->url->link('tool/error_log', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['report'] = array(
+			'title'		=> $this->language->get('text_reports'),
+			'id'		=> 'reports',
+			'icon'		=> 'bar-chart',
+			'child'		=> array()
+		);
+		$navigations['report']['child']['sale'] = array(
+			'title'		=> $this->language->get('text_sale'),
+			'child'		=> array()
+		);
+		$navigations['report']['child']['sale']['child'][] = array(
+			'title'		=> $this->language->get('text_report_sale_order'),
+			'url'		=> $this->url->link('report/sale_order', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['report']['child']['sale']['child'][] = array(
+			'title'		=> $this->language->get('text_report_sale_tax'),
+			'url'		=> $this->url->link('report/sale_tax', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['report']['child']['sale']['child'][] = array(
+			'title'		=> $this->language->get('text_report_sale_shipping'),
+			'url'		=> $this->url->link('report/sale_shipping', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['report']['child']['sale']['child'][] = array(
+			'title'		=> $this->language->get('text_report_sale_return'),
+			'url'		=> $this->url->link('report/sale_return', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['report']['child']['sale']['child'][] = array(
+			'title'		=> $this->language->get('text_report_sale_coupon'),
+			'url'		=> $this->url->link('report/sale_coupon', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['report']['child']['product'] = array(
+			'title'		=> $this->language->get('text_product'),
+			'child'		=> array()
+		);
+		$navigations['report']['child']['product']['child'][] = array(
+			'title'		=> $this->language->get('text_report_product_viewed'),
+			'url'		=> $this->url->link('report/product_viewed', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['report']['child']['product']['child'][] = array(
+			'title'		=> $this->language->get('text_report_product_purchased'),
+			'url'		=> $this->url->link('report/product_purchased', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['report']['child']['customer'] = array(
+			'title'		=> $this->language->get('text_customer'),
+			'child'		=> array()
+		);
+		$navigations['report']['child']['customer']['child'][] = array(
+			'title'		=> $this->language->get('text_report_customer_online'),
+			'url'		=> $this->url->link('report/customer_online', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['report']['child']['customer']['child'][] = array(
+			'title'		=> $this->language->get('text_report_customer_activity'),
+			'url'		=> $this->url->link('report/customer_activity', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['report']['child']['customer']['child'][] = array(
+			'title'		=> $this->language->get('text_report_customer_order'),
+			'url'		=> $this->url->link('report/customer_order', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['report']['child']['customer']['child'][] = array(
+			'title'		=> $this->language->get('text_report_customer_reward'),
+			'url'		=> $this->url->link('report/customer_reward', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['report']['child']['customer']['child'][] = array(
+			'title'		=> $this->language->get('text_report_customer_credit'),
+			'url'		=> $this->url->link('report/customer_credit', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['report']['child']['marketing'] = array(
+			'title'		=> $this->language->get('text_marketing'),
+			'child'		=> array()
+		);
+		$navigations['report']['child']['marketing']['child'][] = array(
+			'title'		=> $this->language->get('text_marketing'),
+			'url'		=> $this->url->link('report/marketing', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['report']['child']['marketing']['child'][] = array(
+			'title'		=> $this->language->get('text_report_affiliate'),
+			'url'		=> $this->url->link('report/affiliate', 'token=' . $this->session->data['token'], true)
+		);
+		$navigations['report']['child']['marketing']['child'][] = array(
+			'title'		=> $this->language->get('text_report_affiliate_activity'),
+			'url'		=> $this->url->link('report/affiliate_activity', 'token=' . $this->session->data['token'], true)
+		);
+
+		$data['navigations'] = $navigations;
 
 		return $this->load->view('common/menu', $data);
 	}

--- a/upload/admin/view/template/common/menu.tpl
+++ b/upload/admin/view/template/common/menu.tpl
@@ -1,203 +1,86 @@
 <ul id="menu">
-  <li id="dashboard"><a href="<?php echo $home; ?>"><i class="fa fa-dashboard fa-fw"></i> <span><?php echo $text_dashboard; ?></span></a></li>
-  <li id="catalog"><a class="parent"><i class="fa fa-tags fa-fw"></i> <span><?php echo $text_catalog; ?></span></a>
-    <ul>
-      <li><a href="<?php echo $category; ?>"><?php echo $text_category; ?></a></li>
-      <li><a href="<?php echo $product; ?>"><?php echo $text_product; ?></a></li>
-      <li><a href="<?php echo $recurring; ?>"><?php echo $text_recurring; ?></a></li>
-      <li><a href="<?php echo $filter; ?>"><?php echo $text_filter; ?></a></li>
-      <li><a class="parent"><?php echo $text_attribute; ?></a>
-        <ul>
-          <li><a href="<?php echo $attribute; ?>"><?php echo $text_attribute; ?></a></li>
-          <li><a href="<?php echo $attribute_group; ?>"><?php echo $text_attribute_group; ?></a></li>
-        </ul>
-      </li>
-      <li><a href="<?php echo $option; ?>"><?php echo $text_option; ?></a></li>
-      <li><a href="<?php echo $manufacturer; ?>"><?php echo $text_manufacturer; ?></a></li>
-      <li><a href="<?php echo $download; ?>"><?php echo $text_download; ?></a></li>
-      <li><a href="<?php echo $review; ?>"><?php echo $text_review; ?></a></li>
-      <li><a href="<?php echo $information; ?>"><?php echo $text_information; ?></a></li>
-    </ul>
-  </li>
-  <li id="extension"><a class="parent"><i class="fa fa-puzzle-piece fa-fw"></i> <span><?php echo $text_extension; ?></span></a>
-    <ul>
-      <li><a href="<?php echo $installer; ?>"><?php echo $text_installer; ?></a></li>
-      <li><a href="<?php echo $modification; ?>"><?php echo $text_modification; ?></a></li>
-      <li><a href="<?php echo $theme; ?>"><?php echo $text_theme; ?></a></li>
-      <li><a href="<?php echo $analytics; ?>"><?php echo $text_analytics; ?></a></li>
-      <li><a href="<?php echo $captcha; ?>"><?php echo $text_captcha; ?></a></li>
-      <li><a href="<?php echo $feed; ?>"><?php echo $text_feed; ?></a></li>
-      <li><a href="<?php echo $fraud; ?>"><?php echo $text_fraud; ?></a></li>
-      <li><a href="<?php echo $module; ?>"><?php echo $text_module; ?></a></li>
-      <li><a href="<?php echo $payment; ?>"><?php echo $text_payment; ?></a></li>
-      <li><a href="<?php echo $shipping; ?>"><?php echo $text_shipping; ?></a></li>
-      <li><a href="<?php echo $total; ?>"><?php echo $text_total; ?></a></li>
-      <?php if ($openbay_show_menu == 1) { ?>
-      <li><a class="parent"><?php echo $text_openbay_extension; ?></a>
-        <ul>
-          <li><a href="<?php echo $openbay_link_extension; ?>"><?php echo $text_openbay_dashboard; ?></a></li>
-          <li><a href="<?php echo $openbay_link_orders; ?>"><?php echo $text_openbay_orders; ?></a></li>
-          <li><a href="<?php echo $openbay_link_items; ?>"><?php echo $text_openbay_items; ?></a></li>
-          <?php if ($openbay_markets['ebay'] == 1) { ?>
-          <li><a class="parent"><?php echo $text_openbay_ebay; ?></a>
-            <ul>
-              <li><a href="<?php echo $openbay_link_ebay; ?>"><?php echo $text_openbay_dashboard; ?></a></li>
-              <li><a href="<?php echo $openbay_link_ebay_settings; ?>"><?php echo $text_openbay_settings; ?></a></li>
-              <li><a href="<?php echo $openbay_link_ebay_links; ?>"><?php echo $text_openbay_links; ?></a></li>
-              <li><a href="<?php echo $openbay_link_ebay_orderimport; ?>"><?php echo $text_openbay_order_import; ?></a></li>
-            </ul>
-          </li>
-          <?php } ?>
-          <?php if ($openbay_markets['amazon'] == 1) { ?>
-          <li><a class="parent"><?php echo $text_openbay_amazon; ?></a>
-            <ul>
-              <li><a href="<?php echo $openbay_link_amazon; ?>"><?php echo $text_openbay_dashboard; ?></a></li>
-              <li><a href="<?php echo $openbay_link_amazon_settings; ?>"><?php echo $text_openbay_settings; ?></a></li>
-              <li><a href="<?php echo $openbay_link_amazon_links; ?>"><?php echo $text_openbay_links; ?></a></li>
-            </ul>
-          </li>
-          <?php } ?>
-          <?php if ($openbay_markets['amazonus'] == 1) { ?>
-          <li><a class="parent"><?php echo $text_openbay_amazonus; ?></a>
-            <ul>
-              <li><a href="<?php echo $openbay_link_amazonus; ?>"><?php echo $text_openbay_dashboard; ?></a></li>
-              <li><a href="<?php echo $openbay_link_amazonus_settings; ?>"><?php echo $text_openbay_settings; ?></a></li>
-              <li><a href="<?php echo $openbay_link_amazonus_links; ?>"><?php echo $text_openbay_links; ?></a></li>
-            </ul>
-          </li>
-          <?php } ?>
-          <?php if ($openbay_markets['etsy'] == 1) { ?>
-          <li><a class="parent"><?php echo $text_openbay_etsy; ?></a>
-            <ul>
-              <li><a href="<?php echo $openbay_link_etsy; ?>"><?php echo $text_openbay_dashboard; ?></a></li>
-              <li><a href="<?php echo $openbay_link_etsy_settings; ?>"><?php echo $text_openbay_settings; ?></a></li>
-              <li><a href="<?php echo $openbay_link_etsy_links; ?>"><?php echo $text_openbay_links; ?></a></li>
-            </ul>
-          </li>
-          <?php } ?>
-        </ul>
-      </li>
+  <?php foreach ($navigations as $nav) { ?>
+    <li id="<?php echo !empty($nav['id']) ? $nav['id'] : ''; ?>">
+      <?php if (!empty($nav['icon'])) { ?>
+        <a <?php echo !empty($nav['url']) ? 'href="' . $nav['url'] . '"' : ''; ?> class="<?php echo !empty($nav['child']) ? 'parent' : ''; ?> <?php echo !empty($nav['class']) ? $nav['class'] : ''; ?>"><i class="fa fa-<?php echo $nav['icon']; ?> fa-fw"></i> <span><?php echo $nav['title']; ?></span></a>
+      <?php } else { ?>
+        <a <?php echo !empty($nav['url']) ? 'href="' . $nav['url'] . '"' : ''; ?> class="<?php echo !empty($nav['child']) ? 'parent' : ''; ?> <?php echo !empty($nav['class']) ? $nav['class'] : ''; ?>"><?php echo $nav['title']; ?></a>
       <?php } ?>
-    </ul>
-  </li>
-  <li id="design"><a class="parent"><i class="fa fa-television fa-fw"></i> <span><?php echo $text_design; ?></span></a>
-    <ul>
-      <li><a href="<?php echo $layout; ?>"><?php echo $text_layout; ?></a></li>
-      <li><a href="<?php echo $banner; ?>"><?php echo $text_banner; ?></a></li>
-    </ul>
-  </li>
-  <li id="sale"><a class="parent"><i class="fa fa-shopping-cart fa-fw"></i> <span><?php echo $text_sale; ?></span></a>
-    <ul>
-      <li><a href="<?php echo $order; ?>"><?php echo $text_order; ?></a></li>
-      <li><a href="<?php echo $order_recurring; ?>"><?php echo $text_order_recurring; ?></a></li>
-      <li><a href="<?php echo $return; ?>"><?php echo $text_return; ?></a></li>
-      <li><a class="parent"><?php echo $text_voucher; ?></a>
+
+      <?php if (!empty($nav['child'])) { ?>
         <ul>
-          <li><a href="<?php echo $voucher; ?>"><?php echo $text_voucher; ?></a></li>
-          <li><a href="<?php echo $voucher_theme; ?>"><?php echo $text_voucher_theme; ?></a></li>
+          <?php foreach ($nav['child'] as $subnav) { ?>
+            <li id="<?php echo !empty($subnav['id']) ? $subnav['id'] : ''; ?>">
+              <?php if (!empty($subnav['icon'])) { ?>
+                <a <?php echo !empty($subnav['url']) ? 'href="' . $subnav['url'] . '"' : ''; ?> class="<?php echo !empty($subnav['child']) ? 'parent' : ''; ?> <?php echo !empty($subnav['class']) ? $subnav['class'] : ''; ?>"><i class="fa fa-<?php echo $subnav['icon']; ?> fa-fw"></i> <span><?php echo $subnav['title']; ?></span></a>
+              <?php } else { ?>
+                <a <?php echo !empty($subnav['url']) ? 'href="' . $subnav['url'] . '"' : ''; ?> class="<?php echo !empty($subnav['child']) ? 'parent' : ''; ?> <?php echo !empty($subnav['class']) ? $subnav['class'] : ''; ?>"><?php echo $subnav['title']; ?></a>
+              <?php } ?>
+
+              <?php if (!empty($subnav['child'])) { ?>
+                <ul>
+                  <?php foreach ($subnav['child'] as $child) { ?>
+                    <li id="<?php echo !empty($child['id']) ? $child['id'] : ''; ?>">
+                      <?php if (!empty($child['icon'])) { ?>
+                        <a <?php echo !empty($child['url']) ? 'href="' . $child['url'] . '"' : ''; ?> class="<?php echo !empty($child['child']) ? 'parent' : ''; ?> <?php echo !empty($child['class']) ? $child['class'] : ''; ?>"><i class="fa fa-<?php echo $child['icon']; ?> fa-fw"></i> <span><?php echo $child['title']; ?></span></a>
+                      <?php } else { ?>
+                        <a <?php echo !empty($child['url']) ? 'href="' . $child['url'] . '"' : ''; ?> class="<?php echo !empty($child['child']) ? 'parent' : ''; ?> <?php echo !empty($child['class']) ? $child['class'] : ''; ?>"><?php echo $child['title']; ?></a>
+                      <?php } ?>
+
+                      <?php if (!empty($child['child'])) { ?>
+                        <ul>
+                          <?php foreach ($child['child'] as $subchild) { ?>
+                            <li id="<?php echo !empty($subchild['id']) ? $subchild['id'] : ''; ?>">
+                              <?php if (!empty($subchild['icon'])) { ?>
+                                <a <?php echo !empty($subchild['url']) ? 'href="' . $subchild['url'] . '"' : ''; ?> class="<?php echo !empty($subchild['child']) ? 'parent' : ''; ?> <?php echo !empty($subchild['class']) ? $subchild['class'] : ''; ?>"><i class="fa fa-<?php echo $subchild['icon']; ?> fa-fw"></i> <span><?php echo $subchild['title']; ?></span></a>
+                              <?php } else { ?>
+                                <a <?php echo !empty($subchild['url']) ? 'href="' . $subchild['url'] . '"' : ''; ?> class="<?php echo !empty($subchild['child']) ? 'parent' : ''; ?> <?php echo !empty($subchild['class']) ? $subchild['class'] : ''; ?>"><?php echo $subchild['title']; ?></a>
+                              <?php } ?>
+
+                              <?php if (!empty($subchild['child'])) { ?>
+                                <ul>
+                                  <?php foreach ($subchild['child'] as $grandchild) { ?>
+                                    <li id="<?php echo !empty($grandchild['id']) ? $grandchild['id'] : ''; ?>">
+                                      <?php if (!empty($grandchild['icon'])) { ?>
+                                        <a <?php echo !empty($grandchild['url']) ? 'href="' . $grandchild['url'] . '"' : ''; ?> class="<?php echo !empty($grandchild['class']) ? $grandchild['class'] : ''; ?>"><i class="fa fa-<?php echo $grandchild['icon']; ?> fa-fw"></i> <span><?php echo $grandchild['title']; ?></span></a>
+                                      <?php } else { ?>
+                                        <a <?php echo !empty($grandchild['url']) ? 'href="' . $grandchild['url'] . '"' : ''; ?> class="<?php echo !empty($grandchild['class']) ? $grandchild['class'] : ''; ?>"><?php echo $grandchild['title']; ?></a>
+                                      <?php } ?>
+
+                                      <?php if (!empty($grandchild['child'])) { ?>
+                                        <ul>
+                                          <?php foreach ($grandchild['child'] as $subgrandchild) { ?>
+                                            <li id="<?php echo !empty($subgrandchild['id']) ? $subgrandchild['id'] : ''; ?>">
+                                              <?php if (!empty($subgrandchild['icon'])) { ?>
+                                                <a <?php echo !empty($subgrandchild['url']) ? 'href="' . $subgrandchild['url'] . '"' : ''; ?> class="<?php echo !empty($subgrandchild['class']) ? $subgrandchild['class'] : ''; ?>"><i class="fa fa-<?php echo $grandchild['icon']; ?> fa-fw"></i> <span><?php echo $subgrandchild['title']; ?></span></a>
+                                              <?php } else { ?>
+                                                <a <?php echo !empty($subgrandchild['url']) ? 'href="' . $subgrandchild['url'] . '"' : ''; ?> class="<?php echo !empty($subgrandchild['class']) ? $subgrandchild['class'] : ''; ?>"><?php echo $subgrandchild['title']; ?></a>
+                                              <?php } ?>
+                                            </li>
+                                          <?php } ?>
+                                        </ul>
+                                      <?php } ?>
+
+                                    </li>
+                                  <?php } ?>
+                                </ul>
+                              <?php } ?>
+
+                            </li>
+                          <?php } ?>
+                        </ul>
+                      <?php } ?>
+
+                    </li>
+                  <?php } ?>
+                </ul>
+              <?php } ?>
+
+            </li>
+          <?php } ?>
         </ul>
-      </li>
-      <li><a class="parent"><?php echo $text_paypal ?></a>
-        <ul>
-          <li><a href="<?php echo $paypal_search ?>"><?php echo $text_paypal_search ?></a></li>
-        </ul>
-      </li>
-    </ul>
-  </li>
-  <li id="customer"><a class="parent"><i class="fa fa-user fa-fw"></i> <span><?php echo $text_customer; ?></span></a>
-    <ul>
-      <li><a href="<?php echo $customer; ?>"><?php echo $text_customer; ?></a></li>
-      <li><a href="<?php echo $customer_group; ?>"><?php echo $text_customer_group; ?></a></li>
-      <li><a href="<?php echo $custom_field; ?>"><?php echo $text_custom_field; ?></a></li>
-    </ul>
-  </li>
-  <li><a class="parent"><i class="fa fa-share-alt fa-fw"></i> <span><?php echo $text_marketing; ?></span></a>
-    <ul>
-      <li><a href="<?php echo $marketing; ?>"><?php echo $text_marketing; ?></a></li>
-      <li><a href="<?php echo $affiliate; ?>"><?php echo $text_affiliate; ?></a></li>
-      <li><a href="<?php echo $coupon; ?>"><?php echo $text_coupon; ?></a></li>
-      <li><a href="<?php echo $contact; ?>"><?php echo $text_contact; ?></a></li>
-    </ul>
-  </li>
-  <li id="system"><a class="parent"><i class="fa fa-cog fa-fw"></i> <span><?php echo $text_system; ?></span></a>
-    <ul>
-      <li><a href="<?php echo $setting; ?>"><?php echo $text_setting; ?></a></li>
-      <li><a class="parent"><?php echo $text_users; ?></a>
-        <ul>
-          <li><a href="<?php echo $user; ?>"><?php echo $text_user; ?></a></li>
-          <li><a href="<?php echo $user_group; ?>"><?php echo $text_user_group; ?></a></li>
-          <li><a href="<?php echo $api; ?>"><?php echo $text_api; ?></a></li>
-        </ul>
-      </li>
-      <li><a class="parent"><?php echo $text_localisation; ?></a>
-        <ul>
-          <li><a href="<?php echo $location; ?>"><?php echo $text_location; ?></a></li>
-          <li><a href="<?php echo $language; ?>"><?php echo $text_language; ?></a></li>
-          <li><a href="<?php echo $currency; ?>"><?php echo $text_currency; ?></a></li>
-          <li><a href="<?php echo $stock_status; ?>"><?php echo $text_stock_status; ?></a></li>
-          <li><a href="<?php echo $order_status; ?>"><?php echo $text_order_status; ?></a></li>
-          <li><a class="parent"><?php echo $text_return; ?></a>
-            <ul>
-              <li><a href="<?php echo $return_status; ?>"><?php echo $text_return_status; ?></a></li>
-              <li><a href="<?php echo $return_action; ?>"><?php echo $text_return_action; ?></a></li>
-              <li><a href="<?php echo $return_reason; ?>"><?php echo $text_return_reason; ?></a></li>
-            </ul>
-          </li>
-          <li><a href="<?php echo $country; ?>"><?php echo $text_country; ?></a></li>
-          <li><a href="<?php echo $zone; ?>"><?php echo $text_zone; ?></a></li>
-          <li><a href="<?php echo $geo_zone; ?>"><?php echo $text_geo_zone; ?></a></li>
-          <li><a class="parent"><?php echo $text_tax; ?></a>
-            <ul>
-              <li><a href="<?php echo $tax_class; ?>"><?php echo $text_tax_class; ?></a></li>
-              <li><a href="<?php echo $tax_rate; ?>"><?php echo $text_tax_rate; ?></a></li>
-            </ul>
-          </li>
-          <li><a href="<?php echo $length_class; ?>"><?php echo $text_length_class; ?></a></li>
-          <li><a href="<?php echo $weight_class; ?>"><?php echo $text_weight_class; ?></a></li>
-        </ul>
-      </li>
-      <li><a class="parent"><?php echo $text_tools; ?></a>
-        <ul>
-          <li><a href="<?php echo $upload; ?>"><?php echo $text_upload; ?></a></li>
-          <li><a href="<?php echo $backup; ?>"><?php echo $text_backup; ?></a></li>
-          <li><a href="<?php echo $error_log; ?>"><?php echo $text_error_log; ?></a></li>
-        </ul>
-      </li>
-    </ul>
-  </li>
-  <li id="reports"><a class="parent"><i class="fa fa-bar-chart-o fa-fw"></i> <span><?php echo $text_reports; ?></span></a>
-    <ul>
-      <li><a class="parent"><?php echo $text_sale; ?></a>
-        <ul>
-          <li><a href="<?php echo $report_sale_order; ?>"><?php echo $text_report_sale_order; ?></a></li>
-          <li><a href="<?php echo $report_sale_tax; ?>"><?php echo $text_report_sale_tax; ?></a></li>
-          <li><a href="<?php echo $report_sale_shipping; ?>"><?php echo $text_report_sale_shipping; ?></a></li>
-          <li><a href="<?php echo $report_sale_return; ?>"><?php echo $text_report_sale_return; ?></a></li>
-          <li><a href="<?php echo $report_sale_coupon; ?>"><?php echo $text_report_sale_coupon; ?></a></li>
-        </ul>
-      </li>
-      <li><a class="parent"><?php echo $text_product; ?></a>
-        <ul>
-          <li><a href="<?php echo $report_product_viewed; ?>"><?php echo $text_report_product_viewed; ?></a></li>
-          <li><a href="<?php echo $report_product_purchased; ?>"><?php echo $text_report_product_purchased; ?></a></li>
-        </ul>
-      </li>
-      <li><a class="parent"><?php echo $text_customer; ?></a>
-        <ul>
-          <li><a href="<?php echo $report_customer_online; ?>"><?php echo $text_report_customer_online; ?></a></li>
-          <li><a href="<?php echo $report_customer_activity; ?>"><?php echo $text_report_customer_activity; ?></a></li>
-          <li><a href="<?php echo $report_customer_order; ?>"><?php echo $text_report_customer_order; ?></a></li>
-          <li><a href="<?php echo $report_customer_reward; ?>"><?php echo $text_report_customer_reward; ?></a></li>
-          <li><a href="<?php echo $report_customer_credit; ?>"><?php echo $text_report_customer_credit; ?></a></li>
-        </ul>
-      </li>
-      <li><a class="parent"><?php echo $text_marketing; ?></a>
-        <ul>
-          <li><a href="<?php echo $report_marketing; ?>"><?php echo $text_marketing; ?></a></li>
-          <li><a href="<?php echo $report_affiliate; ?>"><?php echo $text_report_affiliate; ?></a></li>
-          <li><a href="<?php echo $report_affiliate_activity; ?>"><?php echo $text_report_affiliate_activity; ?></a></li>
-        </ul>
-      </li>
-    </ul>
-  </li>
+      <?php } ?>
+
+    </li>
+  <?php } ?>
 </ul>


### PR DESCRIPTION
Using Events with current admin common/menu code require to outputing custom template in order adding menu. This can raise issue when using multiple Event to add menu; also possibly issue with extension use OcMod or vQmod.

In order to add admin main menu dynamicly through Event with minimum conflict issue, common/menu need to be refactored.

Example how we can use Events to add new menu

    $data['navigations']['catalog']['child'][] = array(
        'title'     => 'Hello Extension',
        'url'       => $this->url->link('extension/helloworld', 'token=' . $this->session->data['token'], true),
    );

Also possible to control menu visibility

    if ($this->user->hasPermission('access', 'extension/helloworld')) {
        $data['navigations']['catalog']['child'][] = array(
            'title'     => 'Hello Extension',
            'url'       => $this->url->link('extension/helloworld', 'token=' . $this->session->data['token'], true),
        );
    }

I think I'm going to check hasPermission to all main menu item once this proposal is accepted