### PR TITLE
Use constant DIR_OPENCART in config files.

### DIFF
--- a/upload/install/cli_install.php
+++ b/upload/install/cli_install.php
@@ -195,18 +195,19 @@ function write_config_files($options) {
 	$output .= 'define(\'HTTPS_SERVER\', \'' . $options['http_server'] . '\');' . "\n";
 
 	$output .= '// DIR' . "\n";
-	$output .= 'define(\'DIR_APPLICATION\', \'' . DIR_OPENCART . 'catalog/\');' . "\n";
-	$output .= 'define(\'DIR_SYSTEM\', \'' . DIR_OPENCART . 'system/\');' . "\n";
-	$output .= 'define(\'DIR_DATABASE\', \'' . DIR_OPENCART . 'system/database/\');' . "\n";
-	$output .= 'define(\'DIR_LANGUAGE\', \'' . DIR_OPENCART . 'catalog/language/\');' . "\n";
-	$output .= 'define(\'DIR_TEMPLATE\', \'' . DIR_OPENCART . 'catalog/view/theme/\');' . "\n";
-	$output .= 'define(\'DIR_CONFIG\', \'' . DIR_OPENCART . 'system/config/\');' . "\n";
-	$output .= 'define(\'DIR_IMAGE\', \'' . DIR_OPENCART . 'image/\');' . "\n";
-	$output .= 'define(\'DIR_CACHE\', \'' . DIR_OPENCART . 'system/storage/cache/\');' . "\n";
-	$output .= 'define(\'DIR_DOWNLOAD\', \'' . DIR_OPENCART . 'system/storage/download/\');' . "\n";
-	$output .= 'define(\'DIR_UPLOAD\', \'' . DIR_OPENCART . 'system/storage/upload/\');' . "\n";
-	$output .= 'define(\'DIR_MODIFICATION\', \'' . DIR_OPENCART . 'system/storage/modification/\');' . "\n";
-	$output .= 'define(\'DIR_LOGS\', \'' . DIR_OPENCART . 'system/storage/logs/\');' . "\n\n";
+	$output .= 'define(\'DIR_OPENCART\', str_replace(\'\\\'\', \'/\', realpath(dirname(__FILE__))) . \'/\');' . "\n";
+	$output .= 'define(\'DIR_APPLICATION\', DIR_OPENCART . \'catalog/\');' . "\n";
+	$output .= 'define(\'DIR_SYSTEM\', DIR_OPENCART . \'system/\');' . "\n";
+	$output .= 'define(\'DIR_DATABASE\', DIR_OPENCART . \'system/database/\');' . "\n";
+	$output .= 'define(\'DIR_LANGUAGE\', DIR_OPENCART . \'catalog/language/\');' . "\n";
+	$output .= 'define(\'DIR_TEMPLATE\', DIR_OPENCART . \'catalog/view/theme/\');' . "\n";
+	$output .= 'define(\'DIR_CONFIG\', DIR_OPENCART . \'system/config/\');' . "\n";
+	$output .= 'define(\'DIR_IMAGE\', DIR_OPENCART . \'image/\');' . "\n";
+	$output .= 'define(\'DIR_CACHE\', DIR_OPENCART . \'system/storage/cache/\');' . "\n";
+	$output .= 'define(\'DIR_DOWNLOAD\', DIR_OPENCART . \'system/storage/download/\');' . "\n";
+	$output .= 'define(\'DIR_UPLOAD\', DIR_OPENCART . \'system/storage/upload/\');' . "\n";
+	$output .= 'define(\'DIR_MODIFICATION\', DIR_OPENCART . \'system/storage/modification/\');' . "\n";
+	$output .= 'define(\'DIR_LOGS\', DIR_OPENCART . \'system/storage/logs/\');' . "\n\n";
 
 	$output .= '// DB' . "\n";
 	$output .= 'define(\'DB_DRIVER\', \'' . addslashes($options['db_driver']) . '\');' . "\n";
@@ -234,19 +235,20 @@ function write_config_files($options) {
 	$output .= 'define(\'HTTPS_CATALOG\', \'' . $options['http_server'] . '\');' . "\n";
 
 	$output .= '// DIR' . "\n";
-	$output .= 'define(\'DIR_APPLICATION\', \'' . DIR_OPENCART . 'admin/\');' . "\n";
-	$output .= 'define(\'DIR_SYSTEM\', \'' . DIR_OPENCART . 'system/\');' . "\n";
-	$output .= 'define(\'DIR_DATABASE\', \'' . DIR_OPENCART . 'system/database/\');' . "\n";
-	$output .= 'define(\'DIR_LANGUAGE\', \'' . DIR_OPENCART . 'admin/language/\');' . "\n";
-	$output .= 'define(\'DIR_TEMPLATE\', \'' . DIR_OPENCART . 'admin/view/template/\');' . "\n";
-	$output .= 'define(\'DIR_CONFIG\', \'' . DIR_OPENCART . 'system/config/\');' . "\n";
-	$output .= 'define(\'DIR_IMAGE\', \'' . DIR_OPENCART . 'image/\');' . "\n";
-	$output .= 'define(\'DIR_CACHE\', \'' . DIR_OPENCART . 'system/storage/cache/\');' . "\n";
-	$output .= 'define(\'DIR_DOWNLOAD\', \'' . DIR_OPENCART . 'system/storage/download/\');' . "\n";
-	$output .= 'define(\'DIR_UPLOAD\', \'' . DIR_OPENCART . 'system/storage/upload/\');' . "\n";
-	$output .= 'define(\'DIR_LOGS\', \'' . DIR_OPENCART . 'system/storage/logs/\');' . "\n";
-	$output .= 'define(\'DIR_MODIFICATION\', \'' . DIR_OPENCART . 'system/storage/modification/\');' . "\n";
-	$output .= 'define(\'DIR_CATALOG\', \'' . DIR_OPENCART . 'catalog/\');' . "\n\n";
+	$output .= 'define(\'DIR_OPENCART\', str_replace(\'\\\'\', \'/\', realpath(dirname(__FILE__). \'/../\')) . \'/\');' . "\n";
+	$output .= 'define(\'DIR_APPLICATION\', DIR_OPENCART . \'admin/\');' . "\n";
+	$output .= 'define(\'DIR_SYSTEM\', DIR_OPENCART . \'system/\');' . "\n";
+	$output .= 'define(\'DIR_DATABASE\', DIR_OPENCART . \'system/database/\');' . "\n";
+	$output .= 'define(\'DIR_LANGUAGE\', DIR_OPENCART . \'admin/language/\');' . "\n";
+	$output .= 'define(\'DIR_TEMPLATE\', DIR_OPENCART . \'admin/view/template/\');' . "\n";
+	$output .= 'define(\'DIR_CONFIG\', DIR_OPENCART . \'system/config/\');' . "\n";
+	$output .= 'define(\'DIR_IMAGE\', DIR_OPENCART . \'image/\');' . "\n";
+	$output .= 'define(\'DIR_CACHE\', DIR_OPENCART . \'system/storage/cache/\');' . "\n";
+	$output .= 'define(\'DIR_DOWNLOAD\', DIR_OPENCART . \'system/storage/download/\');' . "\n";
+	$output .= 'define(\'DIR_UPLOAD\', DIR_OPENCART . \'system/storage/upload/\');' . "\n";
+	$output .= 'define(\'DIR_LOGS\', DIR_OPENCART . \'system/storage/logs/\');' . "\n";
+	$output .= 'define(\'DIR_MODIFICATION\', DIR_OPENCART . \'system/storage/modification/\');' . "\n";
+	$output .= 'define(\'DIR_CATALOG\', DIR_OPENCART . \'catalog/\');' . "\n\n";
 
 	$output .= '// DB' . "\n";
 	$output .= 'define(\'DB_DRIVER\', \'' . addslashes($options['db_driver']) . '\');' . "\n";

--- a/upload/install/controller/install/step_3.php
+++ b/upload/install/controller/install/step_3.php
@@ -18,17 +18,18 @@ class ControllerInstallStep3 extends Controller {
 			$output .= 'define(\'HTTPS_SERVER\', \'' . HTTP_OPENCART . '\');' . "\n\n";
 
 			$output .= '// DIR' . "\n";
-			$output .= 'define(\'DIR_APPLICATION\', \'' . DIR_OPENCART . 'catalog/\');' . "\n";
-			$output .= 'define(\'DIR_SYSTEM\', \'' . DIR_OPENCART . 'system/\');' . "\n";
-			$output .= 'define(\'DIR_IMAGE\', \'' . DIR_OPENCART . 'image/\');' . "\n";			
-			$output .= 'define(\'DIR_LANGUAGE\', \'' . DIR_OPENCART . 'catalog/language/\');' . "\n";
-			$output .= 'define(\'DIR_TEMPLATE\', \'' . DIR_OPENCART . 'catalog/view/theme/\');' . "\n";
-			$output .= 'define(\'DIR_CONFIG\', \'' . DIR_OPENCART . 'system/config/\');' . "\n";
-			$output .= 'define(\'DIR_CACHE\', \'' . DIR_OPENCART . 'system/storage/cache/\');' . "\n";
-			$output .= 'define(\'DIR_DOWNLOAD\', \'' . DIR_OPENCART . 'system/storage/download/\');' . "\n";
-			$output .= 'define(\'DIR_LOGS\', \'' . DIR_OPENCART . 'system/storage/logs/\');' . "\n";
-			$output .= 'define(\'DIR_MODIFICATION\', \'' . DIR_OPENCART . 'system/storage/modification/\');' . "\n";
-			$output .= 'define(\'DIR_UPLOAD\', \'' . DIR_OPENCART . 'system/storage/upload/\');' . "\n\n";
+			$output .= 'define(\'DIR_OPENCART\', str_replace(\'\\\'\', \'/\', realpath(dirname(__FILE__))) . \'/\');' . "\n";
+			$output .= 'define(\'DIR_APPLICATION\', DIR_OPENCART . \'catalog/\');' . "\n";
+			$output .= 'define(\'DIR_SYSTEM\', DIR_OPENCART . \'system/\');' . "\n";
+			$output .= 'define(\'DIR_IMAGE\', DIR_OPENCART . \'image/\');' . "\n";			
+			$output .= 'define(\'DIR_LANGUAGE\', DIR_OPENCART . \'catalog/language/\');' . "\n";
+			$output .= 'define(\'DIR_TEMPLATE\', DIR_OPENCART . \'catalog/view/theme/\');' . "\n";
+			$output .= 'define(\'DIR_CONFIG\', DIR_OPENCART . \'system/config/\');' . "\n";
+			$output .= 'define(\'DIR_CACHE\', DIR_OPENCART . \'system/storage/cache/\');' . "\n";
+			$output .= 'define(\'DIR_DOWNLOAD\', DIR_OPENCART . \'system/storage/download/\');' . "\n";
+			$output .= 'define(\'DIR_LOGS\', DIR_OPENCART . \'system/storage/logs/\');' . "\n";
+			$output .= 'define(\'DIR_MODIFICATION\', DIR_OPENCART . \'system/storage/modification/\');' . "\n";
+			$output .= 'define(\'DIR_UPLOAD\', DIR_OPENCART . \'system/storage/upload/\');' . "\n\n";
 
 			$output .= '// DB' . "\n";
 			$output .= 'define(\'DB_DRIVER\', \'' . addslashes($this->request->post['db_driver']) . '\');' . "\n";
@@ -55,18 +56,19 @@ class ControllerInstallStep3 extends Controller {
 			$output .= 'define(\'HTTPS_CATALOG\', \'' . HTTP_OPENCART . '\');' . "\n\n";
 
 			$output .= '// DIR' . "\n";
-			$output .= 'define(\'DIR_APPLICATION\', \'' . DIR_OPENCART . 'admin/\');' . "\n";
-			$output .= 'define(\'DIR_SYSTEM\', \'' . DIR_OPENCART . 'system/\');' . "\n";
-			$output .= 'define(\'DIR_IMAGE\', \'' . DIR_OPENCART . 'image/\');' . "\n";			
-			$output .= 'define(\'DIR_LANGUAGE\', \'' . DIR_OPENCART . 'admin/language/\');' . "\n";
-			$output .= 'define(\'DIR_TEMPLATE\', \'' . DIR_OPENCART . 'admin/view/template/\');' . "\n";
-			$output .= 'define(\'DIR_CONFIG\', \'' . DIR_OPENCART . 'system/config/\');' . "\n";
-			$output .= 'define(\'DIR_CACHE\', \'' . DIR_OPENCART . 'system/storage/cache/\');' . "\n";
-			$output .= 'define(\'DIR_DOWNLOAD\', \'' . DIR_OPENCART . 'system/storage/download/\');' . "\n";
-			$output .= 'define(\'DIR_LOGS\', \'' . DIR_OPENCART . 'system/storage/logs/\');' . "\n";
-			$output .= 'define(\'DIR_MODIFICATION\', \'' . DIR_OPENCART . 'system/storage/modification/\');' . "\n";
-			$output .= 'define(\'DIR_UPLOAD\', \'' . DIR_OPENCART . 'system/storage/upload/\');' . "\n";
-			$output .= 'define(\'DIR_CATALOG\', \'' . DIR_OPENCART . 'catalog/\');' . "\n\n";
+			$output .= 'define(\'DIR_OPENCART\', str_replace(\'\\\'\', \'/\', realpath(dirname(__FILE__). \'/../\')) . \'/\');' . "\n";
+			$output .= 'define(\'DIR_APPLICATION\', DIR_OPENCART . \'admin/\');' . "\n";
+			$output .= 'define(\'DIR_SYSTEM\', DIR_OPENCART . \'system/\');' . "\n";
+			$output .= 'define(\'DIR_IMAGE\', DIR_OPENCART . \'image/\');' . "\n";			
+			$output .= 'define(\'DIR_LANGUAGE\', DIR_OPENCART . \'admin/language/\');' . "\n";
+			$output .= 'define(\'DIR_TEMPLATE\', DIR_OPENCART . \'admin/view/template/\');' . "\n";
+			$output .= 'define(\'DIR_CONFIG\', DIR_OPENCART . \'system/config/\');' . "\n";
+			$output .= 'define(\'DIR_CACHE\', DIR_OPENCART . \'system/storage/cache/\');' . "\n";
+			$output .= 'define(\'DIR_DOWNLOAD\', DIR_OPENCART . \'system/storage/download/\');' . "\n";
+			$output .= 'define(\'DIR_LOGS\', DIR_OPENCART . \'system/storage/logs/\');' . "\n";
+			$output .= 'define(\'DIR_MODIFICATION\', DIR_OPENCART . \'system/storage/modification/\');' . "\n";
+			$output .= 'define(\'DIR_UPLOAD\', DIR_OPENCART . \'system/storage/upload/\');' . "\n";
+			$output .= 'define(\'DIR_CATALOG\', DIR_OPENCART . \'catalog/\');' . "\n\n";
 
 			$output .= '// DB' . "\n";
 			$output .= 'define(\'DB_DRIVER\', \'' . addslashes($this->request->post['db_driver']) . '\');' . "\n";


### PR DESCRIPTION
Write constant DIR_OPENCART in config files while installing so that no need to update config files after switch server every time.

Generate code like this below:

> `//DIR`
> `define('DIR_OPENCART', str_replace('\'', '/', realpath(dirname(__FILE__))) . '/');`
> `define('DIR_APPLICATION', DIR_OPENCART . 'catalog/');`
> `define('DIR_SYSTEM', DIR_OPENCART . 'system/');`
> `define('DIR_IMAGE', DIR_OPENCART . 'image/');`
> `define('DIR_LANGUAGE', DIR_OPENCART . 'catalog/language/');`
> `define('DIR_TEMPLATE', DIR_OPENCART . 'catalog/view/theme/');`
> `define('DIR_CONFIG', DIR_OPENCART . 'system/config/');`
> `define('DIR_CACHE', DIR_OPENCART . 'system/storage/cache/');`
> `define('DIR_DOWNLOAD', DIR_OPENCART . 'system/storage/download/');`
> `define('DIR_LOGS', DIR_OPENCART . 'system/storage/logs/');`
> `define('DIR_MODIFICATION', DIR_OPENCART . 'system/storage/modification/');`
> `define('DIR_UPLOAD', DIR_OPENCART . 'system/storage/upload/');`