### PR TITLE
Site Search by Partial SKU, Model, UPC, etc.

### DIFF
--- a/upload/catalog/model/catalog/product.php
+++ b/upload/catalog/model/catalog/product.php
@@ -127,13 +127,13 @@ class ModelCatalogProduct extends Model {
 			}
 
 			if (!empty($data['filter_name'])) {
-				$sql .= " OR LCASE(p.model) = '" . $this->db->escape(utf8_strtolower($data['filter_name'])) . "'";
-				$sql .= " OR LCASE(p.sku) = '" . $this->db->escape(utf8_strtolower($data['filter_name'])) . "'";
-				$sql .= " OR LCASE(p.upc) = '" . $this->db->escape(utf8_strtolower($data['filter_name'])) . "'";
-				$sql .= " OR LCASE(p.ean) = '" . $this->db->escape(utf8_strtolower($data['filter_name'])) . "'";
-				$sql .= " OR LCASE(p.jan) = '" . $this->db->escape(utf8_strtolower($data['filter_name'])) . "'";
-				$sql .= " OR LCASE(p.isbn) = '" . $this->db->escape(utf8_strtolower($data['filter_name'])) . "'";
-				$sql .= " OR LCASE(p.mpn) = '" . $this->db->escape(utf8_strtolower($data['filter_name'])) . "'";
+				$sql .= " OR LCASE(p.model) LIKE '%" . $this->db->escape(utf8_strtolower($data['filter_name'])) . "%'";
+				$sql .= " OR LCASE(p.sku) LIKE '%" . $this->db->escape(utf8_strtolower($data['filter_name'])) . "%'";
+				$sql .= " OR LCASE(p.upc) LIKE '%" . $this->db->escape(utf8_strtolower($data['filter_name'])) . "%'";
+				$sql .= " OR LCASE(p.ean) LIKE '%" . $this->db->escape(utf8_strtolower($data['filter_name'])) . "%'";
+				$sql .= " OR LCASE(p.jan) LIKE '%" . $this->db->escape(utf8_strtolower($data['filter_name'])) . "%'";
+				$sql .= " OR LCASE(p.isbn) LIKE '%" . $this->db->escape(utf8_strtolower($data['filter_name'])) . "%'";
+				$sql .= " OR LCASE(p.mpn) LIKE '%" . $this->db->escape(utf8_strtolower($data['filter_name'])) . "%'";
 			}
 
 			$sql .= ")";
@@ -470,13 +470,13 @@ class ModelCatalogProduct extends Model {
 			}
 
 			if (!empty($data['filter_name'])) {
-				$sql .= " OR LCASE(p.model) = '" . $this->db->escape(utf8_strtolower($data['filter_name'])) . "'";
-				$sql .= " OR LCASE(p.sku) = '" . $this->db->escape(utf8_strtolower($data['filter_name'])) . "'";
-				$sql .= " OR LCASE(p.upc) = '" . $this->db->escape(utf8_strtolower($data['filter_name'])) . "'";
-				$sql .= " OR LCASE(p.ean) = '" . $this->db->escape(utf8_strtolower($data['filter_name'])) . "'";
-				$sql .= " OR LCASE(p.jan) = '" . $this->db->escape(utf8_strtolower($data['filter_name'])) . "'";
-				$sql .= " OR LCASE(p.isbn) = '" . $this->db->escape(utf8_strtolower($data['filter_name'])) . "'";
-				$sql .= " OR LCASE(p.mpn) = '" . $this->db->escape(utf8_strtolower($data['filter_name'])) . "'";
+				$sql .= " OR LCASE(p.model) LIKE '%" . $this->db->escape(utf8_strtolower($data['filter_name'])) . "%'";
+				$sql .= " OR LCASE(p.sku) LIKE '%" . $this->db->escape(utf8_strtolower($data['filter_name'])) . "%'";
+				$sql .= " OR LCASE(p.upc) LIKE '%" . $this->db->escape(utf8_strtolower($data['filter_name'])) . "%'";
+				$sql .= " OR LCASE(p.ean) LIKE '%" . $this->db->escape(utf8_strtolower($data['filter_name'])) . "%'";
+				$sql .= " OR LCASE(p.jan) LIKE '%" . $this->db->escape(utf8_strtolower($data['filter_name'])) . "%'";
+				$sql .= " OR LCASE(p.isbn) LIKE '%" . $this->db->escape(utf8_strtolower($data['filter_name'])) . "%'";
+				$sql .= " OR LCASE(p.mpn) LIKE '%" . $this->db->escape(utf8_strtolower($data['filter_name'])) . "%'";
 			}
 
 			$sql .= ")";


### PR DESCRIPTION
Allows for customers searching on the site to only know partial SKU's, Models, UPC's, etc.

This is useful when you may have your Model set to something similar to the company SKU, but not exactly.  It also doesn't assume that a customer knows exactly what they are looking for all of the time.