### PR TITLE
Change config variables to fix full url paths

### DIFF
--- a/upload/.htaccess.txt
+++ b/upload/.htaccess.txt
@@ -19,6 +19,10 @@ Options -Indexes
 RewriteEngine On
 # If your opencart installation does not run on the main web folder make sure you folder it does run in ie. / becomes /shop/
 
+# Enable always-on SSL
+# RewriteCond %{SERVER_PORT} 80 
+# RewriteRule ^(.*)$ https://www.yourdomain.com/$1 [R,L]
+
 RewriteBase /
 RewriteRule ^sitemap.xml$ index.php?route=feed/google_sitemap [L]
 RewriteRule ^googlebase.xml$ index.php?route=feed/google_base [L]

--- a/upload/system/config/admin.php
+++ b/upload/system/config/admin.php
@@ -1,7 +1,7 @@
 <?php
 // Site
-$_['site_base']         = HTTP_SERVER;
-$_['site_ssl']          = HTTPS_SERVER;
+$_['config_url']         = HTTP_SERVER;
+$_['config_ssl']          = HTTPS_SERVER;
 
 // Database
 $_['db_autostart']      = true;

--- a/upload/system/config/admin.php
+++ b/upload/system/config/admin.php
@@ -1,7 +1,7 @@
 <?php
 // Site
-$_['config_url']         = HTTP_SERVER;
-$_['config_ssl']          = HTTPS_SERVER;
+$_['config_url']        = HTTP_SERVER;
+$_['config_ssl']        = HTTPS_SERVER;
 
 // Database
 $_['db_autostart']      = true;

--- a/upload/system/config/catalog.php
+++ b/upload/system/config/catalog.php
@@ -1,7 +1,7 @@
 <?php
 // Site
-$_['config_url']        = HTTP_SERVER;
-$_['config_ssl']         = HTTPS_SERVER;
+$_['config_url']       = HTTP_SERVER;
+$_['config_ssl']       = HTTPS_SERVER;
 
 //Url
 $_['url_autostart']    = false;

--- a/upload/system/config/catalog.php
+++ b/upload/system/config/catalog.php
@@ -1,7 +1,7 @@
 <?php
 // Site
-$_['site_base']        = HTTP_SERVER;
-$_['site_ssl']         = HTTPS_SERVER;
+$_['config_url']        = HTTP_SERVER;
+$_['config_ssl']         = HTTPS_SERVER;
 
 //Url
 $_['url_autostart']    = false;

--- a/upload/system/framework.php
+++ b/upload/system/framework.php
@@ -37,7 +37,7 @@ $registry->set('cache', new Cache($config->get('cache_type'), $config->get('cach
 
 // Url
 if ($config->get('url_autostart')) {
-	$registry->set('url', new Url($config->get('site_base'), $config->get('site_ssl')));
+	$registry->set('url', new Url($config->get('config_url'), $config->get('config_ssl')));
 }
 
 // Language


### PR DESCRIPTION
Change unused $_['site_base'] and $_['site_ssl'] to $_['config_url'] and
$_['config_ssl'] which is used throughout the project. Fixes full url
path not being called in on SSL, which consequently fixes issue with
always-on SSL with SEO_links not working.