### PR TITLE
remove magic_quotes_gpc cleanup code

### DIFF
--- a/upload/system/startup.php
+++ b/upload/system/startup.php
@@ -7,25 +7,6 @@ if (version_compare(phpversion(), '5.4.0', '<') == true) {
 	exit('PHP5.4+ Required');
 }
 
-// Magic Quotes Fix
-if (ini_get('magic_quotes_gpc')) {
-	function clean($data) {
-   		if (is_array($data)) {
-  			foreach ($data as $key => $value) {
-    			$data[clean($key)] = clean($value);
-  			}
-		} else {
-  			$data = stripslashes($data);
-		}
-
-		return $data;
-	}
-
-	$_GET = clean($_GET);
-	$_POST = clean($_POST);
-	$_COOKIE = clean($_COOKIE);
-}
-
 if (!ini_get('date.timezone')) {
 	date_default_timezone_set('UTC');
 }


### PR DESCRIPTION
as `magic_quotes_gpc` was removed in php 5.4.0, the minimum php version now supported by opencart.

for the same reason we can now start using the "new" array syntax `[]`, which looks less like a function call :-)