### PR TITLE
Fix for DB parameters in install process

### DIFF
--- a/upload/install/model/install/install.php
+++ b/upload/install/model/install/install.php
@@ -1,7 +1,7 @@
 <?php
 class ModelInstallInstall extends Model {
 	public function database($data) {
-		$db = new DB($data['db_driver'], $data['db_hostname'], $data['db_username'], $data['db_password'], $data['db_database'], $data['db_port']);
+		$db = new DB($data['db_driver'], htmlspecialchars_decode($data['db_hostname']), htmlspecialchars_decode($data['db_username']), htmlspecialchars_decode($data['db_password']), htmlspecialchars_decode($data['db_database']), $data['db_port']);
 
 		$file = DIR_APPLICATION . 'opencart.sql';
 


### PR DESCRIPTION
This fix will eventually decode back the DB parameters sent by the form in the install process, so that the connection will be executed succesfully