### PR TITLE
changing the function to return the total of reviews that it is waiti…

### DIFF
--- a/upload/admin/controller/common/header.php
+++ b/upload/admin/controller/common/header.php
@@ -97,7 +97,7 @@ class ControllerCommonHeader extends Controller {
 			// Reviews
 			$this->load->model('catalog/review');
 
-			$review_total = $this->model_catalog_review->getTotalReviews(array('filter_status' => 0));
+			$review_total = $this->model_catalog_review->getTotalReviewsAwaitingApproval();
 
 			$data['review_total'] = $review_total;
 


### PR DESCRIPTION
I'm changing the function to return the total of reviews that it is waiting approval.

getTotalReviewsAwaitingApproval() is more performatic and semantic than getTotalReviews($data = array()) to return only the total of reviews that it is waiting the approval.

getTotalReviews($data = array())
$sql = "SELECT COUNT(*) AS total FROM " . DB_PREFIX . "review r LEFT JOIN " . DB_PREFIX . "product_description pd ON (r.product_id = pd.product_id) WHERE pd.language_id = '" . (int)$this->config->get('config_language_id') . "'";

getTotalReviewsAwaitingApproval()
$query = $this->db->query("SELECT COUNT(*) AS total FROM " . DB_PREFIX . "review WHERE status = '0'");
