### PR TITLE
skip loading common controller views with empty data

### DIFF
--- a/upload/catalog/controller/common/column_left.php
+++ b/upload/catalog/controller/common/column_left.php
@@ -69,6 +69,10 @@ class ControllerCommonColumnLeft extends Controller {
 			}
 		}
 
+		if (empty($data['modules'])) {
+			return '';
+		}
+
 		return $this->load->view('common/column_left', $data);
 	}
 }

--- a/upload/catalog/controller/common/column_right.php
+++ b/upload/catalog/controller/common/column_right.php
@@ -69,6 +69,10 @@ class ControllerCommonColumnRight extends Controller {
 			}
 		}
 
+		if (empty($data['modules'])) {
+			return '';
+		}
+
 		return $this->load->view('common/column_right', $data);
 	}
 }

--- a/upload/catalog/controller/common/content_bottom.php
+++ b/upload/catalog/controller/common/content_bottom.php
@@ -69,6 +69,10 @@ class ControllerCommonContentBottom extends Controller {
 			}
 		}
 
+		if (empty($data['modules'])) {
+			return '';
+		}
+
 		return $this->load->view('common/content_bottom', $data);
 	}
 }

--- a/upload/catalog/controller/common/content_top.php
+++ b/upload/catalog/controller/common/content_top.php
@@ -69,6 +69,10 @@ class ControllerCommonContentTop extends Controller {
 			}
 		}
 
+		if (empty($data['modules'])) {
+			return '';
+		}
+
 		return $this->load->view('common/content_top', $data);
 	}
 }


### PR DESCRIPTION
in case there is no module data to be rendered we can just skip loading the view since the result will be an empty string anyway.
This saves a few included files for templates without modules or with modules in only a few positions (which represents most of the cases)