### PR TITLE
[phpcs] Adding code style auto formatters for PhpStorm

### DIFF
--- a/tests/phpcs/OpenCart/IDE/README.md
+++ b/tests/phpcs/OpenCart/IDE/README.md
@@ -1,0 +1,11 @@
+## IDE auto formatters
+
+* PHPStorm
+Copy the file ```opencart_phpstorm.xml``` to:
+ 	- Mac ```~/Library/Preferences/<PRODUCT><VERSION>/codestyles/OpenCart.xml```
+ 	- Windows ```<User home>\.<PRODUCT><VERSION>\config\codestyles\OpenCart.xml```
+ 	- Linux ```~/.<PRODUCT><VERSION>/config/codestyles/OpenCart.xml```
+
+### References
+* PHPStorm https://www.jetbrains.com/phpstorm/webhelp/code-style-xml.html
+* PHPStorm https://www.jetbrains.com/help/phpstorm/2016.1/directories-used-by-phpstorm-to-store-settings-caches-plugins-and-logs.html

--- a/tests/phpcs/OpenCart/IDE/opencart_phpstorm.xml
+++ b/tests/phpcs/OpenCart/IDE/opencart_phpstorm.xml
@@ -1,0 +1,22 @@
+<code_scheme name="OpenCart">
+  <PHPCodeStyleSettings>
+    <option name="ALIGN_KEY_VALUE_PAIRS" value="true" />
+    <option name="ALIGN_PHPDOC_PARAM_NAMES" value="true" />
+    <option name="ALIGN_PHPDOC_COMMENTS" value="true" />
+    <option name="PHPDOC_BLANK_LINES_AROUND_PARAMETERS" value="true" />
+    <option name="UPPER_CASE_BOOLEAN_CONST" value="true" />
+    <option name="UPPER_CASE_NULL_CONST" value="true" />
+    <option name="BLANK_LINE_BEFORE_RETURN_STATEMENT" value="true" />
+    <option name="ALIGN_CLASS_CONSTANTS" value="true" />
+  </PHPCodeStyleSettings>
+  <codeStyleSettings language="PHP">
+    <option name="CLASS_BRACE_STYLE" value="1" />
+    <option name="METHOD_BRACE_STYLE" value="1" />
+    <option name="SPECIAL_ELSE_IF_TREATMENT" value="true" />
+    <option name="IF_BRACE_FORCE" value="3" />
+    <indentOptions>
+      <option name="USE_TAB_CHARACTER" value="true" />
+      <option name="SMART_TABS" value="true" />
+    </indentOptions>
+  </codeStyleSettings>
+</code_scheme>


### PR DESCRIPTION
Suggesting IDE auto formatters settings to format code automatically.

## IDE auto formatters

* PHPStorm
Copy the file ```opencart_phpstorm.xml``` to:
 	- Mac ```~/Library/Preferences/<PRODUCT><VERSION>/codestyles/OpenCart.xml```
 	- Windows ```<User home>\.<PRODUCT><VERSION>\config\codestyles\OpenCart.xml```
 	- Linux ```~/.<PRODUCT><VERSION>/config/codestyles/OpenCart.xml```

### References
* PHPStorm https://www.jetbrains.com/phpstorm/webhelp/code-style-xml.html
* PHPStorm https://www.jetbrains.com/help/phpstorm/2016.1/directories-used-by-phpstorm-to-store-settings-caches-plugins-and-logs.html

Thanks.
