### PR TITLE
add missing property $user_group_id;

### DIFF
--- a/upload/system/library/cart/user.php
+++ b/upload/system/library/cart/user.php
@@ -2,6 +2,7 @@
 namespace Cart;
 class User {
 	private $user_id;
+	private $user_group_id;
 	private $username;
 	private $permission = array();
 


### PR DESCRIPTION
Even if every class inherits from stdClass allowing us to add properties on runtime, i believe it's better to declare them.

I also think that we should add service properties (those fetched from the registry/service-provider), smt like:
```php
	// User properties
	private $user_id;
	private $user_group_id;
	private $username;
	private $permission = array();
	
	// services
	private $db;
	private $request;
	private $session;
```

or as i always do, with doc-blocks to allow type-hinting and code completion
```php
class User {
    // User properties

    /** 
     * @var int 
     */
    private $user_id;

    /** 
     * @var int 
     */
    	private $user_group_id;

    /** 
     * @var string
     */
    	private $username;

    /** 
     * @var array 
     */
	    private $permission = array();
	
    	//services
    /** 
     * @var DB 
     */
	    private $db;

    /** 
     * @var Request 
     */
	    private $request;

    /** 
     * @var Session 
     */
    	private $session;

    //...
```

kind regards