### PR TITLE
Fixed Issue #4739

### DIFF
--- a/upload/admin/view/javascript/common.js
+++ b/upload/admin/view/javascript/common.js
@@ -77,7 +77,15 @@ $(document).ready(function() {
 			$('#menu > li > ul').removeClass('in collapse');
 			$('#menu > li > ul').removeAttr('style');
 		} else {
-			localStorage.setItem('column-left', 'active');
+			if (typeof localStorage === 'object') {
+				try {
+					localStorage.setItem('column-left', 'active');
+				} catch (e) {
+					Storage.prototype._setItem = Storage.prototype.setItem;
+					Storage.prototype.setItem = function() {};
+					alert('Your web browser does not support storing settings locally. In Safari, the most common cause of this is using "Private Browsing Mode". Some settings may not save or some features may not work properly for you.');
+				}
+			}
 
 			$('#button-menu i').replaceWith('<i class="fa fa-dedent fa-lg"></i>');
 


### PR DESCRIPTION
Fixed issue #4739 with admin menu button not working to make vertical
menu slide out from the left on Safari browser, in Private Mode.