### PR TITLE
Allow unregister of single event actions

### DIFF
--- a/upload/system/engine/action.php
+++ b/upload/system/engine/action.php
@@ -46,4 +46,8 @@ class Action {
 			return new \Exception('Error: Could not call ' . $this->route . '/' . $this->method . '!');
 		}
 	}
+	
+	public function getRoute() {
+		return $this->route;
+	}	
 }

--- a/upload/system/engine/event.php
+++ b/upload/system/engine/event.php
@@ -24,9 +24,9 @@ class Event {
 		if (null === $action) {
 			unset($this->data[$trigger]);
 		} else {
-			foreach ($this->data[$trigger] as $data_key => $data_action) {
-				if ($data_action->getRoute() == $action->getRoute()) {
-					unset($this->data[$trigger][$data_key]);
+			foreach ($this->data[$trigger] as $trigger_key => $trigger_action) {
+				if ($trigger_action->getRoute() == $action->getRoute()) {
+					unset($this->data[$trigger][$trigger_key]);
 				}
 			}
 		}

--- a/upload/system/engine/event.php
+++ b/upload/system/engine/event.php
@@ -6,19 +6,29 @@
 */
 class Event {
 	protected $registry;
-	public $data = array();
+	protected $data = array();
 
 	public function __construct($registry) {
 		$this->registry = $registry;
 	}
 
-	public function register($trigger, $action) {
+	public function register($trigger, Action $action) {
 		$this->data[$trigger][] = $action;
 	}
 	
-	public function unregister($trigger, $action) {
-		if (isset($this->data[$trigger])) {
+	public function unregister($trigger, Action $action = null) {
+		if (!isset($this->data[$trigger])) {
+			return;
+		}
+
+		if (null === $action) {
 			unset($this->data[$trigger]);
+		} else {
+			foreach ($this->data[$trigger] as $data_key => $data_action) {
+				if ($data_action->getRoute() == $action->getRoute()) {
+					unset($this->data[$trigger][$data_key]);
+				}
+			}
 		}
 	}
 
@@ -35,4 +45,8 @@ class Event {
 			}
 		}
 	}
+	
+	public function getData() {
+		return $this->data;
+	}	
 }


### PR DESCRIPTION
Currently the event implementation removes all of the actions for a given event trigger. Related to #4074

This pull request makes possible to unregister a certain action only. It also adds typehint for the action argument to allow registering of Action class instances only. The current possibility to unregister the entire trigger has been kept as the action argument is optional.

The $data class variable has been made protected in order to prevent unneeded modifications through direct access (they should happen via register/unregister methods only). A getData() method has been added if someone wants to inspect the events though.