### PR TITLE
fixed error days when date_modified is 0000-00-00 00:00:00

### DIFF
--- a/upload/catalog/controller/extension/feed/google_sitemap.php
+++ b/upload/catalog/controller/extension/feed/google_sitemap.php
@@ -15,7 +15,8 @@ class ControllerExtensionFeedGoogleSitemap extends Controller {
 					$output .= '<url>';
 					$output .= '<loc>' . $this->url->link('product/product', 'product_id=' . $product['product_id']) . '</loc>';
 					$output .= '<changefreq>weekly</changefreq>';
-					$output .= '<lastmod>' . date('Y-m-d\TH:i:sP', strtotime($product['date_modified'])) . '</lastmod>';
+					$date_modified = $product['date_modified'] != '0000-00-00 00:00:00' ? $product['date_modified'] : $product['date_added'];
+					$output .= '<lastmod>' . date('Y-m-d\TH:i:sP', strtotime($date_modified)) . '</lastmod>';
 					$output .= '<priority>1.0</priority>';
 					$output .= '<image:image>';
 					$output .= '<image:loc>' . $this->model_tool_image->resize($product['image'], $this->config->get($this->config->get('config_theme') . '_image_popup_width'), $this->config->get($this->config->get('config_theme') . '_image_popup_height')) . '</image:loc>';


### PR DESCRIPTION
When the product has no modified the date will be 0000-00-00 00:00:00. it cause error in google site map. We should change to date_added
$date_modified = $product['date_modified'] != '0000-00-00 00:00:00' ? $product['date_modified'] : $product['date_added'];
$output .= '<lastmod>' . date('Y-m-d\TH:i:sP', strtotime($date_modified)) . '</lastmod>';