### PR TITLE
Bug - whitespace in input and textarea

### DIFF
--- a/upload/admin/view/template/catalog/attribute_form.twig
+++ b/upload/admin/view/template/catalog/attribute_form.twig
@@ -29,7 +29,7 @@
             <div class="col-sm-10">
               {% for language in languages %}
               <div class="input-group"><span class="input-group-addon"><img src="language/{{ language.code }}/{{ language.code }}.png" title="{{ language.name }}" /></span>
-                <input type="text" name="attribute_description[{{ language.language_id }}][name]" value="{% if attribute_description[language.language_id] %} {{ attribute_description[language.language_id].name }} {% endif %}" placeholder="{{ entry_name }}" class="form-control" />
+                <input type="text" name="attribute_description[{{ language.language_id }}][name]" value="{{ attribute_description[language.language_id] ? attribute_description[language.language_id].name }}" placeholder="{{ entry_name }}" class="form-control" />
               </div>
               {% if error_name[language.language_id] %}
               <div class="text-danger">{{ error_name[language.language_id] }}</div>

--- a/upload/admin/view/template/catalog/attribute_group_form.twig
+++ b/upload/admin/view/template/catalog/attribute_group_form.twig
@@ -1,10 +1,10 @@
-{{ header %}{{ column_left }}
+{{ header }}{{ column_left }}
 <div id="content">
   <div class="page-header">
     <div class="container-fluid">
       <div class="pull-right">
         <button type="submit" form="form-attribute-group" data-toggle="tooltip" title="{{ button_save }}" class="btn btn-primary"><i class="fa fa-save"></i></button>
-        <a href="{{ cancel }}" data-toggle="tooltip" title="{% button_cancel }}" class="btn btn-default"><i class="fa fa-reply"></i></a></div>
+        <a href="{{ cancel }}" data-toggle="tooltip" title="{{ button_cancel }}" class="btn btn-default"><i class="fa fa-reply"></i></a></div>
       <h1>{{ heading_title }}</h1>
       <ul class="breadcrumb">
         {% for breadcrumb in breadcrumbs %}
@@ -30,7 +30,7 @@
             <div class="col-sm-10">
               {% for language in languages %}
               <div class="input-group"><span class="input-group-addon"><img src="language/{{ language.code }}/{{ language.code }}.png" title="{{ language.name }}" /></span>
-                <input type="text" name="attribute_group_description[{{ language.language_id }}][name]" value="{% if attribute_group_description[language.language_id] %} {{ attribute_group_description[language.language_id].name }} {% endif %}" placeholder="{{ entry_name }}" class="form-control" />
+                <input type="text" name="attribute_group_description[{{ language.language_id }}][name]" value="{{ attribute_group_description[language.language_id] ? attribute_group_description[language.language_id].name }}" placeholder="{{ entry_name }}" class="form-control" />
               </div>
               {% if error_name[language.language_id] %}
               <div class="text-danger">{{ error_name[language.language_id] }}</div>

--- a/upload/admin/view/template/catalog/category_form.twig
+++ b/upload/admin/view/template/catalog/category_form.twig
@@ -43,7 +43,7 @@
                   <div class="form-group required">
                     <label class="col-sm-2 control-label" for="input-name{{ language.language_id }}">{{ entry_name }}</label>
                     <div class="col-sm-10">
-                      <input type="text" name="category_description[{{ language.language_id }}][name]" value="{% if category_description[language.language_id] %} {{ category_description[language.language_id].name }} {% endif %}" placeholder="{{ entry_name }}" id="input-name{{ language.language_id }}" class="form-control" />
+                      <input type="text" name="category_description[{{ language.language_id }}][name]" value="{{ category_description[language.language_id] ? category_description[language.language_id].name }}" placeholder="{{ entry_name }}" id="input-name{{ language.language_id }}" class="form-control" />
                       {% if error_name[language.language_id] %}
                       <div class="text-danger">{{ error_name[language.language_id] }}</div>
                       {% endif %}
@@ -52,13 +52,13 @@
                   <div class="form-group">
                     <label class="col-sm-2 control-label" for="input-description{{ language.language_id }}">{{ entry_description }}</label>
                     <div class="col-sm-10">
-                      <textarea name="category_description[{{ language.language_id }}][description]" placeholder="{{ entry_description }}" id="input-description{{ language.language_id }}" class="form-control summernote">{% if category_description[language.language_id] %} {{ category_description[language.language_id].description }} {% endif %}</textarea>
+                      <textarea name="category_description[{{ language.language_id }}][description]" placeholder="{{ entry_description }}" id="input-description{{ language.language_id }}" class="form-control summernote">{{ category_description[language.language_id] ? category_description[language.language_id].description }}</textarea>
                     </div>
                   </div>
                   <div class="form-group required">
                     <label class="col-sm-2 control-label" for="input-meta-title{{ language.language_id }}">{{ entry_meta_title }}</label>
                     <div class="col-sm-10">
-                      <input type="text" name="category_description[{{ language.language_id }}][meta_title]" value="{% if category_description[language.language_id] %} {{ category_description[language.language_id].meta_title }} {% endif %}" placeholder="{{ entry_meta_title }}" id="input-meta-title{{ language.language_id }}" class="form-control" />
+                      <input type="text" name="category_description[{{ language.language_id }}][meta_title]" value="{{ category_description[language.language_id] ? category_description[language.language_id].meta_title }}" placeholder="{{ entry_meta_title }}" id="input-meta-title{{ language.language_id }}" class="form-control" />
                       {% if error_meta_title[language.language_id] %}
                       <div class="text-danger">{{ error_meta_title[language.language_id] }}</div>
                       {% endif %}
@@ -67,13 +67,13 @@
                   <div class="form-group">
                     <label class="col-sm-2 control-label" for="input-meta-description{{ language.language_id }}">{{ entry_meta_description }}</label>
                     <div class="col-sm-10">
-                      <textarea name="category_description[{{ language.language_id }}][meta_description]" rows="5" placeholder="{{ entry_meta_description }}" id="input-meta-description{{ language.language_id }}" class="form-control">{% if category_description[language.language_id] %} {{ category_description[language.language_id].meta_description }} {% endif %}</textarea>
+                      <textarea name="category_description[{{ language.language_id }}][meta_description]" rows="5" placeholder="{{ entry_meta_description }}" id="input-meta-description{{ language.language_id }}" class="form-control">{{ category_description[language.language_id] ? category_description[language.language_id].meta_description }}</textarea>
                     </div>
                   </div>
                   <div class="form-group">
                     <label class="col-sm-2 control-label" for="input-meta-keyword{{ language.language_id }}">{{ entry_meta_keyword }}</label>
                     <div class="col-sm-10">
-                      <textarea name="category_description[{{ language.language_id }}][meta_keyword]" rows="5" placeholder="{{ entry_meta_keyword }}" id="input-meta-keyword{{ language.language_id }}" class="form-control">{% if category_description[language.language_id] %} {{ category_description[language.language_id].meta_keyword }} {% endif %}</textarea>
+                      <textarea name="category_description[{{ language.language_id }}][meta_keyword]" rows="5" placeholder="{{ entry_meta_keyword }}" id="input-meta-keyword{{ language.language_id }}" class="form-control">{{ category_description[language.language_id] ? category_description[language.language_id].meta_keyword }}</textarea>
                     </div>
                   </div>
                 </div>
@@ -240,7 +240,7 @@
   </div>
   <script type="text/javascript" src="view/javascript/summernote/summernote.js"></script>
   <link href="view/javascript/summernote/summernote.css" rel="stylesheet" />
-  <script type="text/javascript" src="view/javascript/summernote/opencart.js"></script> 
+  <script type="text/javascript" src="view/javascript/summernote/opencart.js"></script>
   <script type="text/javascript"><!--
 $('input[name=\'path\']').autocomplete({
 	'source': function(request, response) {
@@ -267,7 +267,7 @@ $('input[name=\'path\']').autocomplete({
 		$('input[name=\'parent_id\']').val(item['value']);
 	}
 });
-//--></script> 
+//--></script>
   <script type="text/javascript"><!--
 $('input[name=\'filter\']').autocomplete({
 	'source': function(request, response) {
@@ -296,7 +296,7 @@ $('input[name=\'filter\']').autocomplete({
 $('#category-filter').delegate('.fa-minus-circle', 'click', function() {
 	$(this).parent().remove();
 });
-//--></script> 
+//--></script>
   <script type="text/javascript"><!--
 $('#language a:first').tab('show');
 //--></script></div>

--- a/upload/admin/view/template/catalog/download_form.twig
+++ b/upload/admin/view/template/catalog/download_form.twig
@@ -30,7 +30,7 @@
             <div class="col-sm-10">
               {% for language in languages %}
               <div class="input-group"> <span class="input-group-addon"><img src="language/{{ language.code }}/{{ language.code }}.png" title="{{ language.name }}" /></span>
-                <input type="text" name="download_description[{{ language.language_id }}][name]" value="{% if download_description[language.language_id] %} {{ download_description[language.language_id].name }} {% endif %}" placeholder="{{ entry_name }}" class="form-control" />
+                <input type="text" name="download_description[{{ language.language_id }}][name]" value="{{ download_description[language.language_id] ? download_description[language.language_id].name }}" placeholder="{{ entry_name }}" class="form-control" />
               </div>
               {% if error_name[language.language_id] %}
               <div class="text-danger">{{ error_name[language.language_id] }}</div>
@@ -67,45 +67,45 @@
 <script type="text/javascript"><!--
 $('#button-upload').on('click', function() {
 	$('#form-upload').remove();
-	
+
 	$('body').prepend('<form enctype="multipart/form-data" id="form-upload" style="display: none;"><input type="file" name="file" /></form>');
 
 	$('#form-upload input[name=\'file\']').trigger('click');
-	
+
 	if (typeof timer != 'undefined') {
     	clearInterval(timer);
 	}
-	
+
 	timer = setInterval(function() {
 		if ($('#form-upload input[name=\'file\']').val() != '') {
-			clearInterval(timer);		
-			
+			clearInterval(timer);
+
 			$.ajax({
 				url: 'index.php?route=catalog/download/upload&token={{ token }}',
-				type: 'post',		
+				type: 'post',
 				dataType: 'json',
 				data: new FormData($('#form-upload')[0]),
 				cache: false,
 				contentType: false,
-				processData: false,		
+				processData: false,
 				beforeSend: function() {
 					$('#button-upload').button('loading');
 				},
 				complete: function() {
 					$('#button-upload').button('reset');
-				},	
+				},
 				success: function(json) {
 					if (json['error']) {
 						alert(json['error']);
 					}
-								
+
 					if (json['success']) {
 						alert(json['success']);
-						
+
 						$('input[name=\'filename\']').val(json['filename']);
 						$('input[name=\'mask\']').val(json['mask']);
 					}
-				},			
+				},
 				error: function(xhr, ajaxOptions, thrownError) {
 					alert(thrownError + "\r\n" + xhr.statusText + "\r\n" + xhr.responseText);
 				}
@@ -113,5 +113,5 @@ $('#button-upload').on('click', function() {
 		}
 	}, 500);
 });
-//--></script></div> 
+//--></script></div>
 {{ footer }}

--- a/upload/admin/view/template/catalog/filter_form.twig
+++ b/upload/admin/view/template/catalog/filter_form.twig
@@ -30,7 +30,7 @@
             <div class="col-sm-10">
               {% for language in languages %}
               <div class="input-group"><span class="input-group-addon"><img src="language/{{ language.code }}/{{ language.code }}.png" title="{{ language.name }}" /></span>
-                <input type="text" name="filter_group_description[{{ language.language_id }}][name]" value="{% if filter_group_description[language.language_id] %} {{ filter_group_description[language.language_id].name }} {% endif %}" placeholder="{{ entry_group }}" class="form-control" />
+                <input type="text" name="filter_group_description[{{ language.language_id }}][name]" value="{{ filter_group_description[language.language_id] ? filter_group_description[language.language_id].name }}" placeholder="{{ entry_group }}" class="form-control" />
               </div>
               {% if error_group[language.language_id] %}
               <div class="text-danger">{{ error_group[language.language_id] }}</div>
@@ -59,7 +59,7 @@
                 <td class="text-left" style="width: 70%;"><input type="hidden" name="filter[{{ filter_row }}][filter_id]" value="{{ filter.filter_id }}" />
                   {% for language in languages %}
                   <div class="input-group"><span class="input-group-addon"><img src="language/{{ language.code }}/{{ language.code }}.png" title="{{ language.name }}" /></span>
-                    <input type="text" name="filter[{{ filter_row }}][filter_description][{{ language.language_id }}][name]" value="{% if filter.filter_description[language.language_id] %} filter.filter_description[language.language_id].name {% endif %}" placeholder="{{ entry_name }}" class="form-control" />
+                    <input type="text" name="filter[{{ filter_row }}][filter_description][{{ language.language_id }}][name]" value="{{ filter.filter_description[language.language_id] ? filter.filter_description[language.language_id].name }}" placeholder="{{ entry_name }}" class="form-control" />
                   </div>
                   {% if error_filter[filter_row][language.language_id] %}
                   <div class="text-danger">{{ error_filter[filter_row][language.language_id] }}</div>
@@ -86,7 +86,7 @@
 var filter_row = {{ filter_row }};
 
 function addFilterRow() {
-	html  = '<tr id="filter-row' + filter_row + '">';	
+	html  = '<tr id="filter-row' + filter_row + '">';
     html += '  <td class="text-left" style="width: 70%;"><input type="hidden" name="filter[' + filter_row + '][filter_id]" value="" />';
 	{% for language in languages %}
 	html += '  <div class="input-group">';
@@ -96,11 +96,11 @@ function addFilterRow() {
 	html += '  </td>';
 	html += '  <td class="text-right"><input type="text" name="filter[' + filter_row + '][sort_order]" value="" placeholder="{{ entry_sort_order }}" id="input-sort-order" class="form-control" /></td>';
 	html += '  <td class="text-right"><button type="button" onclick="$(\'#filter-row' + filter_row + '\').remove();" data-toggle="tooltip" title="{{ button_remove }}" class="btn btn-danger"><i class="fa fa-minus-circle"></i></button></td>';
-	html += '</tr>';	
-	
+	html += '</tr>';
+
 	$('#filter tbody').append(html);
-	
+
 	filter_row++;
 }
 //--></script></div>
-{{ footer }} 
+{{ footer }}

--- a/upload/admin/view/template/catalog/information_form.twig
+++ b/upload/admin/view/template/catalog/information_form.twig
@@ -43,7 +43,7 @@
                   <div class="form-group required">
                     <label class="col-sm-2 control-label" for="input-title{{ language.language_id }}">{{ entry_title }}</label>
                     <div class="col-sm-10">
-                      <input type="text" name="information_description[{{ language.language_id }}][title]" value="{% if information_description[language.language_id] %} {{ information_description[language.language_id].title }} {% endif %}" placeholder="{{ entry_title }}" id="input-title{{ language.language_id }}" class="form-control" />
+                      <input type="text" name="information_description[{{ language.language_id }}][title]" value="{{ information_description[language.language_id] ? information_description[language.language_id].title }}" placeholder="{{ entry_title }}" id="input-title{{ language.language_id }}" class="form-control" />
                       {% if error_title[language.language_id] %}
                       <div class="text-danger">{{ error_title[language.language_id] }}</div>
                       {% endif %}
@@ -52,7 +52,7 @@
                   <div class="form-group required">
                     <label class="col-sm-2 control-label" for="input-description{{ language.language_id }}">{{ entry_description }}</label>
                     <div class="col-sm-10">
-                      <textarea name="information_description[{{ language.language_id }}][description]" placeholder="{{ entry_description }}" id="input-description{{ language.language_id }}" class="form-control summernote">{% if information_description[language.language_id] %} {{ information_description[language.language_id].description }} {% endif %}</textarea>
+                      <textarea name="information_description[{{ language.language_id }}][description]" placeholder="{{ entry_description }}" id="input-description{{ language.language_id }}" class="form-control summernote">{{ information_description[language.language_id] ? information_description[language.language_id].description }}</textarea>
                       {% if error_description[language.language_id] %}
                       <div class="text-danger">{{ error_description[language.language_id] }}</div>
                       {% endif %}
@@ -61,7 +61,7 @@
                   <div class="form-group required">
                     <label class="col-sm-2 control-label" for="input-meta-title{{ language.language_id }}">{{ entry_meta_title }}</label>
                     <div class="col-sm-10">
-                      <input type="text" name="information_description[{{ language.language_id }}][meta_title]" value="{% if information_description[language.language_id] %} {{ information_description[language.language_id].meta_title }} {% endif %}" placeholder="{{ entry_meta_title }}" id="input-meta-title{{ language.language_id }}" class="form-control" />
+                      <input type="text" name="information_description[{{ language.language_id }}][meta_title]" value="{{ information_description[language.language_id] ? information_description[language.language_id].meta_title }}" placeholder="{{ entry_meta_title }}" id="input-meta-title{{ language.language_id }}" class="form-control" />
                       {% if error_meta_title[language.language_id] %}
                       <div class="text-danger">{{ error_meta_title[language.language_id] }}</div>
                       {% endif %}
@@ -70,13 +70,13 @@
                   <div class="form-group">
                     <label class="col-sm-2 control-label" for="input-meta-description{{ language.language_id }}">{{ entry_meta_description }}</label>
                     <div class="col-sm-10">
-                      <textarea name="information_description[{{ language.language_id }}][meta_description]" rows="5" placeholder="{{ entry_meta_description }}" id="input-meta-description{{ language.language_id }}" class="form-control">{% if information_description[language.language_id] %} {{ information_description[language.language_id].meta_description }} {% endif %}</textarea>
+                      <textarea name="information_description[{{ language.language_id }}][meta_description]" rows="5" placeholder="{{ entry_meta_description }}" id="input-meta-description{{ language.language_id }}" class="form-control">{{ information_description[language.language_id] ? information_description[language.language_id].meta_description }}</textarea>
                     </div>
                   </div>
                   <div class="form-group">
                     <label class="col-sm-2 control-label" for="input-meta-keyword{{ language.language_id }}">{{ entry_meta_keyword }}</label>
                     <div class="col-sm-10">
-                      <textarea name="information_description[{{ language.language_id }}][meta_keyword]" rows="5" placeholder="{{ entry_meta_keyword }}" id="input-meta-keyword{{ language.language_id }}" class="form-control">{% if information_description[language.language_id] %} {{ information_description[language.language_id].meta_keyword }} {% endif %}</textarea>
+                      <textarea name="information_description[{{ language.language_id }}][meta_keyword]" rows="5" placeholder="{{ entry_meta_keyword }}" id="input-meta-keyword{{ language.language_id }}" class="form-control">{{ information_description[language.language_id] ? information_description[language.language_id].meta_keyword }}</textarea>
                     </div>
                   </div>
                 </div>
@@ -208,7 +208,7 @@
   </div>
   <script type="text/javascript" src="view/javascript/summernote/summernote.js"></script>
   <link href="view/javascript/summernote/summernote.css" rel="stylesheet" />
-  <script type="text/javascript" src="view/javascript/summernote/opencart.js"></script>  
+  <script type="text/javascript" src="view/javascript/summernote/opencart.js"></script>
   <script type="text/javascript"><!--
 $('#language a:first').tab('show');
 //--></script></div>

--- a/upload/admin/view/template/catalog/option_form.twig
+++ b/upload/admin/view/template/catalog/option_form.twig
@@ -30,7 +30,7 @@
             <div class="col-sm-10">
               {% for language in languages %}
               <div class="input-group"><span class="input-group-addon"><img src="language/{{ language.code }}/{{ language.code }}.png" title="{{ language.name }}" /></span>
-                <input type="text" name="option_description[{{ language.language_id }}][name]" value="{% if option_description[language.language_id] %} {{ option_description[language.language_id].name }} {% endif %}" placeholder="{{ entry_name }}" class="form-control" />
+                <input type="text" name="option_description[{{ language.language_id }}][name]" value="{{ option_description[language.language_id] ? option_description[language.language_id].name }}" placeholder="{{ entry_name }}" class="form-control" />
               </div>
               {% if error_name[language.language_id] %}
               <div class="text-danger">{{ error_name[language.language_id] }}</div>
@@ -120,7 +120,7 @@
                 <td class="text-left"><input type="hidden" name="option_value[{{ option_value_row }}][option_value_id]" value="{{ option_value.option_value_id }}" />
                   {% for language in languages %}
                   <div class="input-group"><span class="input-group-addon"><img src="language/{{ language.code }}/{{ language.code }}.png" title="{{ language.name }}" /></span>
-                    <input type="text" name="option_value[{{ option_value_row }}][option_value_description][{{ language.language_id }}][name]" value="{% if option_value.option_value_description[language.language_id] %} {{ option_value.option_value_description[language.language_id].name }}" placeholder="{{ entry_option_value }}" class="form-control" />
+                    <input type="text" name="option_value[{{ option_value_row }}][option_value_description][{{ language.language_id }}][name]" value="{{ option_value.option_value_description[language.language_id] ? option_value.option_value_description[language.language_id].name }}" placeholder="{{ entry_option_value }}" class="form-control" />
                   </div>
                   {% if error_option_value[option_value_row][language.language_id] %}
                   <div class="text-danger">{{ error_option_value[option_value_row][language.language_id] }}</div>
@@ -160,7 +160,7 @@ $('select[name=\'type\']').trigger('change');
 var option_value_row = {{ option_value_row }};
 
 function addOptionValue() {
-	html  = '<tr id="option-value-row' + option_value_row + '">';	
+	html  = '<tr id="option-value-row' + option_value_row + '">';
     html += '  <td class="text-left"><input type="hidden" name="option_value[' + option_value_row + '][option_value_id]" value="" />';
 	{% for language in languages %}
 	html += '    <div class="input-group">';
@@ -171,10 +171,10 @@ function addOptionValue() {
     html += '  <td class="text-left"><a href="" id="thumb-image' + option_value_row + '" data-toggle="image" class="img-thumbnail"><img src="{{ placeholder }}" alt="" title="" data-placeholder="{{ placeholder }}" /></a><input type="hidden" name="option_value[' + option_value_row + '][image]" value="" id="input-image' + option_value_row + '" /></td>';
 	html += '  <td class="text-right"><input type="text" name="option_value[' + option_value_row + '][sort_order]" value="" placeholder="{{ entry_sort_order }}" class="form-control" /></td>';
 	html += '  <td class="text-right"><button type="button" onclick="$(\'#option-value-row' + option_value_row + '\').remove();" data-toggle="tooltip" title="{{ button_remove }}" class="btn btn-danger"><i class="fa fa-minus-circle"></i></button></td>';
-	html += '</tr>';	
-	
+	html += '</tr>';
+
 	$('#option-value tbody').append(html);
-	
+
 	option_value_row++;
 }
 //--></script></div>

--- a/upload/admin/view/template/catalog/product_form.twig
+++ b/upload/admin/view/template/catalog/product_form.twig
@@ -49,7 +49,7 @@
                   <div class="form-group required">
                     <label class="col-sm-2 control-label" for="input-name{{ language.language_id }}">{{ entry_name }}</label>
                     <div class="col-sm-10">
-                      <input type="text" name="product_description[{{ language.language_id }}][name]" value="{% if product_description[language.language_id] %} {{ product_description[language.language_id].name }} {% endif %}" placeholder="{{ entry_name }}" id="input-name{{ language.language_id }}" class="form-control" />
+                      <input type="text" name="product_description[{{ language.language_id }}][name]" value="{{ product_description[language.language_id] ? product_description[language.language_id].name }}" placeholder="{{ entry_name }}" id="input-name{{ language.language_id }}" class="form-control" />
                       {% if error_name[language.language_id] %}
                       <div class="text-danger">{{ error_name[language.language_id] }}</div>
                       {% endif %} </div>
@@ -57,13 +57,13 @@
                   <div class="form-group">
                     <label class="col-sm-2 control-label" for="input-description{{ language.language_id }}">{{ entry_description }}</label>
                     <div class="col-sm-10">
-                      <textarea name="product_description[{{ language.language_id }}][description]" placeholder="{{ entry_description }}" id="input-description{{ language.language_id }}" class="form-control summernote">{% if product_description[language.language_id] %} {{ product_description[language.language_id].description }} {% endif %}</textarea>
+                      <textarea name="product_description[{{ language.language_id }}][description]" placeholder="{{ entry_description }}" id="input-description{{ language.language_id }}" class="form-control summernote">{{ product_description[language.language_id] ? product_description[language.language_id].description }}</textarea>
                     </div>
                   </div>
                   <div class="form-group required">
                     <label class="col-sm-2 control-label" for="input-meta-title{{ language.language_id }}">{{ entry_meta_title }}</label>
                     <div class="col-sm-10">
-                      <input type="text" name="product_description[{{ language.language_id }}][meta_title]" value="{% if product_description[language.language_id] %} {{ product_description[language.language_id].meta_title }} {% endif %}" placeholder="{{ entry_meta_title }}" id="input-meta-title{{ language.language_id }}" class="form-control" />
+                      <input type="text" name="product_description[{{ language.language_id }}][meta_title]" value="{{ product_description[language.language_id] ? product_description[language.language_id].meta_title }}" placeholder="{{ entry_meta_title }}" id="input-meta-title{{ language.language_id }}" class="form-control" />
                       {% if error_meta_title[language.language_id] %}
                       <div class="text-danger">{{ error_meta_title[language.language_id] }}</div>
                       {% endif %} </div>
@@ -71,19 +71,19 @@
                   <div class="form-group">
                     <label class="col-sm-2 control-label" for="input-meta-description{{ language.language_id }}">{{ entry_meta_description }}</label>
                     <div class="col-sm-10">
-                      <textarea name="product_description[{{ language.language_id }}][meta_description]" rows="5" placeholder="{{ entry_meta_description }}" id="input-meta-description{{ language.language_id }}" class="form-control">{% if product_description[language.language_id] %} {{ product_description[language.language_id].meta_description }} {% endif %}</textarea>
+                      <textarea name="product_description[{{ language.language_id }}][meta_description]" rows="5" placeholder="{{ entry_meta_description }}" id="input-meta-description{{ language.language_id }}" class="form-control">{{ product_description[language.language_id] ? product_description[language.language_id].meta_description }}</textarea>
                     </div>
                   </div>
                   <div class="form-group">
                     <label class="col-sm-2 control-label" for="input-meta-keyword{{ language.language_id }}">{{ entry_meta_keyword }}</label>
                     <div class="col-sm-10">
-                      <textarea name="product_description[{{ language.language_id }}][meta_keyword]" rows="5" placeholder="{{ entry_meta_keyword }}" id="input-meta-keyword{{ language.language_id }}" class="form-control">{% if product_description[language.language_id] %} {{ product_description[language.language_id].meta_keyword }} {% endif %}</textarea>
+                      <textarea name="product_description[{{ language.language_id }}][meta_keyword]" rows="5" placeholder="{{ entry_meta_keyword }}" id="input-meta-keyword{{ language.language_id }}" class="form-control">{{ product_description[language.language_id] ? product_description[language.language_id].meta_keyword }}</textarea>
                     </div>
                   </div>
                   <div class="form-group">
                     <label class="col-sm-2 control-label" for="input-tag{{ language.language_id }}"><span data-toggle="tooltip" title="{{ help_tag }}">{{ entry_tag }}</span></label>
                     <div class="col-sm-10">
-                      <input type="text" name="product_description[{{ language.language_id }}][tag]" value="{% if product_description[language.language_id] %} {{ product_description[language.language_id].tag }} {% endif %}" placeholder="{{ entry_tag }}" id="input-tag{{ language.language_id }}" class="form-control" />
+                      <input type="text" name="product_description[{{ language.language_id }}][tag]" value="{{ product_description[language.language_id] ? product_description[language.language_id].tag }}" placeholder="{{ entry_tag }}" id="input-tag{{ language.language_id }}" class="form-control" />
                     </div>
                   </div>
                 </div>
@@ -151,19 +151,19 @@
                 <div class="col-sm-10">
                   <select name="tax_class_id" id="input-tax-class" class="form-control">
                     <option value="0">{{ text_none }}</option>
-                    
+
                     {% for tax_class in tax_classes %}
                     {% if tax_class.tax_class_id == tax_class_id %}
-                    
+
                     <option value="{{ tax_class.tax_class_id }}" selected="selected">{{ tax_class.title }}</option>
-                    
+
                     {% else %}
-                    
+
                     <option value="{{ tax_class.tax_class_id }}">{{ tax_class.title }}</option>
-                    
+
                     {% endif %}
                     {% endfor %}
-                  
+
                   </select>
                 </div>
               </div>
@@ -183,19 +183,19 @@
                 <label class="col-sm-2 control-label" for="input-subtract">{{ entry_subtract }}</label>
                 <div class="col-sm-10">
                   <select name="subtract" id="input-subtract" class="form-control">
-                    
+
                     {% if subtract %}
-                    
+
                     <option value="1" selected="selected">{{ text_yes }}</option>
                     <option value="0">{{ text_no }}</option>
-                    
+
                     {% else %}
-                    
+
                     <option value="1">{{ text_yes }}</option>
                     <option value="0" selected="selected">{{ text_no }}</option>
-                    
+
                     {% endif %}
-                  
+
                   </select>
                 </div>
               </div>
@@ -203,19 +203,19 @@
                 <label class="col-sm-2 control-label" for="input-stock-status"><span data-toggle="tooltip" title="{{ help_stock_status }}">{{ entry_stock_status }}</span></label>
                 <div class="col-sm-10">
                   <select name="stock_status_id" id="input-stock-status" class="form-control">
-                    
+
                     {% for stock_status in stock_statuses %}
                     {% if stock_status.stock_status_id == stock_status_id %}
-                    
+
                     <option value="{{ stock_status.stock_status_id }}" selected="selected">{{ stock_status.name }}</option>
-                    
+
                     {% else %}
-                    
+
                     <option value="{{ stock_status.stock_status_id }}">{{ stock_status.name }}</option>
-                    
+
                     {% endif %}
                     {% endfor %}
-                  
+
                   </select>
                 </div>
               </div>
@@ -276,19 +276,19 @@
                 <label class="col-sm-2 control-label" for="input-length-class">{{ entry_length_class }}</label>
                 <div class="col-sm-10">
                   <select name="length_class_id" id="input-length-class" class="form-control">
-                    
+
                     {% for length_class in length_classes %}
                     {% if length_class.length_class_id == length_class_id %}
-                    
+
                     <option value="{{ length_class.length_class_id }}" selected="selected">{{ length_class.title }}</option>
-                    
+
                     {% else %}
-                    
+
                     <option value="{{ length_class.length_class_id }}">{{ length_class.title }}</option>
-                    
+
                     {% endif %}
                     {% endfor %}
-                  
+
                   </select>
                 </div>
               </div>
@@ -302,19 +302,19 @@
                 <label class="col-sm-2 control-label" for="input-weight-class">{{ entry_weight_class }}</label>
                 <div class="col-sm-10">
                   <select name="weight_class_id" id="input-weight-class" class="form-control">
-                    
+
                     {% for weight_class in weight_classes %}
                     {% if weight_class.weight_class_id == weight_class_id %}
-                    
+
                     <option value="{{ weight_class.weight_class_id }}" selected="selected">{{ weight_class.title }}</option>
-                    
+
                     {% else %}
-                    
+
                     <option value="{{ weight_class.weight_class_id }}">{{ weight_class.title }}</option>
-                    
+
                     {% endif %}
                     {% endfor %}
-                  
+
                   </select>
                 </div>
               </div>
@@ -322,19 +322,19 @@
                 <label class="col-sm-2 control-label" for="input-status">{{ entry_status }}</label>
                 <div class="col-sm-10">
                   <select name="status" id="input-status" class="form-control">
-                    
+
                     {% if status %}
-                    
+
                     <option value="1" selected="selected">{{ text_enabled }}</option>
                     <option value="0">{{ text_disabled }}</option>
-                    
+
                     {% else %}
-                    
+
                     <option value="1">{{ text_enabled }}</option>
                     <option value="0" selected="selected">{{ text_disabled }}</option>
-                    
+
                     {% endif %}
-                  
+
                   </select>
                 </div>
               </div>
@@ -435,7 +435,7 @@
                     </tr>
                   </thead>
                   <tbody>
-                  
+
                   {% set attribute_row = 0 %}
                   {% for product_attribute in product_attributes %}
                   <tr id="attribute-row{{ attribute_row }}">
@@ -443,7 +443,7 @@
                       <input type="hidden" name="product_attribute[{{ attribute_row }}][attribute_id]" value="{{ product_attribute.attribute_id }}" /></td>
                     <td class="text-left">{% for language in languages %}
                       <div class="input-group"><span class="input-group-addon"><img src="language/{{ language.code }}/{{ language.code }}.png" title="{{ language.name }}" /></span>
-                        <textarea name="product_attribute[{{ attribute_row }}][product_attribute_description][{{ language.language_id }}][text]" rows="5" placeholder="{{ entry_text }}" class="form-control">{% if product_attribute.product_attribute_description[language.language_id] %} {{ product_attribute.product_attribute_description[language.language_id].text }} {% endif %}</textarea>
+                        <textarea name="product_attribute[{{ attribute_row }}][product_attribute_description][{{ language.language_id }}][text]" rows="5" placeholder="{{ entry_text }}" class="form-control">{{ product_attribute.product_attribute_description[language.language_id] ? product_attribute.product_attribute_description[language.language_id].text }}</textarea>
                       </div>
                       {% endfor %}</td>
                     <td class="text-right"><button type="button" onclick="$('#attribute-row{{ attribute_row }}').remove();" data-toggle="tooltip" title="{{ button_remove }}" class="btn btn-danger"><i class="fa fa-minus-circle"></i></button></td>
@@ -451,7 +451,7 @@
                   {% set attribute_row = attribute_row + 1 %}
                   {% endfor %}
                     </tbody>
-                  
+
                   <tfoot>
                     <tr>
                       <td colspan="2"></td>
@@ -488,19 +488,19 @@
                         <label class="col-sm-2 control-label" for="input-required{{ option_row }}">{{ entry_required }}</label>
                         <div class="col-sm-10">
                           <select name="product_option[{{ option_row }}][required]" id="input-required{{ option_row }}" class="form-control">
-                            
+
                             {% if product_option.required %}
-                            
+
                             <option value="1" selected="selected">{{ text_yes }}</option>
                             <option value="0">{{ text_no }}</option>
-                            
+
                             {% else %}
-                            
+
                             <option value="1">{{ text_yes }}</option>
                             <option value="0" selected="selected">{{ text_no }}</option>
-                            
+
                             {% endif %}
-                          
+
                           </select>
                         </div>
                       </div>
@@ -579,112 +579,112 @@
                             </tr>
                           </thead>
                           <tbody>
-                          
+
                           {% for product_option_value in product_option.product_option_value %}
                           <tr id="option-value-row{{ option_value_row }}">
                             <td class="text-left"><select name="product_option[{{ option_row }}][product_option_value][{{ option_value_row }}][option_value_id]" class="form-control">
-                                
+
                                   {% if option_values[product_option.option_id] %}
-                                 
+
                                   {% for option_value in option_values[product_option.option_id] %}
-                                  
+
                                   {% if option_value.option_value_id == product_option_value.option_value_id %}
-                                  
+
                                 <option value="{{ option_value.option_value_id }}" selected="selected">{{ option_value.name }}</option>
-                                
+
                                   {% else %}
-                                  
+
                                 <option value="{{ option_value.option_value_id }}">{{ option_value.name }}</option>
-                                
+
                                   {% endif %}
                                   {% endfor %}
                                   {% endif %}
-                                
+
                               </select>
                               <input type="hidden" name="product_option[{{ option_row }}][product_option_value][{{ option_value_row }}][product_option_value_id]" value="{{ product_option_value.product_option_value_id }}" /></td>
                             <td class="text-right"><input type="text" name="product_option[{{ option_row }}][product_option_value][{{ option_value_row }}][quantity]" value="{{ product_option_value.quantity }}" placeholder="{{ entry_quantity }}" class="form-control" /></td>
                             <td class="text-left"><select name="product_option[{{ option_row }}][product_option_value][{{ option_value_row }}][subtract]" class="form-control">
-                                
+
                                   {% if product_option_value.subtract %}
-                                  
+
                                 <option value="1" selected="selected">{{ text_yes }}</option>
                                 <option value="0">{{ text_no }}</option>
-                                
+
                                   {% else %}
-                                  
+
                                 <option value="1">{{ text_yes }}</option>
                                 <option value="0" selected="selected">{{ text_no }}</option>
-                                
+
                                   {% endif %}
-                                
+
                               </select></td>
                             <td class="text-right"><select name="product_option[{{ option_row }}][product_option_value][{{ option_value_row }}][price_prefix]" class="form-control">
-                                
+
                                   {% if product_option_value.price_prefix == '+' %}
-                                  
+
                                 <option value="+" selected="selected">+</option>
-                                
+
                                   {% else %}
-                                  
+
                                 <option value="+">+</option>
-                                
+
                                   {% endif %}
                                   {% if product_option_value.price_prefix == '-' %}
-                                  
+
                                 <option value="-" selected="selected">-</option>
-                                
+
                                   {% else %}
-                                  
+
                                 <option value="-">-</option>
-                                
+
                                   {% endif %}
-                                
+
                               </select>
                               <input type="text" name="product_option[{{ option_row }}][product_option_value][{{ option_value_row }}][price]" value="{{ product_option_value.price }}" placeholder="{{ entry_price }}" class="form-control" /></td>
                             <td class="text-right"><select name="product_option[{{ option_row }}][product_option_value][{{ option_value_row }}][points_prefix]" class="form-control">
-                                
+
                                   {% if product_option_value.points_prefix == '+' %}
-                                  
+
                                 <option value="+" selected="selected">+</option>
-                                
+
                                   {% else %}
-                                  
+
                                 <option value="+">+</option>
-                                
+
                                   {% endif %}
                                   {% if product_option_value.points_prefix == '-' %}
-                                  
+
                                 <option value="-" selected="selected">-</option>
-                                
+
                                   {% else %}
-                                  
+
                                 <option value="-">-</option>
-                                
+
                                   {% endif %}
-                                
+
                               </select>
                               <input type="text" name="product_option[{{ option_row }}][product_option_value][{{ option_value_row }}][points]" value="{{ product_option_value.points }}" placeholder="{{ entry_points }}" class="form-control" /></td>
                             <td class="text-right"><select name="product_option[{{ option_row }}][product_option_value][{{ option_value_row }}][weight_prefix]" class="form-control">
-                                
+
                                   {% if product_option_value.weight_prefix == '+' %}
-                                  
+
                                 <option value="+" selected="selected">+</option>
-                                
+
                                   {% else %}
-                                  
+
                                 <option value="+">+</option>
-                                
+
                                   {% endif %}
                                   {% if product_option_value.weight_prefix == '-' %}
-                                  
+
                                 <option value="-" selected="selected">-</option>
-                                
+
                                   {% else %}
-                                  
+
                                 <option value="-">-</option>
-                                
+
                                   {% endif %}
-                                
+
                               </select>
                               <input type="text" name="product_option[{{ option_row }}][product_option_value][{{ option_value_row }}][weight]" value="{{ product_option_value.weight }}" placeholder="{{ entry_weight }}" class="form-control" /></td>
                             <td class="text-right"><button type="button" onclick="$(this).tooltip('destroy');$('#option-value-row{{ option_value_row }}').remove();" data-toggle="tooltip" title="{{ button_remove }}" class="btn btn-danger"><i class="fa fa-minus-circle"></i></button></td>
@@ -692,7 +692,7 @@
                           {% set option_value_row = option_value_row + 1 %}
                           {% endfor %}
                             </tbody>
-                          
+
                           <tfoot>
                             <tr>
                               <td colspan="6"></td>
@@ -702,15 +702,15 @@
                         </table>
                       </div>
                       <select id="option-values{{ option_row }}" style="display: none;">
-                        
+
                         {% if option_values[product_option.option_id] %}
                         {% for option_value in option_values[product_option.option_id] %}
-                        
+
                         <option value="{{ option_value.option_value_id }}">{{ option_value.name }}</option>
-                        
+
                         {% endfor %}
                         {% endif %}
-                      
+
                       </select>
                       {% endif %} </div>
                     {% set option_row = option_row + 1 %}
@@ -729,46 +729,46 @@
                     </tr>
                   </thead>
                   <tbody>
-                  
+
                   {% set recurring_row = 0 %}
                   {% for product_recurring in product_recurrings %}
                   <tr id="recurring-row{{ recurring_row }}">
                     <td class="text-left"><select name="product_recurring[{{ recurring_row }}][recurring_id]" class="form-control">
-                        
+
                           {% for recurring in recurrings %}
                           {% if recurring.recurring_id == product_recurring.recurring_id %}
-                          
+
                         <option value="{{ recurring.recurring_id }}" selected="selected">{{ recurring.name }}</option>
-                        
+
                           {% else %}
-                          
+
                         <option value="{{ recurring.recurring_id }}">{{ recurring.name }}</option>
-                        
+
                           {% endif %}
                           {% endfor %}
-                        
+
                       </select></td>
                     <td class="text-left"><select name="product_recurring[{{ recurring_row }}][customer_group_id]" class="form-control">
-                        
+
                           {% for customer_group in customer_groups %}
                           {% if customer_group.customer_group_id == product_recurring.customer_group_id %}
-                          
+
                         <option value="{{ customer_group.customer_group_id }}" selected="selected">{{ customer_group.name }}</option>
-                        
+
                           {% else %}
-                          
+
                         <option value="{{ customer_group.customer_group_id }}">{{ customer_group.name }}</option>
-                        
+
                           {% endif %}
                           {% endfor %}
-                        
+
                       </select></td>
                     <td class="text-left"><button type="button" onclick="$('#recurring-row{{ recurring_row }}').remove()" data-toggle="tooltip" title="{{ button_remove }}" class="btn btn-danger"><i class="fa fa-minus-circle"></i></button></td>
                   </tr>
                   {% set recurring_row = recurring_row + 1 %}
                   {% endfor %}
                     </tbody>
-                  
+
                   <tfoot>
                     <tr>
                       <td colspan="2"></td>
@@ -793,24 +793,24 @@
                     </tr>
                   </thead>
                   <tbody>
-                  
+
                   {% set discount_row = 0 %}
                   {% for product_discount in product_discounts %}
                   <tr id="discount-row{{ discount_row }}">
                     <td class="text-left"><select name="product_discount[{{ discount_row }}][customer_group_id]" class="form-control">
-                        
+
                           {% for customer_group in customer_groups %}
                           {% if customer_group.customer_group_id == product_discount.customer_group_id %}
-                          
+
                         <option value="{{ customer_group.customer_group_id }}" selected="selected">{{ customer_group.name }}</option>
-                        
+
                           {% else %}
-                          
+
                         <option value="{{ customer_group.customer_group_id }}">{{ customer_group.name }}</option>
-                        
+
                           {% endif %}
                           {% endfor %}
-                        
+
                       </select></td>
                     <td class="text-right"><input type="text" name="product_discount[{{ discount_row }}][quantity]" value="{{ product_discount.quantity }}" placeholder="{{ entry_quantity }}" class="form-control" /></td>
                     <td class="text-right"><input type="text" name="product_discount[{{ discount_row }}][priority]" value="{{ product_discount.priority }}" placeholder="{{ entry_priority }}" class="form-control" /></td>
@@ -830,7 +830,7 @@
                   {% set discount_row = discount_row + 1 %}
                   {% endfor %}
                     </tbody>
-                  
+
                   <tfoot>
                     <tr>
                       <td colspan="6"></td>
@@ -854,24 +854,24 @@
                     </tr>
                   </thead>
                   <tbody>
-                  
+
                   {% set special_row = 0 %}
                   {% for product_special in product_specials %}
                   <tr id="special-row{{ special_row }}">
                     <td class="text-left"><select name="product_special[{{ special_row }}][customer_group_id]" class="form-control">
-                        
+
                           {% for customer_group in customer_groups %}
                           {% if customer_group.customer_group_id == product_special.customer_group_id %}
-                          
+
                         <option value="{{ customer_group.customer_group_id }}" selected="selected">{{ customer_group.name }}</option>
-                        
+
                           {% else %}
-                          
+
                         <option value="{{ customer_group.customer_group_id }}">{{ customer_group.name }}</option>
-                        
+
                           {% endif %}
                           {% endfor %}
-                        
+
                       </select></td>
                     <td class="text-right"><input type="text" name="product_special[{{ special_row }}][priority]" value="{{ product_special.priority }}" placeholder="{{ entry_priority }}" class="form-control" /></td>
                     <td class="text-right"><input type="text" name="product_special[{{ special_row }}][price]" value="{{ product_special.price }}" placeholder="{{ entry_price }}" class="form-control" /></td>
@@ -890,7 +890,7 @@
                   {% set special_row = special_row + 1 %}
                   {% endfor %}
                     </tbody>
-                  
+
                   <tfoot>
                     <tr>
                       <td colspan="5"></td>
@@ -926,7 +926,7 @@
                     </tr>
                   </thead>
                   <tbody>
-                  
+
                   {% set image_row = 0 %}
                   {% for product_image in product_images %}
                   <tr id="image-row{{ image_row }}">
@@ -938,7 +938,7 @@
                   {% set image_row = image_row + 1 %}
                   {% endfor %}
                     </tbody>
-                  
+
                   <tfoot>
                     <tr>
                       <td colspan="2"></td>
@@ -964,15 +964,15 @@
                     </tr>
                   </thead>
                   <tbody>
-                  
+
                   {% for customer_group in customer_groups %}
                   <tr>
                     <td class="text-left">{{ customer_group.name }}</td>
-                    <td class="text-right"><input type="text" name="product_reward[{{ customer_group.customer_group_id }}][points]" value="{% if product_reward[customer_group.customer_group_id] %} {{ product_reward[customer_group.customer_group_id].points }} {% endif %}" class="form-control" /></td>
+                    <td class="text-right"><input type="text" name="product_reward[{{ customer_group.customer_group_id }}][points]" value="{{ product_reward[customer_group.customer_group_id] ? product_reward[customer_group.customer_group_id].points }}" class="form-control" /></td>
                   </tr>
                   {% endfor %}
                     </tbody>
-                  
+
                 </table>
               </div>
             </div>
@@ -990,19 +990,19 @@
                       <td class="text-left">{{ text_default }}</td>
                       <td class="text-left"><select name="product_layout[0]" class="form-control">
                           <option value=""></option>
-                          
+
                           {% for layout in layouts %}
                           {% if product_layout[0] and product_layout[0] == layout.layout_id %}
-                          
+
                           <option value="{{ layout.layout_id }}" selected="selected">{{ layout.name }}</option>
-                          
+
                           {% else %}
-                          
+
                           <option value="{{ layout.layout_id }}">{{ layout.name }}</option>
-                          
+
                           {% endif %}
                           {% endfor %}
-                        
+
                         </select></td>
                     </tr>
                   {% for store in stores %}
@@ -1010,24 +1010,24 @@
                     <td class="text-left">{{ store.name }}</td>
                     <td class="text-left"><select name="product_layout[{{ store.store_id }}]" class="form-control">
                         <option value=""></option>
-                        
+
                           {% for layout in layouts %}
                           {% if product_layout[store.store_id] and product_layout[store.store_id] == layout.layout_id %}
-                          
+
                         <option value="{{ layout.layout_id }}" selected="selected">{{ layout.name }}</option>
-                        
+
                           {% else %}
-                          
+
                         <option value="{{ layout.layout_id }}">{{ layout.name }}</option>
-                        
+
                           {% endif %}
                           {% endfor %}
-                        
+
                       </select></td>
                   </tr>
                   {% endfor %}
                     </tbody>
-                  
+
                 </table>
               </div>
             </div>
@@ -1038,7 +1038,7 @@
   </div>
   <script type="text/javascript" src="view/javascript/summernote/summernote.js"></script>
   <link href="view/javascript/summernote/summernote.css" rel="stylesheet" />
-  <script type="text/javascript" src="view/javascript/summernote/opencart.js"></script> 
+  <script type="text/javascript" src="view/javascript/summernote/opencart.js"></script>
   <script type="text/javascript"><!--
 // Manufacturer
 $('input[name=\'manufacturer\']').autocomplete({
@@ -1182,7 +1182,7 @@ $('input[name=\'related\']').autocomplete({
 $('#product-related').delegate('.fa-minus-circle', 'click', function() {
 	$(this).parent().remove();
 });
-//--></script> 
+//--></script>
   <script type="text/javascript"><!--
 var attribute_row = {{ attribute_row }};
 
@@ -1231,7 +1231,7 @@ function attributeautocomplete(attribute_row) {
 $('#attribute tbody tr').each(function(index, element) {
 	attributeautocomplete(index);
 });
-//--></script> 
+//--></script>
   <script type="text/javascript"><!--
 var option_row = {{ option_row }};
 
@@ -1350,7 +1350,7 @@ $('input[name=\'option\']').autocomplete({
 		$('#option > li:last-child').before('<li><a href="#tab-option' + option_row + '" data-toggle="tab"><i class="fa fa-minus-circle" onclick=" $(\'#option a:first\').tab(\'show\');$(\'a[href=\\\'#tab-option' + option_row + '\\\']\').parent().remove(); $(\'#tab-option' + option_row + '\').remove();"></i>' + item['label'] + '</li>');
 
 		$('#option a[href=\'#tab-option' + option_row + '\']').tab('show');
-		
+
 		$('[data-toggle=\'tooltip\']').tooltip({
 			container: 'body',
 			html: true
@@ -1372,7 +1372,7 @@ $('input[name=\'option\']').autocomplete({
 		option_row++;
 	}
 });
-//--></script> 
+//--></script>
   <script type="text/javascript"><!--
 var option_value_row = {{ option_value_row }};
 
@@ -1409,7 +1409,7 @@ function addOptionValue(option_row) {
 
 	option_value_row++;
 }
-//--></script> 
+//--></script>
   <script type="text/javascript"><!--
 var discount_row = {{ discount_row }};
 
@@ -1436,7 +1436,7 @@ function addDiscount() {
 
 	discount_row++;
 }
-//--></script> 
+//--></script>
   <script type="text/javascript"><!--
 var special_row = {{ special_row }};
 
@@ -1462,7 +1462,7 @@ function addSpecial() {
 
 	special_row++;
 }
-//--></script> 
+//--></script>
   <script type="text/javascript"><!--
 var image_row = {{ image_row }};
 
@@ -1477,7 +1477,7 @@ function addImage() {
 
 	image_row++;
 }
-//--></script> 
+//--></script>
   <script type="text/javascript"><!--
 var recurring_row = {{ recurring_row }};
 
@@ -1503,10 +1503,10 @@ function addRecurring() {
 	html += '</tr>';
 
 	$('#tab-recurring table tbody').append(html);
-	
+
 	recurring_row++;
 }
-//--></script> 
+//--></script>
   <script type="text/javascript"><!--
 $('.date').datetimepicker({
 	pickTime: false
@@ -1520,9 +1520,9 @@ $('.datetime').datetimepicker({
 	pickDate: true,
 	pickTime: true
 });
-//--></script> 
+//--></script>
   <script type="text/javascript"><!--
 $('#language a:first').tab('show');
 $('#option a:first').tab('show');
 //--></script></div>
-{{ footer }} 
+{{ footer }}

--- a/upload/admin/view/template/catalog/recurring_form.twig
+++ b/upload/admin/view/template/catalog/recurring_form.twig
@@ -31,7 +31,7 @@
             <div class="col-sm-10">
               {% for language in languages %}
               <div class="input-group"><span class="input-group-addon"><img src="language/{{ language.code }}/{{ language.code }}.png" title="{{ language.name }}" /></span>
-                <input type="text" name="recurring_description[{{ language.language_id }}][name]" value="{% if recurring_description[language.language_id] %} {{ recurring_description[language.language_id].name }} {% endif %}" placeholder="{{ entry_name }}" class="form-control" />
+                <input type="text" name="recurring_description[{{ language.language_id }}][name]" value="{{ recurring_description[language.language_id] ? recurring_description[language.language_id].name }}" placeholder="{{ entry_name }}" class="form-control" />
               </div>
               {% if error_name[language.language_id] %}
               <div class="text-danger">{{ error_name[language.language_id] }}</div>

--- a/upload/admin/view/template/customer/custom_field_form.twig
+++ b/upload/admin/view/template/customer/custom_field_form.twig
@@ -28,7 +28,7 @@
             <label class="col-sm-2 control-label">{{ entry_name }}</label>
             <div class="col-sm-10"> {% for language in languages %}
               <div class="input-group"><span class="input-group-addon"><img src="language/{{ language.code }}/{{ language.code }}.png" title="{{ language.name }}" /></span>
-                <input type="text" name="custom_field_description[{{ language.language_id }}][name]" value="{% if custom_field_description[language.language_id] %} {{ custom_field_description[language.language_id].name }} {% endif %}" placeholder="{{ entry_name }}" class="form-control" />
+                <input type="text" name="custom_field_description[{{ language.language_id }}][name]" value="{{ custom_field_description[language.language_id] ? custom_field_description[language.language_id].name }}" placeholder="{{ entry_name }}" class="form-control" />
               </div>
               {% if error_name[language.language_id] %}
               <div class="text-danger">{{ error_name[language.language_id] }}</div>
@@ -39,26 +39,26 @@
             <label class="col-sm-2 control-label" for="input-location">{{ entry_location }}</label>
             <div class="col-sm-10">
               <select name="location" id="input-location" class="form-control">
-                
+
                 {% if location == 'account' %}
-                
+
                 <option value="account" selected="selected">{{ text_account }}</option>
-                
+
                 {% else %}
-                
+
                 <option value="account">{{ text_account }}</option>
-                
+
                 {% endif %}
                 {% if location == 'address' %}
-                
+
                 <option value="address" selected="selected">{{ text_address }}</option>
-                
+
                 {% else %}
-                
+
                 <option value="address">{{ text_address }}</option>
-                
+
                 {% endif %}
-              
+
               </select>
             </div>
           </div>
@@ -68,91 +68,91 @@
               <select name="type" id="input-type" class="form-control">
                 <optgroup label="{{ text_choose }}">
                 {% if type == 'select' %}
-                
+
                 <option value="select" selected="selected">{{ text_select }}</option>
-                
+
                 {% else %}
-                
+
                 <option value="select">{{ text_select }}</option>
-                
+
                 {% endif %}
                 {% if type == 'radio' %}
-                
+
                 <option value="radio" selected="selected">{{ text_radio }}</option>
-                
+
                 {% else %}
-                
+
                 <option value="radio">{{ text_radio }}</option>
-                
+
                 {% endif %}
                 {% if type == 'checkbox' %}
-                
+
                 <option value="checkbox" selected="selected">{{ text_checkbox }}</option>
-                
+
                 {% else %}
-                
+
                 <option value="checkbox">{{ text_checkbox }}</option>
-                
+
                 {% endif %}
                 </optgroup>
                 <optgroup label="{{ text_input }}">
                 {% if type == 'text' %}
-                
+
                 <option value="text" selected="selected">{{ text_text }}</option>
-                
+
                 {% else %}
-                
+
                 <option value="text">{{ text_text }}</option>
-                
+
                 {% endif %}
                 {% if type == 'textarea' %}
-                
+
                 <option value="textarea" selected="selected">{{ text_textarea }}</option>
-                
+
                 {% else %}
-                
+
                 <option value="textarea">{{ text_textarea }}</option>
-                
+
                 {% endif %}
                 </optgroup>
                 <optgroup label="{{ text_file }}">
                 {% if type == 'file' %}
-                
+
                 <option value="file" selected="selected">{{ text_file }}</option>
-                
+
                 {% else %}
-                
+
                 <option value="file">{{ text_file }}</option>
-                
+
                 {% endif %}
                 </optgroup>
                 <optgroup label="{{ text_date }}">
                 {% if type == 'date' %}
-                
+
                 <option value="date" selected="selected">{{ text_date }}</option>
-                
+
                 {% else %}
-                
+
                 <option value="date">{{ text_date }}</option>
-                
+
                 {% endif %}
                 {% if type == 'time' %}
-                
+
                 <option value="time" selected="selected">{{ text_time }}</option>
-                
+
                 {% else %}
-                
+
                 <option value="time">{{ text_time }}</option>
-                
+
                 {% endif %}
                 {% if type == 'datetime' %}
-                
+
                 <option value="datetime" selected="selected">{{ text_datetime }}</option>
-                
+
                 {% else %}
-                
+
                 <option value="datetime">{{ text_datetime }}</option>
-                
+
                 {% endif %}
                 </optgroup>
               </select>
@@ -206,19 +206,19 @@
             <label class="col-sm-2 control-label" for="input-status">{{ entry_status }}</label>
             <div class="col-sm-10">
               <select name="status" id="input-status" class="form-control">
-                
+
                 {% if status %}
-                
+
                 <option value="1" selected="selected">{{ text_enabled }}</option>
                 <option value="0">{{ text_disabled }}</option>
-                
+
                 {% else %}
-                
+
                 <option value="1">{{ text_enabled }}</option>
                 <option value="0" selected="selected">{{ text_disabled }}</option>
-                
+
                 {% endif %}
-              
+
               </select>
             </div>
           </div>
@@ -237,14 +237,14 @@
               </tr>
             </thead>
             <tbody>
-            
+
             {% set custom_field_value_row = 0 %}
             {% for custom_field_value in custom_field_values %}
             <tr id="custom-field-value-row{{ custom_field_value_row }}">
               <td class="text-left" style="width: 70%;"><input type="hidden" name="custom_field_value[{{ custom_field_value_row }}][custom_field_value_id]" value="{{ custom_field_value.custom_field_value_id }}" />
                 {% for language in languages %}
                 <div class="input-group"> <span class="input-group-addon"><img src="language/{{ language.code }}/{{ language.code }}.png" title="{{ language.name }}" /></span>
-                  <input type="text" name="custom_field_value[{{ custom_field_value_row }}][custom_field_value_description][{{ language.language_id }}][name]" value="{% if custom_field_value.custom_field_value_description[language.language_id] %} {{ custom_field_value.custom_field_value_description[language.language_id].name }} {% endif %}" placeholder="{{ entry_custom_value }}" class="form-control" />
+                  <input type="text" name="custom_field_value[{{ custom_field_value_row }}][custom_field_value_description][{{ language.language_id }}][name]" value="{{ custom_field_value.custom_field_value_description[language.language_id] ? custom_field_value.custom_field_value_description[language.language_id].name }}" placeholder="{{ entry_custom_value }}" class="form-control" />
                 </div>
                 {% if error_custom_field_value[custom_field_value_row][language.language_id] %}
                 <div class="text-danger">{{ error_custom_field_value[custom_field_value_row][language.language_id] }}</div>
@@ -256,7 +256,7 @@
             {% set custom_field_value_row = custom_field_value_row + 1 %}
             {% endfor %}
               </tbody>
-            
+
             <tfoot>
               <tr>
                 <td colspan="2"></td>
@@ -277,7 +277,7 @@ $('select[name=\'type\']').on('change', function() {
 		$('#custom-field-value').hide();
 		$('#display-value, #display-validation').show();
 	}
-	
+
 	if (this.value == 'date') {
 		$('#display-value > div').html('<div class="input-group date"><input type="text" name="value" value="' + $('#input-value').val() + '" placeholder="{{ entry_value }}" data-date-format="YYYY-MM-DD" id="input-value" class="form-control" /><span class="input-group-btn"><button type="button" class="btn btn-default"><i class="fa fa-calendar"></i></button></span></div>');
 	} else if (this.value == 'time') {
@@ -289,15 +289,15 @@ $('select[name=\'type\']').on('change', function() {
 	} else {
 		$('#display-value > div').html('<input type="text" name="value" value="' + $('#input-value').val() + '" placeholder="{{ entry_value }}" id="input-value" class="form-control" />');
 	}
-	
+
 	$('.date').datetimepicker({
 		pickTime: false
 	});
-	
+
 	$('.time').datetimepicker({
 		pickDate: false
-	});	
-		
+	});
+
 	$('.datetime').datetimepicker({
 		pickDate: true,
 		pickTime: true
@@ -309,7 +309,7 @@ $('select[name=\'type\']').trigger('change');
 var custom_field_value_row = {{ custom_field_value_row }};
 
 function addCustomFieldValue() {
-	html  = '<tr id="custom-field-value-row' + custom_field_value_row + '">';	
+	html  = '<tr id="custom-field-value-row' + custom_field_value_row + '">';
     html += '  <td class="text-left" style="width: 70%;"><input type="hidden" name="custom_field_value[' + custom_field_value_row + '][custom_field_value_id]" value="" />';
 	{% for language in languages %}
 	html += '    <div class="input-group">';
@@ -319,10 +319,10 @@ function addCustomFieldValue() {
 	html += '  </td>';
 	html += '  <td class="text-right"><input type="text" name="custom_field_value[' + custom_field_value_row + '][sort_order]" value="" placeholder="{{ entry_sort_order }}" class="form-control" /></td>';
 	html += '  <td class="text-left"><button type="button" onclick="$(\'#custom-field-value-row' + custom_field_value_row + '\').remove();" data-toggle="tooltip" title="{{ button_remove }}" class="btn btn-danger"><i class="fa fa-minus-circle"></i></button></td>';
-	html += '</tr>';	
-	
+	html += '</tr>';
+
 	$('#custom-field-value tbody').append(html);
-	
+
 	custom_field_value_row++;
 }
 //--></script></div>

--- a/upload/admin/view/template/customer/customer_form.twig
+++ b/upload/admin/view/template/customer/customer_form.twig
@@ -183,7 +183,7 @@
                       <div class="form-group custom-field custom-field{{ custom_field.custom_field_id }}" data-sort="{{ custom_field.sort_order }}">
                         <label class="col-sm-2 control-label" for="input-custom-field{{ custom_field.custom_field_id }}">{{ custom_field.name }}</label>
                         <div class="col-sm-10">
-                          <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{% if account_custom_field[custom_field.custom_field_id] %} {{ account_custom_field[custom_field.custom_field_id] }} {% else %} {{ custom_field.value }} {% endif %}" placeholder="{{ custom_field.name }}" id="input-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
+                          <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{{ account_custom_field[custom_field.custom_field_id] ? account_custom_field[custom_field.custom_field_id] : custom_field.value }}" placeholder="{{ custom_field.name }}" id="input-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
                           {% if error_custom_field[custom_field.custom_field_id] %}
                           <div class="text-danger">{{ error_custom_field[custom_field.custom_field_id] }}</div>
                           {% endif %}
@@ -194,7 +194,7 @@
                       <div class="form-group custom-field custom-field{{ custom_field.custom_field_id }}" data-sort="{{ custom_field.sort_order }}">
                         <label class="col-sm-2 control-label" for="input-custom-field{{ custom_field.custom_field_id }}">{{ custom_field.name }}</label>
                         <div class="col-sm-10">
-                          <textarea name="custom_field[{{ custom_field.custom_field_id }}]" rows="5" placeholder="{{ custom_field.name }}" id="input-custom-field{{ custom_field.custom_field_id }}" class="form-control">{% if account_custom_field[custom_field.custom_field_id] %} {{ account_custom_field[custom_field.custom_field_id] }} {% else %} {{ custom_field.value }} {% endif %}</textarea>
+                          <textarea name="custom_field[{{ custom_field.custom_field_id }}]" rows="5" placeholder="{{ custom_field.name }}" id="input-custom-field{{ custom_field.custom_field_id }}" class="form-control">{{ account_custom_field[custom_field.custom_field_id] ? account_custom_field[custom_field.custom_field_id] : custom_field.value }}</textarea>
                           {% if error_custom_field[custom_field.custom_field_id] %}
                           <div class="text-danger">{{ error_custom_field[custom_field.custom_field_id] }}</div>
                           {% endif %}
@@ -206,7 +206,7 @@
                         <label class="col-sm-2 control-label">{{ custom_field.name }}</label>
                         <div class="col-sm-10">
                           <button type="button" id="button-custom-field{{ custom_field.custom_field_id }}" data-loading-text="{{ text_loading }}" class="btn btn-default"><i class="fa fa-upload"></i> {{ button_upload }}</button>
-                          <input type="hidden" name="custom_field[{{ custom_field.custom_field_id }}]" value="{% if account_custom_field[custom_field.custom_field_id] %} {{ account_custom_field[custom_field.custom_field_id] }} {% endif %}" id="input-custom-field{{ custom_field.custom_field_id }}" />
+                          <input type="hidden" name="custom_field[{{ custom_field.custom_field_id }}]" value="{{ account_custom_field[custom_field.custom_field_id] ? account_custom_field[custom_field.custom_field_id] }}" id="input-custom-field{{ custom_field.custom_field_id }}" />
                           {% if error_custom_field[custom_field.custom_field_id] %}
                           <div class="text-danger">{{ error_custom_field[custom_field.custom_field_id] }}</div>
                           {% endif %}
@@ -218,7 +218,7 @@
                         <label class="col-sm-2 control-label" for="input-custom-field{{ custom_field.custom_field_id }}">{{ custom_field.name }}</label>
                         <div class="col-sm-10">
                           <div class="input-group date">
-                            <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{% if account_custom_field[custom_field.custom_field_id] %} {{ account_custom_field[custom_field.custom_field_id] }} {% else %} {{ custom_field.value }} {% endif %}" placeholder="{{ custom_field.name }}" data-date-format="YYYY-MM-DD" id="input-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
+                            <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{{ account_custom_field[custom_field.custom_field_id] ? account_custom_field[custom_field.custom_field_id] : custom_field.value }}" placeholder="{{ custom_field.name }}" data-date-format="YYYY-MM-DD" id="input-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
                             <span class="input-group-btn">
                             <button type="button" class="btn btn-default"><i class="fa fa-calendar"></i></button>
                             </span></div>
@@ -233,7 +233,7 @@
                         <label class="col-sm-2 control-label" for="input-custom-field{{ custom_field.custom_field_id }}">{{ custom_field.name }}</label>
                         <div class="col-sm-10">
                           <div class="input-group time">
-                            <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{% if account_custom_field[custom_field.custom_field_id] %} {{ account_custom_field[custom_field.custom_field_id] }} {% else %} {{ custom_field.value }} {% endif %}" placeholder="{{ custom_field.name }}" data-date-format="HH:mm" id="input-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
+                            <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{{ account_custom_field[custom_field.custom_field_id] ? account_custom_field[custom_field.custom_field_id] : custom_field.value }}" placeholder="{{ custom_field.name }}" data-date-format="HH:mm" id="input-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
                             <span class="input-group-btn">
                             <button type="button" class="btn btn-default"><i class="fa fa-calendar"></i></button>
                             </span></div>
@@ -248,7 +248,7 @@
                         <label class="col-sm-2 control-label" for="input-custom-field{{ custom_field.custom_field_id }}">{{ custom_field.name }}</label>
                         <div class="col-sm-10">
                           <div class="input-group datetime">
-                            <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{% if account_custom_field[custom_field.custom_field_id] %} {{ account_custom_field[custom_field.custom_field_id] }} {% else %} {{ custom_field.value }} {% endif %}" placeholder="{{ custom_field.name }}" data-date-format="YYYY-MM-DD HH:mm" id="input-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
+                            <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{{ account_custom_field[custom_field.custom_field_id] ? account_custom_field[custom_field.custom_field_id] : custom_field.value }}" placeholder="{{ custom_field.name }}" data-date-format="YYYY-MM-DD HH:mm" id="input-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
                             <span class="input-group-btn">
                             <button type="button" class="btn btn-default"><i class="fa fa-calendar"></i></button>
                             </span></div>
@@ -500,7 +500,7 @@
                       <div class="form-group custom-field custom-field{{ custom_field.custom_field_id }}" data-sort="{{ custom_field.sort_order + 1 }}">
                         <label class="col-sm-2 control-label" for="input-address{{ address_row }}-custom-field{{ custom_field.custom_field_id }}">{{ custom_field.name }}</label>
                         <div class="col-sm-10">
-                          <input type="text" name="address[{{ address_row }}][custom_field][{{ custom_field.custom_field_id }}]" value="{% if address.custom_field[custom_field.custom_field_id] %} {{ address.custom_field[custom_field.custom_field_id] }} {% else %} {{ custom_field.value }} {% endif %}" placeholder="{{ custom_field.name }}" id="input-address{{ address_row }}-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
+                          <input type="text" name="address[{{ address_row }}][custom_field][{{ custom_field.custom_field_id }}]" value="{{ address.custom_field[custom_field.custom_field_id] ? address.custom_field[custom_field.custom_field_id] : custom_field.value }}" placeholder="{{ custom_field.name }}" id="input-address{{ address_row }}-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
                           {% if error_address[address_row]['custom_field'][custom_field.custom_field_id] %}
                           <div class="text-danger">{{ error_address[address_row].custom_field[custom_field.custom_field_id] }}</div>
                           {% endif %}
@@ -511,7 +511,7 @@
                       <div class="form-group custom-field custom-field{{ custom_field.custom_field_id }}" data-sort="{{ custom_field.sort_order + 1 }}">
                         <label class="col-sm-2 control-label" for="input-address{{ address_row }}-custom-field{{ custom_field.custom_field_id }}">{{ custom_field.name }}</label>
                         <div class="col-sm-10">
-                          <textarea name="address[{{ address_row }}][custom_field][{{ custom_field.custom_field_id }}]" rows="5" placeholder="{{ custom_field.name }}" id="input-address{{ address_row }}-custom-field{{ custom_field.custom_field_id }}" class="form-control">{% if address.custom_field[custom_field.custom_field_id] %} {{ address.custom_field[custom_field.custom_field_id] }} {% else %} {{ custom_field.value }} {% endif %}</textarea>
+                          <textarea name="address[{{ address_row }}][custom_field][{{ custom_field.custom_field_id }}]" rows="5" placeholder="{{ custom_field.name }}" id="input-address{{ address_row }}-custom-field{{ custom_field.custom_field_id }}" class="form-control">{{ address.custom_field[custom_field.custom_field_id] ? address.custom_field[custom_field.custom_field_id] : custom_field.value }}</textarea>
                           {% if error_address[address_row]['custom_field'][custom_field.custom_field_id] %}
                           <div class="text-danger">{{ error_address[address_row].custom_field[custom_field.custom_field_id] }}</div>
                           {% endif %}
@@ -523,7 +523,7 @@
                         <label class="col-sm-2 control-label">{{ custom_field.name }}</label>
                         <div class="col-sm-10">
                           <button type="button" id="button-address{{ address_row }}-custom-field{{ custom_field.custom_field_id }}" data-loading-text="{{ text_loading }}" class="btn btn-default"><i class="fa fa-upload"></i> {{ button_upload }}</button>
-                          <input type="hidden" name="address[{{ address_row }}][custom_field][{{ custom_field.custom_field_id }}]" value="{% if address.custom_field[custom_field.custom_field_id] %} {{ address.custom_field[custom_field.custom_field_id] }} {% endif %}" />
+                          <input type="hidden" name="address[{{ address_row }}][custom_field][{{ custom_field.custom_field_id }}]" value="{{ address.custom_field[custom_field.custom_field_id] ? address.custom_field[custom_field.custom_field_id] }}" />
                           {% if error_address[address_row]['custom_field'][custom_field.custom_field_id] %}
                           <div class="text-danger">{{ error_address[address_row].custom_field[custom_field.custom_field_id] }}</div>
                           {% endif %}
@@ -535,7 +535,7 @@
                         <label class="col-sm-2 control-label" for="input-address{{ address_row }}-custom-field{{ custom_field.custom_field_id }}">{{ custom_field.name }}</label>
                         <div class="col-sm-10">
                           <div class="input-group date">
-                            <input type="text" name="address[{{ address_row }}][custom_field][{{ custom_field.custom_field_id }}]" value="{% if address.custom_field[custom_field.custom_field_id] %} {{ address.custom_field[custom_field.custom_field_id] }} {% else %} {{ custom_field.value }} {% endif %}" placeholder="{{ custom_field.name }}" data-date-format="YYYY-MM-DD" id="input-address{{ address_row }}-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
+                            <input type="text" name="address[{{ address_row }}][custom_field][{{ custom_field.custom_field_id }}]" value="{{ address.custom_field[custom_field.custom_field_id] ? address.custom_field[custom_field.custom_field_id] : custom_field.value }}" placeholder="{{ custom_field.name }}" data-date-format="YYYY-MM-DD" id="input-address{{ address_row }}-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
                             <span class="input-group-btn">
                             <button type="button" class="btn btn-default"><i class="fa fa-calendar"></i></button>
                             </span></div>
@@ -550,7 +550,7 @@
                         <label class="col-sm-2 control-label" for="input-address{{ address_row }}-custom-field{{ custom_field.custom_field_id }}">{{ custom_field.name }}</label>
                         <div class="col-sm-10">
                           <div class="input-group time">
-                            <input type="text" name="address[{{ address_row }}][custom_field][{{ custom_field.custom_field_id }}]" value="{% if address.custom_field[custom_field.custom_field_id] %} {{ address.custom_field[custom_field.custom_field_id] }} {% else %} {{ custom_field.value }} {% endif %}" placeholder="{{ custom_field.name }}" data-date-format="HH:mm" id="input-address{{ address_row }}-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
+                            <input type="text" name="address[{{ address_row }}][custom_field][{{ custom_field.custom_field_id }}]" value="{{ address.custom_field[custom_field.custom_field_id] ? address.custom_field[custom_field.custom_field_id] : custom_field.value }}" placeholder="{{ custom_field.name }}" data-date-format="HH:mm" id="input-address{{ address_row }}-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
                             <span class="input-group-btn">
                             <button type="button" class="btn btn-default"><i class="fa fa-calendar"></i></button>
                             </span></div>
@@ -565,7 +565,7 @@
                         <label class="col-sm-2 control-label" for="input-address{{ address_row }}-custom-field{{ custom_field.custom_field_id }}">{{ custom_field.name }}</label>
                         <div class="col-sm-10">
                           <div class="input-group datetime">
-                            <input type="text" name="address[{{ address_row }}][custom_field][{{ custom_field.custom_field_id }}]" value="{% if address.custom_field[custom_field.custom_field_id] %} {{ address.custom_field[custom_field.custom_field_id] }} {% else %} {{ custom_field.value }} {% endif %}" placeholder="{{ custom_field.name }}" data-date-format="YYYY-MM-DD HH:mm" id="input-address{{ address_row }}-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
+                            <input type="text" name="address[{{ address_row }}][custom_field][{{ custom_field.custom_field_id }}]" value="{{ address.custom_field[custom_field.custom_field_id] ? address.custom_field[custom_field.custom_field_id] : custom_field.value }}" placeholder="{{ custom_field.name }}" data-date-format="YYYY-MM-DD HH:mm" id="input-address{{ address_row }}-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
                             <span class="input-group-btn">
                             <button type="button" class="btn btn-default"><i class="fa fa-calendar"></i></button>
                             </span></div>

--- a/upload/admin/view/template/customer/customer_group_form.twig
+++ b/upload/admin/view/template/customer/customer_group_form.twig
@@ -30,7 +30,7 @@
             <div class="col-sm-10">
               {% for language in languages %}
               <div class="input-group"><span class="input-group-addon"><img src="language/{{ language.code }}/{{ language.code }}.png" title="{{ language.name }}" /></span>
-                <input type="text" name="customer_group_description[{{ language.language_id }}][name]" value="{% if customer_group_description[language.language_id] %} {{ customer_group_description[language.language_id].name }} {% endif %}" placeholder="{{ entry_name }}" class="form-control" />
+                <input type="text" name="customer_group_description[{{ language.language_id }}][name]" value="{{ customer_group_description[language.language_id] ? customer_group_description[language.language_id].name }}" placeholder="{{ entry_name }}" class="form-control" />
               </div>
               {% if error_name[language.language_id] %}
               <div class="text-danger">{{ error_name[language.language_id] }}</div>
@@ -43,7 +43,7 @@
             <label class="col-sm-2 control-label" for="input-description{{ language.language_id }}">{{ entry_description }}</label>
             <div class="col-sm-10">
               <div class="input-group"><span class="input-group-addon"><img src="language/{{ language.code }}/{{ language.code }}.png" title="{{ language.name }}" /></span>
-                <textarea name="customer_group_description[{{ language.language_id }}][description]" rows="5" placeholder="{{ entry_description }}" id="input-description{{ language.language_id }}" class="form-control">{% if customer_group_description[language.language_id] %} {{ customer_group_description[language.language_id].description }} {% endif %}</textarea>
+                <textarea name="customer_group_description[{{ language.language_id }}][description]" rows="5" placeholder="{{ entry_description }}" id="input-description{{ language.language_id }}" class="form-control">{{ customer_group_description[language.language_id] ? customer_group_description[language.language_id].description }}</textarea>
               </div>
             </div>
           </div>

--- a/upload/admin/view/template/extension/module/html.twig
+++ b/upload/admin/view/template/extension/module/html.twig
@@ -33,7 +33,7 @@
               <div class="text-danger">{{ error_name }}</div>
               {% endif %}
             </div>
-          </div>         
+          </div>
           <div class="tab-pane">
             <ul class="nav nav-tabs" id="language">
               {% for language in languages %}
@@ -46,13 +46,13 @@
                 <div class="form-group">
                   <label class="col-sm-2 control-label" for="input-title{{ language.language_id }}">{{ entry_title }}</label>
                   <div class="col-sm-10">
-                    <input type="text" name="module_description[{{ language.language_id }}][title]" placeholder="{{ entry_title }}" id="input-heading{{ language.language_id }}" value="{% if module_description[language.language_id] %} {{ module_description[language.language_id].title }} {% endif %}" class="form-control" />
+                    <input type="text" name="module_description[{{ language.language_id }}][title]" placeholder="{{ entry_title }}" id="input-heading{{ language.language_id }}" value="{{ module_description[language.language_id] ? module_description[language.language_id].title }}" class="form-control" />
                   </div>
                 </div>
                 <div class="form-group">
                   <label class="col-sm-2 control-label" for="input-description{{ language.language_id }}">{{ entry_description }}</label>
                   <div class="col-sm-10">
-                    <textarea name="module_description[{{ language.language_id }}][description]" placeholder="{{ entry_description }}" id="input-description{{ language.language_id }}" class="form-control summernote">{% if module_description[language.language_id] %} {{ module_description[language.language_id].description }} {% endif %}</textarea>
+                    <textarea name="module_description[{{ language.language_id }}][description]" placeholder="{{ entry_description }}" id="input-description{{ language.language_id }}" class="form-control summernote">{{ module_description[language.language_id] ? module_description[language.language_id].description }}</textarea>
                   </div>
                 </div>
               </div>
@@ -79,7 +79,7 @@
   </div>
   <script type="text/javascript" src="view/javascript/summernote/summernote.js"></script>
   <link href="view/javascript/summernote/summernote.css" rel="stylesheet" />
-  <script type="text/javascript" src="view/javascript/summernote/opencart.js"></script>  
+  <script type="text/javascript" src="view/javascript/summernote/opencart.js"></script>
   <script type="text/javascript"><!--
 $('#language a:first').tab('show');
 //--></script></div>

--- a/upload/admin/view/template/extension/payment/bank_transfer.twig
+++ b/upload/admin/view/template/extension/payment/bank_transfer.twig
@@ -30,7 +30,7 @@
             <label class="col-sm-2 control-label" for="input-bank{{ language.language_id }}">{{ entry_bank }}</label>
             <div class="col-sm-10">
               <div class="input-group"><span class="input-group-addon"><img src="language/{{ language.code }}/{{ language.code }}.png" title="{{ language.name }}" /></span>
-                <textarea name="bank_transfer_bank{{ language.language_id }}" cols="80" rows="10" placeholder="{{ entry_bank }}" id="input-bank{{ language.language_id }}" class="form-control">{% if bank_transfer_bank[language.language_id] %} {{ bank_transfer_bank[language.language_id] }} {% endif %}</textarea>
+                <textarea name="bank_transfer_bank{{ language.language_id }}" cols="80" rows="10" placeholder="{{ entry_bank }}" id="input-bank{{ language.language_id }}" class="form-control">{{ bank_transfer_bank[language.language_id] ? bank_transfer_bank[language.language_id] }}</textarea>
               </div>
               {% if error_bank[language.language_id] %}
               <div class="text-danger">{{ error_bank[language.language_id] }}</div>

--- a/upload/admin/view/template/extension/payment/klarna_account.twig
+++ b/upload/admin/view/template/extension/payment/klarna_account.twig
@@ -45,13 +45,13 @@
                   <div class="form-group">
                     <label class="col-sm-2 control-label" for="input-merchant{{ country.code }}"><span data-toggle="tooltip" title="{{ help_merchant }}">{{ entry_merchant }}</span></label>
                     <div class="col-sm-10">
-                      <input type="text" name="klarna_account[{{ country.code }}][merchant]" value="{% if klarna_account[country.code] %} {{ klarna_account[country.code].merchant }} {% endif %}" placeholder="{{ entry_merchant }}" id="input-merchant{{ country.code }}" class="form-control" />
+                      <input type="text" name="klarna_account[{{ country.code }}][merchant]" value="{{ klarna_account[country.code] ? klarna_account[country.code].merchant }}" placeholder="{{ entry_merchant }}" id="input-merchant{{ country.code }}" class="form-control" />
                     </div>
                   </div>
                   <div class="form-group">
                     <label class="col-sm-2 control-label" for="input-secret{{ country.code }}"><span data-toggle="tooltip" title="{{ help_secret }}">{{ entry_secret }}</span></label>
                     <div class="col-sm-10">
-                      <input type="text" name="klarna_account[{{ country.code }}][secret]" value="{% if klarna_account[country.code] %} {{ klarna_account[country.code].secret }} {% endif %}" placeholder="{{ entry_secret }}" id="input-secret{{ country.code }}" class="form-control" />
+                      <input type="text" name="klarna_account[{{ country.code }}][secret]" value="{{ klarna_account[country.code] ? klarna_account[country.code].secret }}" placeholder="{{ entry_secret }}" id="input-secret{{ country.code }}" class="form-control" />
                     </div>
                   </div>
                   <div class="form-group">
@@ -60,48 +60,48 @@
                       <select name="klarna_account[{{ country.code }}][server]" id="input-server{{ country.code }}" class="form-control">
                         {% if klarna_account[country.code] and klarna_account[country.code].server == 'live' %}
                         <option value="live" selected="selected">{{ text_live }}</option>
-                        
+
                         {% else %}
-                        
+
                         <option value="live">{{ text_live }}</option>
-                        
+
                         {% endif %}
-                        
+
                         {% if klarna_account[country.code] and klarna_account[country.code].server == 'beta' %}
                         <option value="beta" selected="selected">{{ text_beta }}</option>
-                        
+
                         {% else %}
-                        
+
                         <option value="beta">{{ text_beta }}</option>
-                        
+
                         {% endif %}
-                      
+
                       </select>
                     </div>
                   </div>
                   <div class="form-group">
                     <label class="col-sm-2 control-label" for="input-total{{ country.code }}"><span data-toggle="tooltip" title="{{ help_total }}">{{ entry_total }}</span></label>
                     <div class="col-sm-10">
-                      <input type="text" name="klarna_account[{{ country.code }}][total]" value="{% if klarna_account[country.code] %} {{ klarna_account[country.code].total }} {% endif %}" placeholder="{{ entry_total }}" id="input-total{{ country.code }}" class="form-control" />
+                      <input type="text" name="klarna_account[{{ country.code }}][total]" value="{{ klarna_account[country.code] ? klarna_account[country.code].total }}" placeholder="{{ entry_total }}" id="input-total{{ country.code }}" class="form-control" />
                     </div>
                   </div>
                   <div class="form-group">
                     <label class="col-sm-2 control-label" for="input-pending-status{{ country.code }}">{{ entry_pending_status }}</label>
                     <div class="col-sm-10">
                       <select name="klarna_account[{{ country.code }}][pending_status_id]" id="input-pending-status{{ country.code }}" class="form-control">
-                        
+
                         {% for order_status in order_statuses %}
-                        
-                        {% if klarna_account[country.code] and order_status.order_status_id == klarna_account[country.code].pending_status_id) { ?>
+
+                        {% if klarna_account[country.code] and order_status.order_status_id == klarna_account[country.code].pending_status_id %}
                         <option value="{{ order_status.order_status_id }}" selected="selected">{{ order_status.name }}</option>
-                        
+
                         {% else %}
-                        
+
                         <option value="{{ order_status.order_status_id }}">{{ order_status.name }}</option>
-                        
+
                         {% endif %}
                         {% endfor %}
-                      
+
                       </select>
                     </div>
                   </div>
@@ -109,19 +109,19 @@
                     <label class="col-sm-2 control-label" for="input-accepted-status{{ country.code }}">{{ entry_accepted_status }}</label>
                     <div class="col-sm-10">
                       <select name="klarna_account[{{ country.code }}][accepted_status_id]" id="input-accepted-status{{ country.code }}" class="form-control">
-                        
+
                         {% for order_status in order_statuses %}
-                        
+
                         {% if klarna_account[country.code] and order_status.order_status_id == klarna_account[country.code].accepted_status_id %}
                         <option value="{{ order_status.order_status_id }}" selected="selected">{{ order_status.name }}</option>
-                        
+
                         {% else %}
-                        
+
                         <option value="{{ order_status.order_status_id }}">{{ order_status.name }}</option>
-                        
+
                         {% endif %}
                         {% endfor %}
-                      
+
                       </select>
                     </div>
                   </div>
@@ -130,19 +130,19 @@
                     <div class="col-sm-10">
                       <select name="klarna_account[{{ country.code }}][geo_zone_id]" id="input-geo-zone{{ country.code }}" class="form-control">
                         <option value="0">{{ text_all_zones }}</option>
-                        
+
                         {% for geo_zone in geo_zones %}
-                        
+
                         {% if klarna_account[country.code] and geo_zone.geo_zone_id == klarna_account[country.code].geo_zone_id %}
                         <option value="{{ geo_zone.geo_zone_id }}" selected="selected">{{ geo_zone.name }}</option>
-                        
+
                         {% else %}
-                        
+
                         <option value="{{ geo_zone.geo_zone_id }}">{{ geo_zone.name }}</option>
-                        
+
                         {% endif %}
                         {% endfor %}
-                      
+
                       </select>
                     </div>
                   </div>
@@ -150,24 +150,24 @@
                     <label class="col-sm-2 control-label" for="input-status{{ country.code }}">{{ entry_status }}</label>
                     <div class="col-sm-10">
                       <select name="klarna_account[{{ country.code }}][status]" id="input-status{{ country.code }}" class="form-control">
-                        {% if klarna_account[country.code] and klarna_account[country.code]['status']) { ?>
+                        {% if klarna_account[country.code] and klarna_account[country.code]['status'] %}
                         <option value="1" selected="selected">{{ text_enabled }}</option>
                         <option value="0">{{ text_disabled }}</option>
-                        
+
                         {% else %}
-                        
+
                         <option value="1">{{ text_enabled }}</option>
                         <option value="0" selected="selected">{{ text_disabled }}</option>
-                        
+
                         {% endif %}
-                      
+
                       </select>
                     </div>
                   </div>
                   <div class="form-group">
                     <label class="col-sm-2 control-label" for="input-sort-order{{ country.code }}">{{ entry_sort_order }}</label>
                     <div class="col-sm-10">
-                      <input type="text" name="klarna_account[{{ country.code }}][sort_order]" value="{% if klarna_account[country.code] %} {{ klarna_account[country.code].sort_order }} {% endif %}" placeholder="{{ entry_sort_order }}" id="input-sort-order{{ country.code }}" class="form-control" />
+                      <input type="text" name="klarna_account[{{ country.code }}][sort_order]" value="{{ klarna_account[country.code] ? klarna_account[country.code].sort_order }}" placeholder="{{ entry_sort_order }}" id="input-sort-order{{ country.code }}" class="form-control" />
                     </div>
                   </div>
                 </div>
@@ -187,4 +187,4 @@
   <script type="text/javascript"><!--
 $('#country a:first').tab('show');
 //--></script></div>
-{{ footer }} 
+{{ footer }}

--- a/upload/admin/view/template/extension/payment/klarna_invoice.twig
+++ b/upload/admin/view/template/extension/payment/klarna_invoice.twig
@@ -47,13 +47,13 @@
                   <div class="form-group">
                     <label class="col-sm-2 control-label" for="input-merchant{{ country.code }}"><span data-toggle="tooltip" title="{{ help_merchant }}">{{ entry_merchant }}</span></label>
                     <div class="col-sm-10">
-                      <input type="text" name="klarna_invoice[{{ country.code }}][merchant]" value="{% if klarna_invoice[country.code] %} {{ klarna_invoice[country.code].merchant }} {% endif %}" placeholder="{{ entry_merchant }}" id="input-merchant{{ country.code }}" class="form-control" />
+                      <input type="text" name="klarna_invoice[{{ country.code }}][merchant]" value="{{ klarna_invoice[country.code] ? klarna_invoice[country.code].merchant }}" placeholder="{{ entry_merchant }}" id="input-merchant{{ country.code }}" class="form-control" />
                     </div>
                   </div>
                   <div class="form-group">
                     <label class="col-sm-2 control-label" for="input-secret{{ country.code }}"><span data-toggle="tooltip" title="{{ help_secret }}">{{ entry_secret }}</span></label>
                     <div class="col-sm-10">
-                      <input type="text" name="klarna_invoice[{{ country.code }}][secret]" value="{% if klarna_invoice[country.code] %} {{ klarna_invoice[country.code].secret }} {% endif %}" placeholder="{{ entry_secret }}" id="input-secret{{ country.code }}" class="form-control" />
+                      <input type="text" name="klarna_invoice[{{ country.code }}][secret]" value="{{ klarna_invoice[country.code] ? klarna_invoice[country.code].secret }}" placeholder="{{ entry_secret }}" id="input-secret{{ country.code }}" class="form-control" />
                     </div>
                   </div>
                   <div class="form-group">
@@ -76,7 +76,7 @@
                   <div class="form-group">
                     <label class="col-sm-2 control-label" for="input-total{{ country.code }}"><span data-toggle="tooltip" title="{{ help_total }}">{{ entry_total }}</span></label>
                     <div class="col-sm-10">
-                      <input type="text" name="klarna_invoice[{{ country.code }}][total]" value="{% if klarna_invoice[country.code] %} {{ klarna_invoice[country.code].total }} {% endif %}" placeholder="{{ entry_total }}" id="input-total{{ country.code }}" class="form-control" />
+                      <input type="text" name="klarna_invoice[{{ country.code }}][total]" value="{{ klarna_invoice[country.code] ? klarna_invoice[country.code].total }}" placeholder="{{ entry_total }}" id="input-total{{ country.code }}" class="form-control" />
                     </div>
                   </div>
                   <div class="form-group">
@@ -139,7 +139,7 @@
                   <div class="form-group">
                     <label class="col-sm-2 control-label" for="input-sort-order{{ country.code }}">{{ entry_sort_order }}</label>
                     <div class="col-sm-10">
-                      <input type="text" name="klarna_invoice[{{ country.code }}][sort_order]" value="{% if klarna_invoice[country.code] %} {{ klarna_invoice[country.code].sort_order }} {% endif %}" placeholder="{{ entry_sort_order }}" id="input-sort-order{{ country.code }}" class="form-control" />
+                      <input type="text" name="klarna_invoice[{{ country.code }}][sort_order]" value="{{ klarna_invoice[country.code] ? klarna_invoice[country.code].sort_order }}" placeholder="{{ entry_sort_order }}" id="input-sort-order{{ country.code }}" class="form-control" />
                     </div>
                   </div>
                 </div>

--- a/upload/admin/view/template/extension/shipping/weight.twig
+++ b/upload/admin/view/template/extension/shipping/weight.twig
@@ -78,7 +78,7 @@
                   <div class="form-group">
                     <label class="col-sm-2 control-label" for="input-rate{{ geo_zone.geo_zone_id }}"><span data-toggle="tooltip" title="{{ help_rate }}">{{ entry_rate }}</span></label>
                     <div class="col-sm-10">
-                      <textarea name="weight_{{ geo_zone.geo_zone_id }}_rate" rows="5" placeholder="{{ entry_rate }}" id="input-rate{{ geo_zone.geo_zone_id }}" class="form-control">{% if weight_geo_zone_rate[geo_zone.geo_zone_id] %} {{ weight_geo_zone_rate[geo_zone.geo_zone_id] }} {% endif %}</textarea>
+                      <textarea name="weight_{{ geo_zone.geo_zone_id }}_rate" rows="5" placeholder="{{ entry_rate }}" id="input-rate{{ geo_zone.geo_zone_id }}" class="form-control">{{ weight_geo_zone_rate[geo_zone.geo_zone_id] ? weight_geo_zone_rate[geo_zone.geo_zone_id] }}</textarea>
                     </div>
                   </div>
                   <div class="form-group">
@@ -105,4 +105,4 @@
     </div>
   </div>
 </div>
-{{ footer }} 
+{{ footer }}

--- a/upload/admin/view/template/extension/total/klarna_fee.twig
+++ b/upload/admin/view/template/extension/total/klarna_fee.twig
@@ -36,13 +36,13 @@
               <div class="form-group">
                 <label class="col-sm-2 control-label" for="input-total{{ country.code }}">{{ entry_total }}</label>
                 <div class="col-sm-10">
-                  <input type="text" name="klarna_fee[{{ country.code }}][total]" value="{% if klarna_fee[country.code] %} {{ klarna_fee[country.code].total }} {% endif %}" placeholder="{{ entry_total }}" id="input-total{{ country.code }}" class="form-control" />
+                  <input type="text" name="klarna_fee[{{ country.code }}][total]" value="{{ klarna_fee[country.code] ? klarna_fee[country.code].total }}" placeholder="{{ entry_total }}" id="input-total{{ country.code }}" class="form-control" />
                 </div>
               </div>
               <div class="form-group">
                 <label class="col-sm-2 control-label" for="input-fee{{ country.code }}">{{ entry_fee }}</label>
                 <div class="col-sm-10">
-                  <input type="text" name="klarna_fee[{{ country.code }}][fee]" value="{% if klarna_fee[country.code] %} {{ klarna_fee[country.code].fee }} {% endif %}" placeholder="{{ entry_fee }}" id="input-fee{{ country.code }}" class="form-control" />
+                  <input type="text" name="klarna_fee[{{ country.code }}][fee]" value="{{ klarna_fee[country.code] ? klarna_fee[country.code].fee }}" placeholder="{{ entry_fee }}" id="input-fee{{ country.code }}" class="form-control" />
                 </div>
               </div>
               <div class="form-group">
@@ -77,7 +77,7 @@
               <div class="form-group">
                 <label class="col-sm-2 control-label" for="input-sort-order{{ country.code }}">{{ entry_sort_order }}</label>
                 <div class="col-sm-10">
-                  <input type="text" name="klarna_fee[{{ country.code }}][sort_order]" value="{% if klarna_fee[country.code] %} {{ klarna_fee[country.code].sort_order }} {% endif %}" placeholder="{{ entry_sort_order }}" id="input-sort-order{{ country.code }}" class="form-control" />
+                  <input type="text" name="klarna_fee[{{ country.code }}][sort_order]" value="{{ klarna_fee[country.code] ? klarna_fee[country.code].sort_order }}" placeholder="{{ entry_sort_order }}" id="input-sort-order{{ country.code }}" class="form-control" />
                 </div>
               </div>
             </div>
@@ -90,4 +90,4 @@
   <script type="text/javascript"><!--
 $('#country a:first').tab('show');
 //--></script></div>
-{{ footer }} 
+{{ footer }}

--- a/upload/admin/view/template/localisation/length_class_form.twig
+++ b/upload/admin/view/template/localisation/length_class_form.twig
@@ -30,7 +30,7 @@
             <div class="col-sm-10">
               {% for language in languages %}
               <div class="input-group"> <span class="input-group-addon"><img src="language/{{ language.code }}/{{ language.code }}.png" title="{{ language.name }}" /></span>
-                <input type="text" name="length_class_description[{{ language.language_id }}][title]" value="{% if length_class_description[language.language_id] %} {{ length_class_description[language.language_id].title }} {% endif %}" placeholder="{{ entry_title }}" class="form-control" />
+                <input type="text" name="length_class_description[{{ language.language_id }}][title]" value="{{ length_class_description[language.language_id] ? length_class_description[language.language_id].title }}" placeholder="{{ entry_title }}" class="form-control" />
               </div>
               {% if error_title[language.language_id] %}
               <div class="text-danger">{{ error_title[language.language_id] }}</div>
@@ -43,7 +43,7 @@
             <div class="col-sm-10">
               {% for language in languages %}
               <div class="input-group"><span class="input-group-addon"><img src="language/{{ language.code }}/{{ language.code }}.png" title="{{ language.name }}" /></span>
-                <input type="text" name="length_class_description[{{ language.language_id }}][unit]" value="{% if length_class_description[language.language_id] %} {{ length_class_description[language.language_id].unit }} {% endif %}" placeholder="{{ entry_unit }}" class="form-control" />
+                <input type="text" name="length_class_description[{{ language.language_id }}][unit]" value="{{ length_class_description[language.language_id] ? length_class_description[language.language_id].unit }}" placeholder="{{ entry_unit }}" class="form-control" />
               </div>
               {% if error_unit[language.language_id] %}
               <div class="text-danger">{{ error_unit[language.language_id] }}</div>

--- a/upload/admin/view/template/localisation/order_status_form.twig
+++ b/upload/admin/view/template/localisation/order_status_form.twig
@@ -30,7 +30,7 @@
             <div class="col-sm-10">
               {% for language in languages %}
               <div class="input-group"><span class="input-group-addon"><img src="language/{{ language.code }}/{{ language.code }}.png" title="{{ language.name }}" /></span>
-                <input type="text" name="order_status[{{ language.language_id }}][name]" value="{% if order_status[language.language_id] %} {{ order_status[language.language_id].name }} {% endif %}" placeholder="{{ entry_name }}" class="form-control" />
+                <input type="text" name="order_status[{{ language.language_id }}][name]" value="{{ order_status[language.language_id] ? order_status[language.language_id].name }}" placeholder="{{ entry_name }}" class="form-control" />
               </div>
               {% if error_name[language.language_id] %}
               <div class="text-danger">{{ error_name[language.language_id] }}</div>

--- a/upload/admin/view/template/localisation/return_action_form.twig
+++ b/upload/admin/view/template/localisation/return_action_form.twig
@@ -30,7 +30,7 @@
             <div class="col-sm-10">
               {% for language in languages %}
               <div class="input-group"> <span class="input-group-addon"><img src="language/{{ language.code }}/{{ language.code }}.png" title="{{ language.name }}" /></span>
-                <input type="text" name="return_action[{{ language.language_id }}][name]" value="{% if return_action[language.language_id] %} {{ return_action[language.language_id].name }} {% endif %}" placeholder="{{ entry_name }}" class="form-control" />
+                <input type="text" name="return_action[{{ language.language_id }}][name]" value="{{ return_action[language.language_id] ? return_action[language.language_id].name }}" placeholder="{{ entry_name }}" class="form-control" />
               </div>
               {% if error_name[language.language_id] %}
               <div class="text-danger">{{ error_name[language.language_id] }}</div>

--- a/upload/admin/view/template/localisation/return_reason_form.twig
+++ b/upload/admin/view/template/localisation/return_reason_form.twig
@@ -30,7 +30,7 @@
             <div class="col-sm-10">
               {% for language in languages %}
               <div class="input-group"> <span class="input-group-addon"><img src="language/{{ language.code }}/{{ language.code }}.png" title="{{ language.name }}" /></span>
-                <input type="text" name="return_reason[{{ language.language_id }}][name]" value="{% if return_reason[language.language_id] %} {{ return_reason[language.language_id].name }} {% endif %}" placeholder="{{ entry_name }}" class="form-control" />
+                <input type="text" name="return_reason[{{ language.language_id }}][name]" value="{{ return_reason[language.language_id] ? return_reason[language.language_id].name }}" placeholder="{{ entry_name }}" class="form-control" />
               </div>
               {% if error_name[language.language_id] %}
               <div class="text-danger">{{ error_name[language.language_id] }}</div>

--- a/upload/admin/view/template/localisation/return_status_form.twig
+++ b/upload/admin/view/template/localisation/return_status_form.twig
@@ -30,7 +30,7 @@
             <div class="col-sm-10">
               {% for language in languages %}
               <div class="input-group"> <span class="input-group-addon"><img src="language/{{ language.code }}/{{ language.code }}.png" title="{{ language.name }}" /></span>
-                <input type="text" name="return_status[{{ language.language_id }}][name]" value="{% if return_status[language.language_id] %} {{ return_status[language.language_id].name }} {% endif %}" placeholder="{{ entry_name }}" class="form-control" />
+                <input type="text" name="return_status[{{ language.language_id }}][name]" value="{{ return_status[language.language_id] ? return_status[language.language_id].name }}" placeholder="{{ entry_name }}" class="form-control" />
               </div>
               {% if error_name[language.language_id] %}
               <div class="text-danger">{{ error_name[language.language_id] }}</div>

--- a/upload/admin/view/template/localisation/stock_status_form.twig
+++ b/upload/admin/view/template/localisation/stock_status_form.twig
@@ -30,7 +30,7 @@
             <div class="col-sm-10">
               {% for language in languages %}
               <div class="input-group"> <span class="input-group-addon"><img src="language/{{ language.code }}/{{ language.code }}.png" title="{{ language.name }}" /></span>
-                <input type="text" name="stock_status[{{ language.language_id }}][name]" value="{% if stock_status[language.language_id] %} {{ stock_status[language.language_id].name }} {% endif %}" placeholder="{{ entry_name }}" class="form-control" />
+                <input type="text" name="stock_status[{{ language.language_id }}][name]" value="{{ stock_status[language.language_id] ? stock_status[language.language_id].name }}" placeholder="{{ entry_name }}" class="form-control" />
               </div>
               {% if error_name[language.language_id] %}
               <div class="text-danger">{{ error_name[language.language_id] }}</div>

--- a/upload/admin/view/template/localisation/weight_class_form.twig
+++ b/upload/admin/view/template/localisation/weight_class_form.twig
@@ -30,7 +30,7 @@
             <div class="col-sm-10">
               {% for language in languages %}
               <div class="input-group"><span class="input-group-addon"><img src="language/{{ language.code }}/{{ language.code }}.png" title="{{ language.name }}" /></span>
-                <input type="text" name="weight_class_description[{{ language.language_id }}][title]" value="{% if weight_class_description[language.language_id] %} {{ weight_class_description[language.language_id].title }} {% endif %}" placeholder="{{ entry_title }}" class="form-control" />
+                <input type="text" name="weight_class_description[{{ language.language_id }}][title]" value="{{ weight_class_description[language.language_id] ? weight_class_description[language.language_id].title }}" placeholder="{{ entry_title }}" class="form-control" />
               </div>
               {% if error_title[language.language_id] %}
               <div class="text-danger">{{ error_title[language.language_id] }}</div>
@@ -43,7 +43,7 @@
             <div class="col-sm-10">
               {% for language in languages %}
               <div class="input-group"><span class="input-group-addon"><img src="language/{{ language.code }}/{{ language.code }}.png" title="{{ language.name }}" /></span>
-                <input type="text" name="weight_class_description[{{ language.language_id }}][unit]" value="{% if weight_class_description[language.language_id] %} {{ weight_class_description[language.language_id].unit }} {% endif %}" placeholder="{{ entry_unit }}" class="form-control" />
+                <input type="text" name="weight_class_description[{{ language.language_id }}][unit]" value="{{ weight_class_description[language.language_id] ? weight_class_description[language.language_id].unit }}" placeholder="{{ entry_unit }}" class="form-control" />
               </div>
               {% if error_unit[language.language_id] %}
               <div class="text-danger">{{ error_unit[language.language_id] }}</div>

--- a/upload/admin/view/template/sale/order_form.twig
+++ b/upload/admin/view/template/sale/order_form.twig
@@ -173,7 +173,7 @@
               <div class="form-group custom-field custom-field{{ custom_field.custom_field_id }}" data-sort="{{ custom_field.sort_order + 3 }}">
                 <label class="col-sm-2 control-label" for="input-custom-field{{ custom_field.custom_field_id }}">{{ custom_field.name }}</label>
                 <div class="col-sm-10">
-                  <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{% if account_custom_field[custom_field.custom_field_id] %} {{ account_custom_field[custom_field.custom_field_id] }} {% else %} {{ custom_field.value }} {% endif %}" placeholder="{{ custom_field.name }}" id="input-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
+                  <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{{ account_custom_field[custom_field.custom_field_id] ? account_custom_field[custom_field.custom_field_id] : custom_field.value }}" placeholder="{{ custom_field.name }}" id="input-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
                 </div>
               </div>
               {% endif %}
@@ -190,7 +190,7 @@
                 <label class="col-sm-2 control-label">{{ custom_field.name }}</label>
                 <div class="col-sm-10">
                   <button type="button" id="button-custom-field{{ custom_field.custom_field_id }}" class="btn btn-default"><i class="fa fa-upload"></i> {{ button_upload }}</button>
-                  <input type="hidden" name="custom_field[{{ custom_field.custom_field_id }}]" value="{% if account_custom_field[custom_field.custom_field_id] %} {{ account_custom_field[custom_field.custom_field_id] }} {% endif %}" id="input-custom-field{{ custom_field.custom_field_id }}" />
+                  <input type="hidden" name="custom_field[{{ custom_field.custom_field_id }}]" value="{{ account_custom_field[custom_field.custom_field_id] ? account_custom_field[custom_field.custom_field_id] }}" id="input-custom-field{{ custom_field.custom_field_id }}" />
                 </div>
               </div>
               {% endif %}
@@ -199,7 +199,7 @@
                 <label class="col-sm-2 control-label" for="input-custom-field{{ custom_field.custom_field_id }}">{{ custom_field.name }}</label>
                 <div class="col-sm-10">
                   <div class="input-group date">
-                    <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{% if account_custom_field[custom_field.custom_field_id] %} {{ account_custom_field[custom_field.custom_field_id] }} {% else %} {{ custom_field.value }} {% endif %}" placeholder="{{ custom_field.name }}" data-date-format="YYYY-MM-DD" id="input-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
+                    <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{{ account_custom_field[custom_field.custom_field_id] ? account_custom_field[custom_field.custom_field_id] : custom_field.value }}" placeholder="{{ custom_field.name }}" data-date-format="YYYY-MM-DD" id="input-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
                     <span class="input-group-btn">
                     <button type="button" class="btn btn-default"><i class="fa fa-calendar"></i></button>
                     </span></div>
@@ -211,7 +211,7 @@
                 <label class="col-sm-2 control-label" for="input-custom-field{{ custom_field.custom_field_id }}">{{ custom_field.name }}</label>
                 <div class="col-sm-10">
                   <div class="input-group time">
-                    <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{% if account_custom_field[custom_field.custom_field_id] %} {{ account_custom_field[custom_field.custom_field_id] }} {% else %} {{ custom_field.value }} {% endif %}" placeholder="{{ custom_field.name }}" data-date-format="HH:mm" id="input-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
+                    <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{{ account_custom_field[custom_field.custom_field_id] ? account_custom_field[custom_field.custom_field_id] : custom_field.value }}" placeholder="{{ custom_field.name }}" data-date-format="HH:mm" id="input-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
                     <span class="input-group-btn">
                     <button type="button" class="btn btn-default"><i class="fa fa-calendar"></i></button>
                     </span></div>
@@ -223,7 +223,7 @@
                 <label class="col-sm-2 control-label" for="input-custom-field{{ custom_field.custom_field_id }}">{{ custom_field.name }}</label>
                 <div class="col-sm-10">
                   <div class="input-group datetime">
-                    <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{% if account_custom_field[custom_field.custom_field_id] %} {{ account_custom_field[custom_field.custom_field_id] }} {% else %} {{ custom_field.value }} {% endif %}" placeholder="{{ custom_field.name }}" data-date-format="YYYY-MM-DD HH:mm" id="input-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
+                    <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{{ account_custom_field[custom_field.custom_field_id] ? account_custom_field[custom_field.custom_field_id] : custom_field.value }}" placeholder="{{ custom_field.name }}" data-date-format="YYYY-MM-DD HH:mm" id="input-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
                     <span class="input-group-btn">
                     <button type="button" class="btn btn-default"><i class="fa fa-calendar"></i></button>
                     </span></div>
@@ -542,7 +542,7 @@
               <div class="form-group custom-field custom-field{{ custom_field.custom_field_id }}" data-sort="{{ custom_field.sort_order + 3 }}">
                 <label class="col-sm-2 control-label" for="input-payment-custom-field{{ custom_field.custom_field_id }}">{{ custom_field.name }}</label>
                 <div class="col-sm-10">
-                  <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{% if payment_custom_field[custom_field.custom_field_id] %} {{ payment_custom_field[custom_field.custom_field_id] }} {% else %} {{ custom_field.value }} {% endif %}" placeholder="{{ custom_field.name }}" id="input-payment-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
+                  <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{{ payment_custom_field[custom_field.custom_field_id] ? payment_custom_field[custom_field.custom_field_id] : custom_field.value }}" placeholder="{{ custom_field.name }}" id="input-payment-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
                 </div>
               </div>
               {% endif %}
@@ -550,7 +550,7 @@
               <div class="form-group custom-field custom-field{{ custom_field.custom_field_id }}" data-sort="{{ custom_field.sort_order + 3 }}">
                 <label class="col-sm-2 control-label" for="input-payment-custom-field{{ custom_field.custom_field_id }}">{{ custom_field.name }}</label>
                 <div class="col-sm-10">
-                  <textarea name="custom_field[{{ custom_field.custom_field_id }}]" rows="5" placeholder="{{ custom_field.name }}" id="input-payment-custom-field{{ custom_field.custom_field_id }}" class="form-control">{% if payment_custom_field[custom_field.custom_field_id] %} {{ payment_custom_field[custom_field.custom_field_id] }} {% else %} {{ custom_field.value }} {% endif %}</textarea>
+                  <textarea name="custom_field[{{ custom_field.custom_field_id }}]" rows="5" placeholder="{{ custom_field.name }}" id="input-payment-custom-field{{ custom_field.custom_field_id }}" class="form-control">{{ payment_custom_field[custom_field.custom_field_id] ? payment_custom_field[custom_field.custom_field_id] : custom_field.value }}</textarea>
                 </div>
               </div>
               {% endif %}
@@ -559,7 +559,7 @@
                 <label class="col-sm-2 control-label">{{ custom_field.name }}</label>
                 <div class="col-sm-10">
                   <button type="button" id="button-payment-custom-field{{ custom_field.custom_field_id }}" data-loading-text="{{ text_loading }}" class="btn btn-default"><i class="fa fa-upload"></i> {{ button_upload }}</button>
-                  <input type="hidden" name="custom_field[{{ custom_field.custom_field_id }}]" value="{% if payment_custom_field[custom_field.custom_field_id] %} {{ payment_custom_field[custom_field.custom_field_id] }} {% endif %}" id="input-payment-custom-field{{ custom_field.custom_field_id }}" />
+                  <input type="hidden" name="custom_field[{{ custom_field.custom_field_id }}]" value="{{ payment_custom_field[custom_field.custom_field_id] ? payment_custom_field[custom_field.custom_field_id] }}" id="input-payment-custom-field{{ custom_field.custom_field_id }}" />
                 </div>
               </div>
               {% endif %}
@@ -568,7 +568,7 @@
                 <label class="col-sm-2 control-label" for="input-payment-custom-field{{ custom_field.custom_field_id }}">{{ custom_field.name }}</label>
                 <div class="col-sm-10">
                   <div class="input-group date">
-                    <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{% if payment_custom_field[custom_field.custom_field_id] %} {{ payment_custom_field[custom_field.custom_field_id] }} {% else %} {{ custom_field.value }} {% endif %}" placeholder="{{ custom_field.name }}" data-date-format="YYYY-MM-DD" id="input-payment-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
+                    <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{{ payment_custom_field[custom_field.custom_field_id] ? payment_custom_field[custom_field.custom_field_id] : custom_field.value }}" placeholder="{{ custom_field.name }}" data-date-format="YYYY-MM-DD" id="input-payment-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
                     <span class="input-group-btn">
                     <button type="button" class="btn btn-default"><i class="fa fa-calendar"></i></button>
                     </span></div>
@@ -580,7 +580,7 @@
                 <label class="col-sm-2 control-label" for="input-payment-custom-field{{ custom_field.custom_field_id }}">{{ custom_field.name }}</label>
                 <div class="col-sm-10">
                   <div class="input-group time">
-                    <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{% if payment_custom_field[custom_field.custom_field_id] %} {{ payment_custom_field[custom_field.custom_field_id] }} {% else %} {{ custom_field.value }} {% endif %}" placeholder="{{ custom_field.name }}" data-date-format="HH:mm" id="input-payment-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
+                    <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{{ payment_custom_field[custom_field.custom_field_id] ? payment_custom_field[custom_field.custom_field_id] : custom_field.value }}" placeholder="{{ custom_field.name }}" data-date-format="HH:mm" id="input-payment-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
                     <span class="input-group-btn">
                     <button type="button" class="btn btn-default"><i class="fa fa-calendar"></i></button>
                     </span></div>
@@ -592,7 +592,7 @@
                 <label class="col-sm-2 control-label" for="input-payment-custom-field{{ custom_field.custom_field_id }}">{{ custom_field.name }}</label>
                 <div class="col-sm-10">
                   <div class="input-group datetime">
-                    <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{% if payment_custom_field[custom_field.custom_field_id] %} {{ payment_custom_field[custom_field.custom_field_id] }} {% else %} {{ custom_field.value }} {% endif %}" placeholder="{{ custom_field.name }}" data-date-format="YYYY-MM-DD HH:mm" id="input-payment-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
+                    <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{{ payment_custom_field[custom_field.custom_field_id] ? payment_custom_field[custom_field.custom_field_id] : custom_field.value }}" placeholder="{{ custom_field.name }}" data-date-format="YYYY-MM-DD HH:mm" id="input-payment-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
                     <span class="input-group-btn">
                     <button type="button" class="btn btn-default"><i class="fa fa-calendar"></i></button>
                     </span></div>
@@ -753,7 +753,7 @@
               <div class="form-group custom-field custom-field{{ custom_field.custom_field_id }}" data-sort="{{ custom_field.sort_order + 3 }}">
                 <label class="col-sm-2 control-label" for="input-shipping-custom-field{{ custom_field.custom_field_id }}">{{ custom_field.name }}</label>
                 <div class="col-sm-10">
-                  <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{% if shipping_custom_field[custom_field.custom_field_id] %} {{ shipping_custom_field[custom_field.custom_field_id] }} {% else %} {{ custom_field.value }} {% endif %}" placeholder="{{ custom_field.name }}" id="input-shipping-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
+                  <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{{ shipping_custom_field[custom_field.custom_field_id] ? shipping_custom_field[custom_field.custom_field_id] ? custom_field.value }}" placeholder="{{ custom_field.name }}" id="input-shipping-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
                 </div>
               </div>
               {% endif %}
@@ -761,7 +761,7 @@
               <div class="form-group custom-field custom-field{{ custom_field.custom_field_id }}" data-sort="{{ custom_field.sort_order + 3 }}">
                 <label class="col-sm-2 control-label" for="input-shipping-custom-field{{ custom_field.custom_field_id }}">{{ custom_field.name }}</label>
                 <div class="col-sm-10">
-                  <textarea name="custom_field[{{ custom_field.custom_field_id }}]" rows="5" placeholder="{{ custom_field.name }}" id="input-shipping-custom-field{{ custom_field.custom_field_id }}" class="form-control">{% if shipping_custom_field[custom_field.custom_field_id] %} {{ shipping_custom_field[custom_field.custom_field_id] }} {% else %} {{ custom_field.value }} {% endif %}</textarea>
+                  <textarea name="custom_field[{{ custom_field.custom_field_id }}]" rows="5" placeholder="{{ custom_field.name }}" id="input-shipping-custom-field{{ custom_field.custom_field_id }}" class="form-control">{{ shipping_custom_field[custom_field.custom_field_id] ? shipping_custom_field[custom_field.custom_field_id] : custom_field.value }}</textarea>
                 </div>
               </div>
               {% endif %}
@@ -770,7 +770,7 @@
                 <label class="col-sm-2 control-label">{{ custom_field.name }}</label>
                 <div class="col-sm-10">
                   <button type="button" id="button-shipping-custom-field{{ custom_field.custom_field_id }}" data-loading-text="{{ text_loading }}" class="btn btn-default"><i class="fa fa-upload"></i> {{ button_upload }}</button>
-                  <input type="hidden" name="custom_field[{{ custom_field.custom_field_id }}]" value="{% if shipping_custom_field[custom_field.custom_field_id] %} {{ shipping_custom_field[custom_field.custom_field_id] }} {% endif %}" id="input-custom-field{{ custom_field.custom_field_id }}" />
+                  <input type="hidden" name="custom_field[{{ custom_field.custom_field_id }}]" value="{{ shipping_custom_field[custom_field.custom_field_id] ? shipping_custom_field[custom_field.custom_field_id] }}" id="input-custom-field{{ custom_field.custom_field_id }}" />
                 </div>
               </div>
               {% endif %}
@@ -779,7 +779,7 @@
                 <label class="col-sm-2 control-label" for="input-shipping-custom-field{{ custom_field.custom_field_id }}">{{ custom_field.name }}</label>
                 <div class="col-sm-10">
                   <div class="input-group date">
-                    <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{% if shipping_custom_field[custom_field.custom_field_id] %} {{ shipping_custom_field[custom_field.custom_field_id] }} {% else %} {{ custom_field.value }} {% endif %}" placeholder="{{ custom_field.name }}" data-date-format="YYYY-MM-DD" id="input-shipping-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
+                    <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{{ shipping_custom_field[custom_field.custom_field_id] ? shipping_custom_field[custom_field.custom_field_id] : custom_field.value }}" placeholder="{{ custom_field.name }}" data-date-format="YYYY-MM-DD" id="input-shipping-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
                     <span class="input-group-btn">
                     <button type="button" class="btn btn-default"><i class="fa fa-calendar"></i></button>
                     </span></div>
@@ -791,7 +791,7 @@
                 <label class="col-sm-2 control-label" for="input-shipping-custom-field{{ custom_field.custom_field_id }}">{{ custom_field.name }}</label>
                 <div class="col-sm-10">
                   <div class="input-group time">
-                    <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{% if shipping_custom_field[custom_field.custom_field_id] %} {{ shipping_custom_field[custom_field.custom_field_id] }} {% else %} {{ custom_field.value }} {% endif %}" placeholder="{{ custom_field.name }}" data-date-format="HH:mm" id="input-shipping-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
+                    <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{{ shipping_custom_field[custom_field.custom_field_id] ? shipping_custom_field[custom_field.custom_field_id] : custom_field.value }}" placeholder="{{ custom_field.name }}" data-date-format="HH:mm" id="input-shipping-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
                     <span class="input-group-btn">
                     <button type="button" class="btn btn-default"><i class="fa fa-calendar"></i></button>
                     </span></div>
@@ -803,7 +803,7 @@
                 <label class="col-sm-2 control-label" for="input-shipping-custom-field{{ custom_field.custom_field_id }}">{{ custom_field.name }}</label>
                 <div class="col-sm-10">
                   <div class="input-group datetime">
-                    <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{% if shipping_custom_field[custom_field.custom_field_id] %} {{ shipping_custom_field[custom_field.custom_field_id] }} {% else %} {{ custom_field.value }} {% endif %}" placeholder="{{ custom_field.name }}" data-date-format="YYYY-MM-DD HH:mm" id="input-shipping-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
+                    <input type="text" name="custom_field[{{ custom_field.custom_field_id }}]" value="{{ shipping_custom_field[custom_field.custom_field_id] ? shipping_custom_field[custom_field.custom_field_id] : custom_field.value }}" placeholder="{{ custom_field.name }}" data-date-format="YYYY-MM-DD HH:mm" id="input-shipping-custom-field{{ custom_field.custom_field_id }}" class="form-control" />
                     <span class="input-group-btn">
                     <button type="button" class="btn btn-default"><i class="fa fa-calendar"></i></button>
                     </span></div>
@@ -2508,7 +2508,7 @@ $('.datetime').datetimepicker({
 $('.time').datetimepicker({
 	pickDate: false
 });
-//--></script> 
+//--></script>
   <script type="text/javascript">
 // Sort the custom fields
 $('#tab-customer .form-group[data-sort]').detach().each(function() {
@@ -2554,4 +2554,4 @@ $('#tab-shipping .form-group[data-sort]').detach().each(function() {
 	}
 });
 </script></div>
-{{ footer }} 
+{{ footer }}

--- a/upload/admin/view/template/sale/voucher_theme_form.twig
+++ b/upload/admin/view/template/sale/voucher_theme_form.twig
@@ -30,7 +30,7 @@
             <div class="col-sm-10">
               {% for language in languages %}
               <div class="input-group"><span class="input-group-addon"><img src="language/{{ language.code }}/{{ language.code }}.png" title="{{ language.name }}" /></span>
-                <input type="text" name="voucher_theme_description[{{ language.language_id }}][name]" value="{% if voucher_theme_description[language.language_id] %} {{ voucher_theme_description[language.language_id].name }} {% endif %}" placeholder="{{ entry_name }}" class="form-control" />
+                <input type="text" name="voucher_theme_description[{{ language.language_id }}][name]" value="{{ voucher_theme_description[language.language_id] ? voucher_theme_description[language.language_id].name }}" placeholder="{{ entry_name }}" class="form-control" />
               </div>
               {% if error_name[language.language_id] %}
               <div class="text-danger">{{ error_name[language.language_id] }}</div>


### PR DESCRIPTION
### Bug - whitespace in input and textarea

#### Example code:
```twig
<input type="text" value="{% if foo %} {{ foo }} {% endif %}" />
```
```twig
<textarea name="text">{% if foo %} {{ foo }} {% endif %}</textarea>
```

#### Result after saving
![fix](https://cloud.githubusercontent.com/assets/9871980/18237452/5c153b2c-733a-11e6-96de-72899a486c3f.jpg)
If you click "Save" for the second time, the form will be **saved**! As you can see for yourself - it's wrong.
   
#### What i'm done for solution this bug:
Replaced all inputs and textareas
```twig
<input type="text" value="{% if foo %} {{ foo }} {% endif %}" />
<input type="text" value="{% if foo %} {{ foo }} {% else %} {{ bar }} {% endif %}" />
<textarea name="text">{% if foo %} {{ foo }} {% endif %}</textarea>
<textarea name="text">{% if foo %} {{ foo }} {% else %} {{ bar }} {% endif %}</textarea>
```
on
```twig
<input type="text" value="{{ foo ? foo }}" />
<input type="text" value="{{ foo ? foo : bar }}" />
<textarea name="text">{{ foo ? foo }}</textarea>
<textarea name="text">{{ foo ? foo : bar }}</textarea>
```
