### PR TITLE
Change heading_title variable to match Module settings in Admin

### DIFF
--- a/upload/catalog/controller/module/featured.php
+++ b/upload/catalog/controller/module/featured.php
@@ -3,7 +3,7 @@ class ControllerModuleFeatured extends Controller {
 	public function index($setting) {
 		$this->load->language('module/featured');
 
-		$data['heading_title'] = $this->language->get('heading_title');
+		$data['heading_title'] = $setting['name'];
 
 		$data['text_tax'] = $this->language->get('text_tax');
 


### PR DESCRIPTION
Now that OC supports more than one instance of the module in the same layout, we can have different titles to each one.

Example: One instance of the featured module with chairs with the title "Check out our chairs"; and another instance with tables with the title "Check out our tables". We can have 2 modules, with different titles instead of 2 modules, with different products and the same "Featured" title. 

Just change

$data['heading_title'] = $this->language->get('heading_title');

to

$data['heading_title'] = $setting['name'];

This could be applied to other modules too..