### PR TITLE
Replace opencart logo with fa icon for mobile view

### DIFF
--- a/upload/admin/view/template/common/header.tpl
+++ b/upload/admin/view/template/common/header.tpl
@@ -37,7 +37,7 @@
     <?php if ($logged) { ?>
     <a type="button" id="button-menu" class="pull-left"><i class="fa fa-indent fa-lg"></i></a>
     <?php } ?>
-    <a href="<?php echo $home; ?>" class="navbar-brand"><img src="view/image/logo.png" alt="<?php echo $heading_title; ?>" title="<?php echo $heading_title; ?>" /></a></div>
+    <a href="<?php echo $home; ?>" class="navbar-brand"><span class="hidden-xs"><img src="view/image/logo.png" alt="<?php echo $heading_title; ?>" title="<?php echo $heading_title; ?>" /></span><span class="hidden-lg hidden-md hidden-sm"><i class="fa fa-opencart"></i></span></a></div>
   <?php if ($logged) { ?>
   <ul class="nav pull-right">
     <li class="dropdown"><a class="dropdown-toggle" data-toggle="dropdown"><?php if($alerts > 0) { ?><span class="label label-danger pull-left"><?php echo $alerts; ?></span><?php } ?> <i class="fa fa-bell fa-lg"></i></a>


### PR DESCRIPTION
The Opencart logo at the admin panel is replaced with fa-opencart in order to adjust the mobile view.