### PR TITLE
Fixed Issue #4728

### DIFF
--- a/upload/catalog/model/tool/image.php
+++ b/upload/catalog/model/tool/image.php
@@ -1,7 +1,7 @@
 <?php
 class ModelToolImage extends Model {
 	public function resize($filename, $width, $height) {
-		if (!is_file(DIR_IMAGE . $filename) || substr(str_replace('\\', '/', realpath(DIR_IMAGE . $filename)), 0, strlen(DIR_IMAGE)) != DIR_IMAGE) {
+		if (!is_file(DIR_IMAGE . $filename) || substr(str_replace('\\', '/', realpath(DIR_IMAGE . $filename)), 0, strlen(DIR_IMAGE)) != str_replace('\\', '/', DIR_IMAGE)) {
 			return;
 		}
 


### PR DESCRIPTION
Issue #4728 has been amended. 

Added extra ```str_replace()``` call to replace the sub-string on the right side.

This should stop the paths from breaking. 

Thank you.