### PR TITLE
returning directly via ob_get_clean

### DIFF
--- a/upload/system/library/template/php.php
+++ b/upload/system/library/template/php.php
@@ -10,21 +10,17 @@ final class PHP {
 	public function render($template) {
 		$file = DIR_TEMPLATE . $template;
 
-		if (file_exists($file)) {
+		if (is_file($file)) {
 			extract($this->data);
 
 			ob_start();
 
 			require($file);
 
-			$output = ob_get_contents();
-
-			ob_end_clean();
-
-			return $output;
-		} else {
-			trigger_error('Error: Could not load template ' . $file . '!');
-			exit();
+			return ob_get_clean();
 		}
+
+		trigger_error('Error: Could not load template ' . $file . '!');
+		exit();
 	}	
 }


### PR DESCRIPTION
`ob_get_clean()` acts like `ob_get_contents()` + `ob_end_clean()` combined call, we can return directly without assigning the buffer to a variable.

returning inside conditional allows us to get rid of `else` as well