### PR TITLE
Fix startup/event pre_action order

### DIFF
--- a/upload/system/config/catalog.php
+++ b/upload/system/config/catalog.php
@@ -21,9 +21,9 @@ $_['library_autoload'] = array(
 $_['action_pre_action'] = array(
 	'startup/startup',
 	'startup/error',
+	'startup/event',
 	'startup/maintenance',
 	'startup/seo_url',
-	'startup/event',
 	'startup/session'
 );
 


### PR DESCRIPTION
Event on front site is not trigered because it's registered after the _startup/seo_url_.
Both _startup/seo_url_ and _maintenance_ have side effect by returning new action.

After change the sequence, Events is working as expected.

Note: the reason _action_event_ in config/catalog.php working because it's registered before the _pre_action_ on framework.php