### PR TITLE
Update header.php

### DIFF
--- a/upload/catalog/controller/common/header.php
+++ b/upload/catalog/controller/common/header.php
@@ -19,6 +19,12 @@ class ControllerCommonHeader extends Controller {
 		} else {
 			$server = $this->config->get('config_url');
 		}
+		//fixed error add to cart acction(and all ajax Action) between www and non www 
+		$server_url_info = parse_url($server);
+		
+		if(strtolower($server_url_info['host']) != strtolower($_SERVER["SERVER_NAME"]) &&  strtolower('www.'.$server_url_info['host']) == strtolower($_SERVER["SERVER_NAME"])){
+			$server = $server_url_info['scheme'].'://www.'.$server_url_info['host'].'/';
+		}
 
 		if (is_file(DIR_IMAGE . $this->config->get('config_icon'))) {
 			$this->document->addLink($server . 'image/' . $this->config->get('config_icon'), 'icon');


### PR DESCRIPTION
Fixed error Access-Control-Allow-Origin with ajax action.

How to the error caused.

In config.php file we set: 
define('HTTP_SERVER', 'http://opencarthost.com/');

But we acces to http://www.opencarthost.com/

it will show error like below (we can't run ajax)
XMLHttpRequest cannot load http://opencarthost.com/index.php?route=checkout/cart/add. Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource. Origin 'http://www.opencarthost.com' is therefore not allowed access.