### PR TITLE
improve position at design/layout for Events advantage

### DIFF
--- a/upload/admin/controller/design/layout.php
+++ b/upload/admin/controller/design/layout.php
@@ -263,10 +263,6 @@ class ControllerDesignLayout extends Controller {
 		$data['text_default'] = $this->language->get('text_default');
 		$data['text_enabled'] = $this->language->get('text_enabled');
 		$data['text_disabled'] = $this->language->get('text_disabled');
-		$data['text_content_top'] = $this->language->get('text_content_top');
-		$data['text_content_bottom'] = $this->language->get('text_content_bottom');
-		$data['text_column_left'] = $this->language->get('text_column_left');
-		$data['text_column_right'] = $this->language->get('text_column_right');
 
 		$data['entry_name'] = $this->language->get('entry_name');
 		$data['entry_store'] = $this->language->get('entry_store');
@@ -391,6 +387,24 @@ class ControllerDesignLayout extends Controller {
 				);
 			}
 		}
+
+		$data['positions'] = array();
+		$data['positions'][] = array(
+			'title' => $this->language->get('text_content_top'),
+			'value' => 'content_top'
+		);
+		$data['positions'][] = array(
+			'title' => $this->language->get('text_content_bottom'),
+			'value' => 'content_bottom'
+		);
+		$data['positions'][] = array(
+			'title' => $this->language->get('text_column_left'),
+			'value' => 'column_left'
+		);
+		$data['positions'][] = array(
+			'title' => $this->language->get('text_column_right'),
+			'value' => 'column_right'
+		);
 
 		$data['header'] = $this->load->controller('common/header');
 		$data['column_left'] = $this->load->controller('common/column_left');

--- a/upload/admin/model/extension/extension.php
+++ b/upload/admin/model/extension/extension.php
@@ -12,6 +12,12 @@ class ModelExtensionExtension extends Model {
 		return $extension_data;
 	}
 
+	public function isInstalled($type, $code) {
+		$query = $this->db->query("SELECT * FROM " . DB_PREFIX . "extension WHERE `type` = '" . $this->db->escape($type) . "' AND `code` = '" . $this->db->escape($code) . "'");
+
+		return $query->num_rows ? true : false;
+	}
+
 	public function install($type, $code) {
 		$this->db->query("INSERT INTO " . DB_PREFIX . "extension SET `type` = '" . $this->db->escape($type) . "', `code` = '" . $this->db->escape($code) . "'");
 	}

--- a/upload/admin/view/template/design/layout_form.tpl
+++ b/upload/admin/view/template/design/layout_form.tpl
@@ -103,28 +103,31 @@
                     <?php } ?>
                     <?php } ?>
                   </select></td>
-                <td class="text-left"><select name="layout_module[<?php echo $module_row; ?>][position]" class="form-control">
-                    <?php if ($layout_module['position'] == 'content_top') { ?>
-                    <option value="content_top" selected="selected"><?php echo $text_content_top; ?></option>
-                    <?php } else { ?>
-                    <option value="content_top"><?php echo $text_content_top; ?></option>
+                <td class="text-left">
+                  <select name="layout_module[<?php echo $module_row; ?>][position]" class="form-control">
+                    <?php foreach ($positions as $position) { ?>
+                      <?php if (!isset($position['child'])) { ?>
+                        <?php if ($layout_module['position'] == $position['value']) { ?>
+                          <option value="<?php echo $position['value']; ?>" selected="selected"><?php echo $position['title']; ?></option>
+                        <?php } else { ?>
+                          <option value="<?php echo $position['value']; ?>"><?php echo $position['title']; ?></option>
+                        <?php } ?>
+                      <?php } ?>
+
+                      <?php if (!empty($position['child'])) { ?>
+                        <optgroup label="<?php echo $position['title']; ?>">
+                          <?php foreach ($position['child'] as $pos) { ?>
+                            <?php if ($layout_module['position'] == $pos['value']) { ?>
+                              <option value="<?php echo $pos['value']; ?>" selected="selected"><?php echo $pos['title']; ?></option>
+                            <?php } else { ?>
+                              <option value="<?php echo $pos['value']; ?>"><?php echo $pos['title']; ?></option>
+                            <?php } ?>
+                          <?php } ?>
+                        </optgroup>
+                      <?php } ?>
                     <?php } ?>
-                    <?php if ($layout_module['position'] == 'content_bottom') { ?>
-                    <option value="content_bottom" selected="selected"><?php echo $text_content_bottom; ?></option>
-                    <?php } else { ?>
-                    <option value="content_bottom"><?php echo $text_content_bottom; ?></option>
-                    <?php } ?>
-                    <?php if ($layout_module['position'] == 'column_left') { ?>
-                    <option value="column_left" selected="selected"><?php echo $text_column_left; ?></option>
-                    <?php } else { ?>
-                    <option value="column_left"><?php echo $text_column_left; ?></option>
-                    <?php } ?>
-                    <?php if ($layout_module['position'] == 'column_right') { ?>
-                    <option value="column_right" selected="selected"><?php echo $text_column_right; ?></option>
-                    <?php } else { ?>
-                    <option value="column_right"><?php echo $text_column_right; ?></option>
-                    <?php } ?>
-                  </select></td>
+                  </select>
+                </td>
                 <td class="text-right"><input type="text" name="layout_module[<?php echo $module_row; ?>][sort_order]" value="<?php echo $layout_module['sort_order']; ?>" placeholder="<?php echo $entry_sort_order; ?>" class="form-control" /></td>
                 <td class="text-left"><button type="button" onclick="$('#module-row<?php echo $module_row; ?>').remove();" data-toggle="tooltip" title="<?php echo $button_remove; ?>" class="btn btn-danger"><i class="fa fa-minus-circle"></i></button></td>
               </tr>
@@ -179,12 +182,29 @@ function addModule() {
 	<?php } ?>
 	<?php } ?>
     html += '  </select></td>'; 
-	html += '  <td class="text-left"><select name="layout_module[' + module_row + '][position]" class="form-control">';
-    html += '    <option value="content_top"><?php echo $text_content_top; ?></option>';
-    html += '    <option value="content_bottom"><?php echo $text_content_bottom; ?></option>';
-    html += '    <option value="column_left"><?php echo $text_column_left; ?></option>';
-    html += '    <option value="column_right"><?php echo $text_column_right; ?></option>';
-    html += '  </select></td>';
+  html += '<td class="text-left"><select name="layout_module[' + module_row + '][position]" class="form-control">';
+  <?php foreach ($positions as $position) { ?>
+    <?php if (!isset($position['child'])) { ?>
+      <?php if ($layout_module['position'] == $position['value']) { ?>
+        html += '<option value="<?php echo $position["value"]; ?>" selected="selected"><?php echo $position["title"]; ?></option>';
+      <?php } else { ?>
+        html += '<option value="<?php echo $position["value"]; ?>"><?php echo $position["title"]; ?></option>';
+      <?php } ?>
+    <?php } ?>
+
+    <?php if (isset($position['child'])) { ?>
+      html += "<optgroup label='<?php echo $position['title']; ?>'>"; 
+        <?php foreach ($position['child'] as $pos) { ?>
+          <?php if ($layout_module['position'] == $pos['value']) { ?>
+            html += '<option value="<?php echo $pos["value"]; ?>" selected="selected"><?php echo $pos["title"]; ?></option>';
+          <?php } else { ?>
+            html += '<option value="<?php echo $pos["value"]; ?>"><?php echo $pos["title"]; ?></option>';
+          <?php } ?>
+        <?php } ?>
+      html += "</optgroup>";
+    <?php } ?>
+  <?php } ?>
+  html += '  </select></td>';
 	html += '  <td class="text-left"><input type="text" name="layout_module[' + module_row + '][sort_order]" value="" placeholder="<?php echo $entry_sort_order; ?>" class="form-control" /></td>';
 	html += '  <td class="text-left"><button type="button" onclick="$(\'#module-row' + module_row + '\').remove();" data-toggle="tooltip" title="<?php echo $button_remove; ?>" class="btn btn-danger"><i class="fa fa-minus-circle"></i></button></td>';
 	html += '</tr>';


### PR DESCRIPTION
Like https://github.com/opencart/opencart/pull/3911 I want to improve position list at design/layout to work with Events.

I proposed this change because nowadays most 3rd theme have extra block position.
My change will make them easy to put block position at Layout.

Example code to use Events

    $data['positions'][] = array(
        'title' => 'default2 Theme',
        'child' => array(
            array(
                'title' => 'Main Menu',
                'value' => 'main_menu'
            ),
            array(
                'title' => 'Footer Menu',
                'value' => 'footer_menu'
            )
        )
    );

Results

    Content Top
    Content Bottom
    Column Right
    Column Left
    default2 Theme (optgroup)
        |- Main Menu
        |- Footer Menu

I also add _isInstalled_ at model extension/extension so theme developer can optout their extra position if user not install the theme.

    if ($this->model_extension_extension->isInstalled('theme', 'default2')) {
        // Events code add block position
    }