### PR TITLE
Fixed session assignment

### DIFF
--- a/upload/catalog/controller/api/login.php
+++ b/upload/catalog/controller/api/login.php
@@ -33,7 +33,7 @@ class ControllerApiLogin extends Controller {
 				$session->start($this->session->getId(), $session_name);
 
 				// Set API ID
-				$session->data['api_id'] = $api_info['api_id'];
+				$this->session->data['api_id'] = $api_info['api_id'];
 
 				// Create Token
 				$json['token'] = $this->model_account_api->addApiSession($api_info['api_id'], $session_name, $session->getId(), $this->request->server['REMOTE_ADDR']);


### PR DESCRIPTION
Tried to do fix so that subsequent API calls have access to proper session token. Without this fix, it always gives "permission denied" error even though login token was successfully created.