### PR TITLE
Fix extension error/permission action.

### DIFF
--- a/upload/admin/controller/startup/permission.php
+++ b/upload/admin/controller/startup/permission.php
@@ -13,8 +13,15 @@ class ControllerStartupPermission extends Controller {
 			if (isset($part[1])) {
 				$route .= '/' . $part[1];
 			}
-			
-			if (isset($part[2])) {
+
+			$actions = array(
+				'install',
+				'uninstall',
+				'add',
+				'delete'
+			);
+
+			if (isset($part[2]) && !in_array($part[2], $actions)) {
 				// If a 3rd part is found we need to check if its under one of the extension folders.
 				$routes = array(
 					'extension/dashboard',


### PR DESCRIPTION
Prevent adding part 2 to route when install or uninstall extension, but dashboard errors remain.