### PR TITLE
Use Lower Price of Specials and Discounts

### DIFF
--- a/upload/system/library/cart/cart.php
+++ b/upload/system/library/cart/cart.php
@@ -187,6 +187,15 @@ class Cart {
 					$price = $product_special_query->row['price'];
 				}
 
+				// Use Lower Price of Specials and Discounts
+				if ($product_special_query->num_rows && $product_discount_query->num_rows) {
+				    if ($product_special_query->row['price'] < $product_discount_query->row['price']) {
+					   $price = $product_special_query->row['price'];
+				    } else {
+				       $price = $product_discount_query->row['price'];
+				    }
+				}
+
 				// Reward Points
 				$product_reward_query = $this->db->query("SELECT points FROM " . DB_PREFIX . "product_reward WHERE product_id = '" . (int)$cart['product_id'] . "' AND customer_group_id = '" . (int)$this->config->get('config_customer_group_id') . "'");
 


### PR DESCRIPTION
If you have a Special Price for a product it completely ignores the Discount Price

Example:
Base Price is $10/ea
Special Price is $8/ea
Buy 4 or More is $6/ea

The special price of $8 overrides the $6 lower quantity discount because of the order of execution.  This addition of code will choose the lower price of the two and give that price.