### PR TITLE
Fixed empty keyword entry on new category and information page

### DIFF
--- a/upload/admin/model/catalog/category.php
+++ b/upload/admin/model/catalog/category.php
@@ -45,7 +45,7 @@ class ModelCatalogCategory extends Model {
 			}
 		}
 
-		if (isset($data['keyword'])) {
+		if ($data['keyword']) {
 			$this->db->query("INSERT INTO " . DB_PREFIX . "url_alias SET query = 'category_id=" . (int)$category_id . "', keyword = '" . $this->db->escape($data['keyword']) . "'");
 		}
 

--- a/upload/admin/model/catalog/information.php
+++ b/upload/admin/model/catalog/information.php
@@ -21,7 +21,7 @@ class ModelCatalogInformation extends Model {
 			}
 		}
 
-		if (isset($data['keyword'])) {
+		if ($data['keyword']) {
 			$this->db->query("INSERT INTO " . DB_PREFIX . "url_alias SET query = 'information_id=" . (int)$information_id . "', keyword = '" . $this->db->escape($data['keyword']) . "'");
 		}
 


### PR DESCRIPTION
When new category and information pages are created, it adds empty seo keyword.
Fixed it.