### PR TITLE
memcache entries deletion 

### DIFF
--- a/upload/system/library/cache/mem.php
+++ b/upload/system/library/cache/mem.php
@@ -15,11 +15,28 @@ class Mem {
 		return $this->cache->get(CACHE_PREFIX . $key);
 	}
 
-	public function set($key,$value) {
+	public function set($key, $value) {
 		return $this->cache->set(CACHE_PREFIX . $key, $value, MEMCACHE_COMPRESSED, $this->expire);
 	}
 
 	public function delete($key) {
-		$this->cache->delete(CACHE_PREFIX . $key);
+		$all_slabs = $this->memcache->getExtendedStats('slabs');
+		foreach ($all_slabs as $server => $slabs) {
+			foreach ($slabs as $slab_id => $slab_meta) {
+				if (!is_int($slab_id)) {
+					continue;
+				}
+				$cachedump = $this->memcache->getExtendedStats('cachedump', $slab_id, 1000000);
+				foreach($cachedump as $server => $entries) {
+					if (!empty($entries) && is_array($entries)) {
+						foreach(array_keys($entries) as $entry_key) {
+							if (strpos($entry_key, CACHE_PREFIX . $key) === 0) {
+								$this->cache->delete($entry_key);
+							}
+						}
+					}
+				}
+			}
+		}
 	}
 }

--- a/upload/system/library/cache/mem.php
+++ b/upload/system/library/cache/mem.php
@@ -4,7 +4,7 @@ class Mem {
 	private $expire;
 	private $memcache;
 	
-	const CACHEDUMP_LIMIT = 1000000;
+	const CACHEDUMP_LIMIT = 9999;
 
 	public function __construct($expire) {
 		$this->expire = $expire;

--- a/upload/system/library/cache/mem.php
+++ b/upload/system/library/cache/mem.php
@@ -29,9 +29,9 @@ class Mem {
 					continue;
 				}
 				$cachedump = $this->memcache->getExtendedStats('cachedump', $slab_id, self::CACHEDUMP_LIMIT);
-				foreach($cachedump as $server => $entries) {
+				foreach ($cachedump as $server => $entries) {
 					if (!empty($entries) && is_array($entries)) {
-						foreach(array_keys($entries) as $entry_key) {
+						foreach (array_keys($entries) as $entry_key) {
 							if (strpos($entry_key, CACHE_PREFIX . $key) === 0) {
 								$this->memcache->delete($entry_key);
 							}


### PR DESCRIPTION
Deletion from memcached server(s) should have the same effect of the file cache adapter deletion.
When we use `$this->cache->delete('product')`, this call will delete all cache files with basename starting with 'product'. The same should happen with memcache adapter, but in the current imlementation it only deletes the `CACHE_PREFIX . 'product'` key.
Pls Daniel verify/test (I'm porting this mod from my memcache adapter that i have been using on production for 3+ year. I tested the mod in my setup, pls make sure to test it in your environment too as my original class extends a common abstract adapter with more properties and methods and sometimes different visibility).