### PR TITLE
Fix to issue #4223

### DIFF
--- a/upload/admin/controller/payment/eway.php
+++ b/upload/admin/controller/payment/eway.php
@@ -295,14 +295,14 @@ class ControllerPaymentEway extends Controller {
 				$json['error'] = true;
 				$reason = '';
 				if ($result === false) {
-					$reason = $this->config->get('text_unknown_failure');
+					$reason = $this->language->get('text_unknown_failure');
 				} else {
 					$errors = explode(',', $result->Errors);
 					foreach ($errors as $error) {
 						$reason .= $this->language->get('text_card_message_' . $result->Errors);
 					}
 				}
-				$json['message'] = $this->config->get('text_refund_failed') . $reason;
+				$json['message'] = $this->language->get('text_refund_failed') . $reason;
 			} else {
 				$eway_order = $this->model_payment_eway->getOrder($order_id);
 				$this->model_payment_eway->addTransaction($eway_order['eway_order_id'], $result->Refund->TransactionID, 'refund', $result->Refund->TotalAmount / 100, $eway_order['currency_code']);
@@ -358,7 +358,7 @@ class ControllerPaymentEway extends Controller {
 						$reason .= $this->language->get('text_card_message_' . $result->Errors);
 					}
 				}
-				$json['message'] = $this->config->get('text_capture_failed') . $reason;
+				$json['message'] = $this->language->get('text_capture_failed') . $reason;
 			} else {
 				$this->model_payment_eway->addTransaction($eway_order['eway_order_id'], $result->TransactionID, 'payment', $capture_amount, $eway_order['currency_code']);
 


### PR DESCRIPTION
Amended ticket #4223. 

1) Line 298: 

```$json['message'] = $this->config->get('text_refund_failed') . $reason;```

Changed to: 

```$reason = $this->language->get('text_unknown_failure');```

2) Line 305:

```$json['message'] = $this->config->get('text_refund_failed') . $reason;```

Changed to: 

```$json['message'] = $this->language->get('text_refund_failed') . $reason;```

3) Line 361: 

```$json['message'] = $this->config->get('text_capture_failed') . $reason;```

Changed to: 

```$json['message'] = $this->language->get('text_capture_failed') . $reason;```

The ```$json``` array should now pick it's data from right method. 

Thanks.