### PR TITLE
Disable various input text on return_form.tpl

### DIFF
--- a/upload/catalog/view/theme/default/template/account/return_form.tpl
+++ b/upload/catalog/view/theme/default/template/account/return_form.tpl
@@ -25,7 +25,7 @@
           <div class="form-group required">
             <label class="col-sm-2 control-label" for="input-firstname"><?php echo $entry_firstname; ?></label>
             <div class="col-sm-10">
-              <input type="text" name="firstname" value="<?php echo $firstname; ?>" placeholder="<?php echo $entry_firstname; ?>" id="input-firstname" class="form-control" />
+              <input type="text" name="firstname" value="<?php echo $firstname; ?>" placeholder="<?php echo $entry_firstname; ?>" id="input-firstname" class="form-control" disabled />
               <?php if ($error_firstname) { ?>
               <div class="text-danger"><?php echo $error_firstname; ?></div>
               <?php } ?>
@@ -34,7 +34,7 @@
           <div class="form-group required">
             <label class="col-sm-2 control-label" for="input-lastname"><?php echo $entry_lastname; ?></label>
             <div class="col-sm-10">
-              <input type="text" name="lastname" value="<?php echo $lastname; ?>" placeholder="<?php echo $entry_lastname; ?>" id="input-lastname" class="form-control" />
+              <input type="text" name="lastname" value="<?php echo $lastname; ?>" placeholder="<?php echo $entry_lastname; ?>" id="input-lastname" class="form-control" disabled />
               <?php if ($error_lastname) { ?>
               <div class="text-danger"><?php echo $error_lastname; ?></div>
               <?php } ?>
@@ -43,7 +43,7 @@
           <div class="form-group required">
             <label class="col-sm-2 control-label" for="input-email"><?php echo $entry_email; ?></label>
             <div class="col-sm-10">
-              <input type="text" name="email" value="<?php echo $email; ?>" placeholder="<?php echo $entry_email; ?>" id="input-email" class="form-control" />
+              <input type="text" name="email" value="<?php echo $email; ?>" placeholder="<?php echo $entry_email; ?>" id="input-email" class="form-control" disabled />
               <?php if ($error_email) { ?>
               <div class="text-danger"><?php echo $error_email; ?></div>
               <?php } ?>
@@ -61,7 +61,7 @@
           <div class="form-group required">
             <label class="col-sm-2 control-label" for="input-order-id"><?php echo $entry_order_id; ?></label>
             <div class="col-sm-10">
-              <input type="text" name="order_id" value="<?php echo $order_id; ?>" placeholder="<?php echo $entry_order_id; ?>" id="input-order-id" class="form-control" />
+              <input type="text" name="order_id" value="<?php echo $order_id; ?>" placeholder="<?php echo $entry_order_id; ?>" id="input-order-id" class="form-control" disabled />
               <?php if ($error_order_id) { ?>
               <div class="text-danger"><?php echo $error_order_id; ?></div>
               <?php } ?>
@@ -70,7 +70,7 @@
           <div class="form-group">
             <label class="col-sm-2 control-label" for="input-date-ordered"><?php echo $entry_date_ordered; ?></label>
             <div class="col-sm-3">
-              <div class="input-group date"><input type="text" name="date_ordered" value="<?php echo $date_ordered; ?>" placeholder="<?php echo $entry_date_ordered; ?>" data-date-format="YYYY-MM-DD" id="input-date-ordered" class="form-control" /><span class="input-group-btn">
+              <div class="input-group date"><input type="text" name="date_ordered" value="<?php echo $date_ordered; ?>" placeholder="<?php echo $entry_date_ordered; ?>" data-date-format="YYYY-MM-DD" id="input-date-ordered" class="form-control" disabled /><span class="input-group-btn">
                 <button type="button" class="btn btn-default"><i class="fa fa-calendar"></i></button>
                 </span></div>
             </div>
@@ -81,7 +81,7 @@
           <div class="form-group required">
             <label class="col-sm-2 control-label" for="input-product"><?php echo $entry_product; ?></label>
             <div class="col-sm-10">
-              <input type="text" name="product" value="<?php echo $product; ?>" placeholder="<?php echo $entry_product; ?>" id="input-product" class="form-control" />
+              <input type="text" name="product" value="<?php echo $product; ?>" placeholder="<?php echo $entry_product; ?>" id="input-product" class="form-control" disabled />
               <?php if ($error_product) { ?>
               <div class="text-danger"><?php echo $error_product; ?></div>
               <?php } ?>
@@ -90,7 +90,7 @@
           <div class="form-group required">
             <label class="col-sm-2 control-label" for="input-model"><?php echo $entry_model; ?></label>
             <div class="col-sm-10">
-              <input type="text" name="model" value="<?php echo $model; ?>" placeholder="<?php echo $entry_model; ?>" id="input-model" class="form-control" />
+              <input type="text" name="model" value="<?php echo $model; ?>" placeholder="<?php echo $entry_model; ?>" id="input-model" class="form-control" disabled />
               <?php if ($error_model) { ?>
               <div class="text-danger"><?php echo $error_model; ?></div>
               <?php } ?>
@@ -99,7 +99,7 @@
           <div class="form-group">
             <label class="col-sm-2 control-label" for="input-quantity"><?php echo $entry_quantity; ?></label>
             <div class="col-sm-10">
-              <input type="text" name="quantity" value="<?php echo $quantity; ?>" placeholder="<?php echo $entry_quantity; ?>" id="input-quantity" class="form-control" />
+              <input type="text" name="quantity" value="<?php echo $quantity; ?>" placeholder="<?php echo $entry_quantity; ?>" id="input-quantity" class="form-control" disabled />
             </div>
           </div>
           <div class="form-group required">


### PR DESCRIPTION
Input text like first name, last name, email, order id, order date, product name, product code, quantity is filled with specifics loaded according to order/customer. These fields shouldn't be changeable by the customer when submitting returns. 

Enabled fields are telephone (user might want a different phone number to be contacted on for the return), reason for return, product is opened, faulty or other details.