### PR TITLE
changed main content type of email

### DIFF
--- a/upload/system/library/mail.php
+++ b/upload/system/library/mail.php
@@ -102,7 +102,7 @@ class Mail {
 		
 		$header .= 'Return-Path: ' . $this->from . PHP_EOL;
 		$header .= 'X-Mailer: PHP/' . phpversion() . PHP_EOL;
-		$header .= 'Content-Type: multipart/related; boundary="' . $boundary . '"' . PHP_EOL . PHP_EOL;
+		$header .= 'Content-Type: multipart/mixed; boundary="' . $boundary . '"' . PHP_EOL . PHP_EOL;
 
 		if (!$this->html) {
 			$message  = '--' . $boundary . PHP_EOL;


### PR DESCRIPTION
Content-Type: multipart/related creates a visualization issue on iOS email clients.
"multipart/mixed" solves this issue and the emails are still visualized correctly on multiple clients.