### PR TITLE
remove unneeded else (shortcircuit return)

### DIFF
--- a/upload/system/engine/loader.php
+++ b/upload/system/engine/loader.php
@@ -23,11 +23,11 @@ final class Loader {
 		// Trigger the post events
 		$result = $this->registry->get('event')->trigger('controller/' . $route . '/after', array(&$route, &$data, &$output));
 		
-		if (!($output instanceof Exception)) {
-			return $output;
-		} else {
+		if ($output instanceof Exception) {
 			return false;
 		}
+
+		return $output;
 	}
 	
 	public function model($route) {


### PR DESCRIPTION
Questions:

1) Should we also add
```php
if ($result) {
    return $result;
}
```

before the last return?

2) Should we move the return false on Exception before the after event so it does not get triggered or do we want to trigger the after event even for actions that return exceptions (call to magic methods, private methods, nonexistent controller files)?