### PR TITLE
install and uninstall functions not supported in compatibility

### DIFF
--- a/upload/admin/controller/event/compatibility.php
+++ b/upload/admin/controller/event/compatibility.php
@@ -7,7 +7,8 @@ class ControllerEventCompatibility extends Controller {
 		$part = explode('/', $route);
 				
 		if (!is_file(DIR_APPLICATION . 'controller/' . $route . '.php') && is_file(DIR_APPLICATION . 'controller/' . $part[1] . '/' . $part[2] . '.php')) {
-			$route = $part[1] . '/' . $part[2];
+			unset($part[0]);
+			$route = implode('/', $part);
 		}
 	}
 	


### PR DESCRIPTION
Hi

I noticed that functions install and uninstall were not supported for backwards compatibility. 

the issue lies in this line at /admin/controller/event/compatibility.php

line 10 - route = $part[1] . '/' . $part[2];

it simply drops the method after the route. 

so i have decided to add this fix - hope it gets added to the release since all my modules use theres nice methods.

thanks
