### PR TITLE
Refactored exception message in MySQLi class

### DIFF
--- a/upload/system/library/db/mysqli.php
+++ b/upload/system/library/db/mysqli.php
@@ -7,7 +7,7 @@ final class MySQLi {
 		$this->connection = new \mysqli($hostname, $username, $password, $database, $port);
 
 		if ($this->connection->connect_error) {
-			throw new \Exception('Error: ' . mysql_error($this->connection) . '<br />Error No: ' . mysql_errno($this->connection) . '<br /> Error in: <b>' . $trace[1]['file'] . '</b> line <b>' . $trace[1]['line'] . '</b><br />' . $sql);
+			throw new \Exception('Error: ' . $this->connection->error . '<br />Error No: ' . $this->connection->errno);
 		}
 
 		$this->connection->set_charset("utf8");
@@ -54,7 +54,7 @@ final class MySQLi {
 	}
 	
 	public function connected() {
-		return $this->connection->connected();
+		return $this->connection->ping();
 	}
 	
 	public function __destruct() {


### PR DESCRIPTION
Functions `mysql_error ` and `mysql_errno ` were removed in PHP7. http://php.net/manual/en/migration70.removed-exts-sapis.php

Variable `trace` not exists.

Object `mysqli` doesn't have method `connected()` http://php.net/manual/en/class.mysqli.php
