### PR TITLE
renaming for clarity

### DIFF
--- a/upload/system/engine/event.php
+++ b/upload/system/engine/event.php
@@ -36,7 +36,7 @@ class Event {
 		}
 	}
 	
-	public function trigger($event, $args = array()) {
+	public function trigger($event, array $args = array()) {
 		foreach ($this->data as $trigger => $actions) {
 			if (preg_match('/^' . str_replace(array('\*', '\?'), array('.*', '.'), preg_quote($trigger, '/')) . '/', $event)) {
 				foreach ($actions as $action) {

--- a/upload/system/engine/event.php
+++ b/upload/system/engine/event.php
@@ -36,11 +36,11 @@ class Event {
 		}
 	}
 	
-	public function trigger($trigger, $args = array()) {
-		foreach ($this->data as $key => $value) {
-			if (preg_match('/^' . str_replace(array('\*', '\?'), array('.*', '.'), preg_quote($key, '/')) . '/', $trigger)) {
-				foreach ($value as $event) {
-					$result = $event->execute($this->registry, $args);
+	public function trigger($event, $args = array()) {
+		foreach ($this->data as $trigger => $actions) {
+			if (preg_match('/^' . str_replace(array('\*', '\?'), array('.*', '.'), preg_quote($trigger, '/')) . '/', $event)) {
+				foreach ($actions as $action) {
+					$result = $action->execute($this->registry, $args);
 					
 					if (!is_null($result) && !($result instanceof Exception)) {
 						return $result;


### PR DESCRIPTION
1. the variable name `$key` is used as the numeric index placeholder for actions under the same `$trigger` key in `unregister()` and `removeAction()` methods, while is been used as a placeholder for a trigger key in the `trigger(...)` method

2. every `$this->data[$trigger]` is an array of actions, so i believe it's clearer to use that name instead of `$value` ($action->execute(..) is also more consistent with the resto of oc code)

3. renaming the argument in `trigger($event, ...)` allows us to consistenty use the name `$trigger` for event keys in `$this->data` throughout the whole class