### PR TITLE
Secure Trading Fix

### DIFF
--- a/upload/catalog/controller/extension/payment/securetrading_ws.php
+++ b/upload/catalog/controller/extension/payment/securetrading_ws.php
@@ -89,8 +89,7 @@ class ControllerExtensionPaymentSecureTradingWs extends Controller {
 				$customer_node->addChild('accept', $this->request->server['HTTP_ACCEPT']);
 
 				$billing_node = $request_node->addChild('billing');
-
-				$amount_node = $billing_node->addChild('amount', str_replace('.', '', $this->currency->format($order_info['total'], $order_info['currency_code'], $order_info['currency_value'], false)));
+				$amount_node = $billing_node->addChild('amount', str_replace('.', '', $this->model_extension_payment_securetrading_ws->format($order_info['total'], $order_info['currency_code'], $order_info['currency_value'])));
 				$amount_node->addAttribute('currencycode', $order_info['currency_code']);
 
 				$billing_node->addChild('premise', $order_info['payment_address_1']);
@@ -199,7 +198,7 @@ class ControllerExtensionPaymentSecureTradingWs extends Controller {
 				$name_node->addChild('first', $order_info['payment_firstname']);
 				$name_node->addChild('last', $order_info['payment_lastname']);
 
-				$amount_node = $billing_node->addChild('amount', str_replace('.', '', $this->currency->format($order_info['total'], $order_info['currency_code'], $order_info['currency_value'], false)));
+				$amount_node = $billing_node->addChild('amount', str_replace('.', '', $this->model_extension_payment_securetrading_ws->format($order_info['total'], $order_info['currency_code'], $order_info['currency_value'])));
 				$amount_node->addAttribute('currencycode', $order_info['currency_code']);
 
 				$payment_node = $billing_node->addChild('payment');

--- a/upload/catalog/model/extension/payment/securetrading_ws.php
+++ b/upload/catalog/model/extension/payment/securetrading_ws.php
@@ -62,6 +62,23 @@ class ModelExtensionPaymentSecureTradingWs extends Model {
 		return $response;
 	}
 
+	public function format($number, $currency, $value = '', $format = false) {
+
+		$decimal_place = $this->currency->getDecimalPlace($currency);
+
+		if (!$value) {
+			$value = $this->currency->getValue($currency);
+		}
+
+		$amount = $value ? (float)$number * $value : (float)$number;
+
+		$amount = number_format($amount, (int)$decimal_place);
+
+		if (!$format) {
+			return $amount;
+		}
+	}
+
 	public function getOrder($order_id) {
 		$qry = $this->db->query("SELECT * FROM `" . DB_PREFIX . "securetrading_ws_order` WHERE `order_id` = '" . (int)$order_id . "' LIMIT 1");
 


### PR DESCRIPTION
Fix for problem appearing with value being passed to the format method in Currency class and the last zero being dropped when amount was passed into round function.

Added new format method into the Secure Trading model.
Replaced round functionality with number_format and result conforms with XML spec Secure Trading require