### PR TITLE
Skipping SMTP Server's 220 response code

### DIFF
--- a/upload/system/library/mail.php
+++ b/upload/system/library/mail.php
@@ -187,7 +187,12 @@ class Mail {
 				while ($line = fgets($handle, 515)) {
 					$reply .= $line;
 
-					if (substr($line, 3, 1) == ' ') {
+					//some SMTP servers respond with 220 code before responding with 250. hence, we need to ignore 220 response string
+					if (substr($reply, 0, 3) == 220 && substr($line, 3, 1) == ' ') {
+						$reply = '';
+						continue;
+					}
+					else if (substr($line, 3, 1) == ' ') {
 						break;
 					}
 				}


### PR DESCRIPTION
Some SMTP servers respond with 220 code before responding with 250 response code. Hence, we need to ignore 220 response string if its sent from server before 250 and keep reading for the next empty space at 4th location of SMTP response string line. Look at the sample response below from one of the server, now, when existing code parse the below strings, it breaks in the "while" loop after reading line "220 and/or bulk e-mail." from server. Hence, the next "if" statement fails when it doesn't get the code "250" in the variable $reply as it contains 220 in this case. Now, in this example, 220 is a valid response that "Server is Ready" and the next response code is "250" but existing code is failing to cater this. Hence proposing a change which should just ignore the 220 response as its not an Error response from SMTP server and code should look for the next response code which can expectedly be 250. Current code fails with the error "EHLO Not accepted" however this is not the case and the same issue will be faced by all those users whose hosting server's SMTP respond like below.
Sample SMTP response below

220-coney.arvixe.com ESMTP Exim 4.86_1 #1 Thu, 03 Mar 2016 12:19:59 -0800 
220-We do not authorize the use of this system to transport unsolicited, 
220 and/or bulk e-mail.
250-coney.arvixe.com Hello ec2-52-21-221-150.compute-1.amazonaws.com [52.21.221.150]
250-SIZE 52428800
250-8BITMIME
250-PIPELINING
250-AUTH PLAIN LOGIN
250-STARTTLS
250 HELP