### PR TITLE
Remove Formatting from Descriptions When Creating Google Base Feed

### DIFF
--- a/upload/catalog/controller/feed/google_base.php
+++ b/upload/catalog/controller/feed/google_base.php
@@ -32,7 +32,7 @@ class ControllerFeedGoogleBase extends Controller {
 						$output .= '<item>';
 						$output .= '<title><![CDATA[' . $product['name'] . ']]></title>';
 						$output .= '<link>' . $this->url->link('product/product', 'product_id=' . $product['product_id']) . '</link>';
-						$output .= '<description><![CDATA[' . $product['description'] . ']]></description>';
+						$output .= '<description><![CDATA[' . strip_tags($product['description']) . ']]></description>';
 						$output .= '<g:brand><![CDATA[' . html_entity_decode($product['manufacturer'], ENT_QUOTES, 'UTF-8') . ']]></g:brand>';
 						$output .= '<g:condition>new</g:condition>';
 						$output .= '<g:id>' . $product['product_id'] . '</g:id>';


### PR DESCRIPTION
Google limits the descriptions field to 5,000 characters and, last time I wrote a product export, they went out of their way to say HTML formatting was NOT allowed.

Personally, I like to jazz up my descriptions with bold lettering, images and other formatting.  strip_tags() removes all of that, plus any other tags left by the WYSIWYG editor, during the creation of the feed to keep it compliant.