### PR TITLE
Added check for the PHP GD extension prior to using it in system/library/image.php

### DIFF
--- a/upload/system/library/image.php
+++ b/upload/system/library/image.php
@@ -8,6 +8,10 @@ class Image {
 	private $mime;
 
 	public function __construct($file) {
+		if (!extension_loaded('gd')) {
+			exit('Error: PHP GD is not installed!');
+		}
+		
 		if (file_exists($file)) {
 			$this->file = $file;
 


### PR DESCRIPTION
I personally ran into an issue where my entire site would 500 internal server error due to upgrading PHP recently and not having GD installed with the new install of PHP. It was difficult to track down due to the issue arising in the cart header dropdown images so literally every page (minus admin pages) seemed to error making it appear like a site wide problem. I had to ssh into my server and browse PHP's error logs to figure out that it was the imagecreatefromjpeg function that was causing the issue. 

I put just a basic exit error to handle it and notify the developer of the issue at hand.