### PR TITLE
Update cart products with SEO url for checkout/cart

### DIFF
--- a/upload/catalog/controller/checkout/cart.php
+++ b/upload/catalog/controller/checkout/cart.php
@@ -421,6 +421,8 @@ class ControllerCheckoutCart extends Controller {
 			unset($this->session->data['payment_method']);
 			unset($this->session->data['payment_methods']);
 			unset($this->session->data['reward']);
+			
+			$json['redirect'] = $this->url->link('checkout/cart');
 
 			$this->response->redirect($this->url->link('checkout/cart'));
 		}
@@ -447,7 +449,9 @@ class ControllerCheckoutCart extends Controller {
 			unset($this->session->data['payment_method']);
 			unset($this->session->data['payment_methods']);
 			unset($this->session->data['reward']);
-
+                        
+                        $json['redirect'] = $this->url->link('checkout/cart');
+                        
 			// Totals
 			$this->load->model('extension/extension');
 


### PR DESCRIPTION
When using SEO urls for checkout/cart there is a problem with refreshing the cart page.

When you add a product to the cart and want to remove this product, the cart page must be refreshed. When using SEO url this is not hapening, because it checks the URL with -> getURLVar('route') == 'checkout/cart' 

This change must be in combination with a change in common.js in https://github.com/opencart/opencart/pull/3927 .