### PR TITLE
Add get event to the event extension in the admin

### DIFF
--- a/upload/admin/model/extension/event.php
+++ b/upload/admin/model/extension/event.php
@@ -9,4 +9,10 @@ class ModelExtensionEvent extends Model {
 	public function deleteEvent($code) {
 		$this->db->query("DELETE FROM " . DB_PREFIX . "event WHERE `code` = '" . $this->db->escape($code) . "'");
 	}
+	
+	public function getEvent($code, $trigger, $action) {
+		$event = $this->db->query("SELECT * FROM " . DB_PREFIX . "event WHERE `code` = '" . $this->db->escape($code) . "' AND `trigger` = '" . $this->db->escape($trigger) . "' AND `action` = '" . $this->db->escape($action) . "'");
+		
+		return $event->rows;
+	}
 }


### PR DESCRIPTION
This is useful when you need to update an extension/module/theme and be sure it kept the events, or even for manipulating and solve conflicts.

The function will return the events using the same variables of the add event function.