### PR TITLE
fix image-modal flickering + cache jQuery objects

### DIFF
--- a/upload/admin/view/javascript/common.js
+++ b/upload/admin/view/javascript/common.js
@@ -107,15 +107,20 @@ $(document).ready(function() {
 
 	// Image Manager
 	$(document).delegate('a[data-toggle=\'image\']', 'click', function(e) {
+		var $element = $(this);
+		var $popover = $element.data('bs.popover'); // element has bs popover?
+		
 		e.preventDefault();
 
-		$('.popover').popover('hide', function() {
-			$('.popover').remove();
-		});
+		// destroy all image popovers
+		$('a[data-toggle="image"]').popover('destroy');
 
-		var element = this;
+		// remove flickering (do not re-add popover when clicking for removal)
+		if ($popover) {
+			return;
+		}
 
-		$(element).popover({
+		$element.popover({
 			html: true,
 			placement: 'right',
 			trigger: 'manual',
@@ -124,21 +129,28 @@ $(document).ready(function() {
 			}
 		});
 
-		$(element).popover('show');
+		$element.popover('show');
 
 		$('#button-image').on('click', function() {
+			var $button = $(this);
+			var $icon   = $button.find('> i');
+			
 			$('#modal-image').remove();
 
 			$.ajax({
-				url: 'index.php?route=common/filemanager&token=' + getURLVar('token') + '&target=' + $(element).parent().find('input').attr('id') + '&thumb=' + $(element).attr('id'),
+				url: 'index.php?route=common/filemanager&token=' + getURLVar('token') + '&target=' + $element.parent().find('input').attr('id') + '&thumb=' + $element.attr('id'),
 				dataType: 'html',
 				beforeSend: function() {
-					$('#button-image i').replaceWith('<i class="fa fa-circle-o-notch fa-spin"></i>');
-					$('#button-image').prop('disabled', true);
+					$button.prop('disabled', true);
+					if ($icon.length) {
+						$icon.attr('class', 'fa fa-circle-o-notch fa-spin');
+					}
 				},
 				complete: function() {
-					$('#button-image i').replaceWith('<i class="fa fa-pencil"></i>');
-					$('#button-image').prop('disabled', false);
+					$button.prop('disabled', false);
+					if ($icon.length) {
+						$icon.attr('class', 'fa fa-pencil');
+					}
 				},
 				success: function(html) {
 					$('body').append('<div id="modal-image" class="modal">' + html + '</div>');
@@ -147,19 +159,15 @@ $(document).ready(function() {
 				}
 			});
 
-			$(element).popover('hide', function() {
-				$('.popover').remove();
-			});
+			$element.popover('destroy');
 		});
 
 		$('#button-clear').on('click', function() {
-			$(element).find('img').attr('src', $(element).find('img').attr('data-placeholder'));
+			$element.find('img').attr('src', $element.find('img').attr('data-placeholder'));
 
-			$(element).parent().find('input').val('');
+			$element.parent().find('input').val('');
 
-			$(element).popover('hide', function() {
-				$('.popover').remove();
-			});
+			$element.popover('destroy');
 		});
 	});
 


### PR DESCRIPTION
- fix image-modal flickering on second (close-action click)
- using bootstrap popover api to determine it's existence
- caching $element
- caching $('#button-image') and its icon inside the callback variables
- icon is not replaced, only the class attribute is replaced
