### PR TITLE
[2.2.0.0.b1] locale is missing in cache

### DIFF
--- a/upload/admin/model/localisation/language.php
+++ b/upload/admin/model/localisation/language.php
@@ -325,6 +325,8 @@ class ModelLocalisationLanguage extends Model {
 						'name'        => $result['name'],
 						'code'        => $result['code'],
 						'locale'      => $result['locale'],
+						'image'       => $result['image'],
+						'directory'   => $result['directory'],
 						'sort_order'  => $result['sort_order'],
 						'status'      => $result['status']
 					);

--- a/upload/admin/model/localisation/language.php
+++ b/upload/admin/model/localisation/language.php
@@ -324,6 +324,7 @@ class ModelLocalisationLanguage extends Model {
 						'language_id' => $result['language_id'],
 						'name'        => $result['name'],
 						'code'        => $result['code'],
+						'locale'      => $result['locale'],
 						'sort_order'  => $result['sort_order'],
 						'status'      => $result['status']
 					);


### PR DESCRIPTION
If 'directory' has been replaced by 'code', we always need 'locale' which is not in the cache.