### PR TITLE
Update address.php

### DIFF
--- a/upload/catalog/controller/account/address.php
+++ b/upload/catalog/controller/account/address.php
@@ -519,7 +519,7 @@ class ControllerAccountAddress extends Controller {
 		foreach ($custom_fields as $custom_field) {
 			if (($custom_field['location'] == 'address') && $custom_field['required'] && empty($this->request->post['custom_field'][$custom_field['custom_field_id']])) {
 				$this->error['custom_field'][$custom_field['custom_field_id']] = sprintf($this->language->get('error_custom_field'), $custom_field['name']);
-			} elseif (($custom_field['type'] == 'text' && !empty($custom_field['validation']) && $custom_field['location'] == 'address') && !filter_var($this->request->post['custom_field'][$custom_field['custom_field_id']], FILTER_VALIDATE_REGEXP, array('options' => array('regexp' => $custom_field['validation'])))) {
+			} elseif (($custom_field['type'] == 'text') && !empty($custom_field['validation']) && ($custom_field['location'] == 'address') && !filter_var($this->request->post['custom_field'][$custom_field['custom_field_id']], FILTER_VALIDATE_REGEXP, array('options' => array('regexp' => $custom_field['validation'])))) {
                 $this->error['custom_field'][$custom_field['custom_field_id']] = sprintf($this->language->get('error_custom_field_validate'), $custom_field['name']);
             }
 		}


### PR DESCRIPTION
Fix missing chars to prevent error:

[21-Apr-2016 14:06:18 America/Mexico_City] PHP Parse error: syntax error, unexpected '&&' (T_BOOLEAN_AND), expecting ')' in /home/misitio/public_html/store/catalog/controller/account/address.php on line 522

PD: Credits to daosorio for find the error.