### PR TITLE
simplified pagination rendering

### DIFF
--- a/upload/system/library/pagination.php
+++ b/upload/system/library/pagination.php
@@ -27,6 +27,10 @@ class Pagination {
 
 		$num_links = $this->num_links;
 		$num_pages = ceil($total / $limit);
+		
+		if ($num_pages <= 1) {
+			return '';
+		}
 
 		$this->url = str_replace('%7Bpage%7D', '{page}', $this->url);
 
@@ -42,34 +46,32 @@ class Pagination {
 			}
 		}
 
-		if ($num_pages > 1) {
-			if ($num_pages <= $num_links) {
+		if ($num_pages <= $num_links) {
+			$start = 1;
+			$end = $num_pages;
+		} else {
+			$start = $page - floor($num_links / 2);
+			$end = $page + floor($num_links / 2);
+
+			if ($start < 1) {
+				$end += abs($start) + 1;
 				$start = 1;
-				$end = $num_pages;
-			} else {
-				$start = $page - floor($num_links / 2);
-				$end = $page + floor($num_links / 2);
-
-				if ($start < 1) {
-					$end += abs($start) + 1;
-					$start = 1;
-				}
-
-				if ($end > $num_pages) {
-					$start -= ($end - $num_pages);
-					$end = $num_pages;
-				}
 			}
 
-			for ($i = $start; $i <= $end; $i++) {
-				if ($page == $i) {
-					$output .= '<li class="active"><span>' . $i . '</span></li>';
+			if ($end > $num_pages) {
+				$start -= ($end - $num_pages);
+				$end = $num_pages;
+			}
+		}
+
+		for ($i = $start; $i <= $end; $i++) {
+			if ($page == $i) {
+				$output .= '<li class="active"><span>' . $i . '</span></li>';
+			} else {
+				if ($i === 1) {
+				$output .= '<li><a href="' . str_replace(array('&amp;page={page}', '&page={page}'), '', $this->url) . '">' . $i . '</a></li>';
 				} else {
-					if ($i === 1) {
-					$output .= '<li><a href="' . str_replace(array('&amp;page={page}', '&page={page}'), '', $this->url) . '">' . $i . '</a></li>';
-					} else {
-						$output .= '<li><a href="' . str_replace('{page}', $i, $this->url) . '">' . $i . '</a></li>';
-					}
+					$output .= '<li><a href="' . str_replace('{page}', $i, $this->url) . '">' . $i . '</a></li>';
 				}
 			}
 		}
@@ -81,10 +83,6 @@ class Pagination {
 
 		$output .= '</ul>';
 
-		if ($num_pages > 1) {
-			return $output;
-		} else {
-			return '';
-		}
+		return $output;
 	}
 }


### PR DESCRIPTION
if we have 1 page (or less) ($num_pages) we can early return an empty string without further processing, as it's what is returned anyway.

we can also remove inner confitionals `if ($num_pages > 1)` since the special case when the condition is not met is already handled earlier in the code.

Due to the diff algorithms it seems a lot of changes, but it's just 1 conditional + return moved up and 1 conditinal removed 
https://github.com/pine3ree/opencart/blob/2ce9d5b1c9c24a57aa3a3aa121b84d564fd625a2/upload/system/library/pagination.php