### PR TITLE
Fixes Create new order from admin panel always show the last created order products list #4286

### DIFF
--- a/upload/catalog/controller/api/order.php
+++ b/upload/catalog/controller/api/order.php
@@ -351,6 +351,9 @@ class ControllerApiOrder extends Controller {
 				}
 
 				$this->model_checkout_order->addOrderHistory($json['order_id'], $order_status_id);
+				
+				// clear cart since the order has already been successfully stored.
+				$this->cart->clear();
 			}
 		}
 


### PR DESCRIPTION
fixes #4286

The problem with the issue was even after an order is completed from the back-end the oc_cart table entries remained and that resulted in them showing up again in another new order's product list.

Solution was to clear the cart once the order has been successfully added.