### PR TITLE
adjust to add session source

### DIFF
--- a/upload/install/opencart.sql
+++ b/upload/install/opencart.sql
@@ -356,6 +356,7 @@ CREATE TABLE `oc_cart` (
   `cart_id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT,
   `customer_id` int(11) NOT NULL,
   `session_id` varchar(32) NOT NULL,
+  `session_source` varchar(32) NOT NULL,
   `product_id` int(11) NOT NULL,
   `recurring_id` int(11) NOT NULL,
   `option` text NOT NULL,


### PR DESCRIPTION
This request addresses #4246. 

I believe the issue here is that when an admin user edits or creates and order for a customer the products in that order get added to the cart table. When the customer logs in and their cart object is initialized it captures all of the items in the cart table for that customer session. All items in the cart the admin is editing will appear in the customers session unexpectedly. 

To reproduce: 

1 - add or edit an order for a registered customer in the admin dashboard
2 - in a new browser session log into the catalog view as that customer 
3 - all of the items from the order edited by the admin will show up in the customer cart without the customer having added them. 

The pull request adds a field to the cart table for a session source which will be either "api" or "catalog". Cart items generated via an API call with an api_id in the session will be flagged as api generated cart items and will not be collected into the customer cart in a regular catalog session.