### PR TITLE
Update worldpay.php - fix total sent to payment processor

### DIFF
--- a/upload/catalog/controller/payment/worldpay.php
+++ b/upload/catalog/controller/payment/worldpay.php
@@ -81,7 +81,7 @@ class ControllerPaymentWorldpay extends Controller {
 		$order = array(
 			"token" => $this->request->post['token'],
 			"orderType" => $order_type,
-			"amount" => (int)($order_info['total'] * 100),
+			"amount" => round($this->currency->format($order_info['total'], $order_info['currency_code'], $order_info['currency_value'], false)*100),
 			"currencyCode" => $order_info['currency_code'],
 			"name" => $order_info['firstname'] . ' ' . $order_info['lastname'],
 			"orderDescription" => $order_info['store_name'] . ' - ' . date('Y-m-d H:i:s'),


### PR DESCRIPTION
If a user changes the store currency display, adds items to cart, checks out and pays with Worldpay Online the store sends the incorrect order total to the payment processor.

Actual data sent:
- order amount - eg. 10 GBP (incorrect)
- currency - user selected eg. EUR (correct)

What it should be:
- order amount - cart default currency converted to user selected currency eg. 10 GBP becomes 11.29 EUR

This results in the user's card being charged 10 EUR for what should be a 11.29 EUR sale.