### PR TITLE
Prevent resize function creating new cache file when original file hasn't changed

### DIFF
--- a/upload/catalog/model/tool/image.php
+++ b/upload/catalog/model/tool/image.php
@@ -10,7 +10,7 @@ class ModelToolImage extends Model {
 		$old_image = $filename;
 		$new_image = 'cache/' . utf8_substr($filename, 0, utf8_strrpos($filename, '.')) . '-' . $width . 'x' . $height . '.' . $extension;
 
-		if (!is_file(DIR_IMAGE . $new_image) || (filectime(DIR_IMAGE . $old_image) > filectime(DIR_IMAGE . $new_image))) {
+		if (!is_file(DIR_IMAGE . $new_image) || (filemtime(DIR_IMAGE . $old_image) > filemtime(DIR_IMAGE . $new_image))) {
 			$path = '';
 
 			$directories = explode('/', dirname(str_replace('../', '', $new_image)));


### PR DESCRIPTION
Change:
Replaced filectime with filemtime on line #13.

Background issue:
OpenCart 2.0.3.1 running on Windows Server 2012 R2 with IIS8 and PHP 5.4.45 and 7.0.7 thinks $old_image is newer than $new_image therefore recreates the cached file every time the resize function is called.  

This is only noticeable on categories with many products as time to first byte on page load was consistently pushing 20 seconds.

Reason for change:
I believe filectime is inappropriate when dealing with cached files as it changes when permissions, owner, group, or other meta data is updated.

filemtime on the other hand deals with when the data blocks of a file were being written, ie. when the file content last changed.

OpenCart 1.5.6.4 uses filemtime, I'm unsure when or why this changed.

Other notes:
- I'm unsure what causes PHP to think permissions/owner/group/meta data has changed when filectime is used
- Change back to filemtime has not been tested on any other OS
- I don't have access to any other environment to check how filectime behaves on Linux/Apache
