### PR TITLE
Update order.php

### DIFF
--- a/upload/admin/controller/sale/order.php
+++ b/upload/admin/controller/sale/order.php
@@ -847,7 +847,7 @@ class ControllerSaleOrder extends Controller {
 			$data['order_id'] = $this->request->get['order_id'];
 
 			$data['store_name'] = $order_info['store_name'];
-			$data['store_url'] = $this->request->server['HTTPS'] ? str_replace("http", "https", $order_info['store_url']) : $order_info['store_url'];
+			$data['store_url'] = $this->request->server['HTTPS'] ? preg_replace("/^http:\/\//", "https://", $order_info['store_url']) : $order_info['store_url'];
 
 			if ($order_info['invoice_no']) {
 				$data['invoice_no'] = $order_info['invoice_prefix'] . $order_info['invoice_no'];


### PR DESCRIPTION
Prevent store_url being re-written from "https://" to "httpss://" when admin is served securely and order's store_url already begins "https". Also, prevent error when order store_url contains a reference of "http" anywhere else. Lastly, preg_replace rather than basic str_replace to only affect the initial protocol part URL part, not any subsequent occurrences.