### PR TITLE
Correct filter data passed to google base model

### DIFF
--- a/upload/admin/controller/feed/google_base.php
+++ b/upload/admin/controller/feed/google_base.php
@@ -168,10 +168,15 @@ class ControllerFeedGoogleBase extends Controller {
 		}
 
 		$data['google_base_categories'] = array();
+		
+		$filter_data = array(
+			'start' => ($page - 1) * 10,
+			'limit' => 10
+		);
 
 		$this->load->model('feed/google_base');
 
-		$results = $this->model_feed_google_base->getCategories(($page - 1) * 10, 10);
+		$results = $this->model_feed_google_base->getCategories($filter_data);
 
 		foreach ($results as $result) {
 			$data['google_base_categories'][] = array(


### PR DESCRIPTION
The getCategories function is expecting an array with keys 'start' and 'limit' to pull the correctly paginated records from the data set.

The current code is instead passing 2 individual parameters - meaning all records are rendered on every paginated page.

Corrected to create the $filter_data array, and pass to the model for correct rendering.