### PR TITLE
make sure Events ordered asc by event_id

### DIFF
--- a/upload/admin/controller/startup/event.php
+++ b/upload/admin/controller/startup/event.php
@@ -1,7 +1,7 @@
 <?php
 class ControllerStartupEvent extends Controller {
 	public function index() {
-		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "event` WHERE `trigger` LIKE 'admin/%'");
+		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "event` WHERE `trigger` LIKE 'admin/%' ORDER BY `event_id` ASC");
 		
 		foreach ($query->rows as $result) {
 			$this->event->register(substr($result['trigger'], strpos($result['trigger'], '/') + 1), new Action($result['action']));

--- a/upload/catalog/model/extension/event.php
+++ b/upload/catalog/model/extension/event.php
@@ -1,7 +1,7 @@
 <?php
 class ModelExtensionEvent extends Model {
 	function getEvents() {
-		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "event` WHERE `trigger` LIKE 'catalog/%'");
+		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "event` WHERE `trigger` LIKE 'catalog/%' ORDER BY `event_id` ASC");
 
 		return $query->rows;
 	}


### PR DESCRIPTION
Events doesn't have explicit priority order; and there is no guarante sql use primary index in asc ordering.
Order clause is required to ensure Events is registered in guaranteed order.