### PR TITLE
Update cart products with SEO url for checkout/cart

### DIFF
--- a/upload/catalog/view/javascript/common.js
+++ b/upload/catalog/view/javascript/common.js
@@ -184,7 +184,9 @@ var cart = {
 				setTimeout(function () {
 					$('#cart > button').html('<span id="cart-total"><i class="fa fa-shopping-cart"></i> ' + json['total'] + '</span>');
 				}, 100);
-
+                                if (json['redirect']) {
+                                   location = json['redirect'];
+				} else 
 				if (getURLVar('route') == 'checkout/cart' || getURLVar('route') == 'checkout/checkout') {
 					location = 'index.php?route=checkout/cart';
 				} else {
@@ -213,7 +215,9 @@ var cart = {
 				setTimeout(function () {
 					$('#cart > button').html('<span id="cart-total"><i class="fa fa-shopping-cart"></i> ' + json['total'] + '</span>');
 				}, 100);
-
+                                if (json['redirect']) {
+                                  location = json['redirect'];
+				} else
 				if (getURLVar('route') == 'checkout/cart' || getURLVar('route') == 'checkout/checkout') {
 					location = 'index.php?route=checkout/cart';
 				} else {
@@ -248,7 +252,10 @@ var voucher = {
 				setTimeout(function () {
 					$('#cart > button').html('<span id="cart-total"><i class="fa fa-shopping-cart"></i> ' + json['total'] + '</span>');
 				}, 100);
-
+                                
+                                if (json['redirect']) {
+                                  location = json['redirect'];
+				} else
 				if (getURLVar('route') == 'checkout/cart' || getURLVar('route') == 'checkout/checkout') {
 					location = 'index.php?route=checkout/cart';
 				} else {


### PR DESCRIPTION
When using SEO urls for checkout/cart there is a problem with refreshing the cart page.

When you add a product to the cart and want to remove this product, the cart page must be refreshed. When using SEO url this is not hapening, because it checks the URL with -> getURLVar('route') == 'checkout/cart' 

This change must be in combination with a change in catalog/controller/checkout/cart.php at line 417 and 440, add code -> $json['redirect'] = $this->url->link('checkout/cart');