### PR TITLE
Fix klarna totals

### DIFF
--- a/upload/catalog/controller/extension/payment/klarna_invoice.php
+++ b/upload/catalog/controller/extension/payment/klarna_invoice.php
@@ -80,7 +80,7 @@ class ControllerExtensionPaymentKlarnaInvoice extends Controller {
 					$taxes = array();
 					
 					// We have to put the totals in an array so that they pass by reference.
-					$this->{'model_extension_total_' . $result['code']}->getTotal(array($total_data, $total, $taxes));
+					$this->{'model_extension_total_' . $result['code']}->getTotal(array("totals"=>$total_data, "total"=>$total, "taxes"=>$taxes));
 
 					$amount = 0;
 


### PR DESCRIPTION
When activating the klarna module, a lot of notices and warnings came up in the checkout page. This was caused by array keys missing in the totals. This commit fixes this problem.