### PR TITLE
Missing customer group id on getorder function

### DIFF
--- a/upload/catalog/model/account/order.php
+++ b/upload/catalog/model/account/order.php
@@ -48,6 +48,7 @@ class ModelAccountOrder extends Model {
 				'store_name'              => $order_query->row['store_name'],
 				'store_url'               => $order_query->row['store_url'],
 				'customer_id'             => $order_query->row['customer_id'],
+				'customer_group_id'       => $order_query->row['customer_group_id'],
 				'firstname'               => $order_query->row['firstname'],
 				'lastname'                => $order_query->row['lastname'],
 				'telephone'               => $order_query->row['telephone'],

--- a/upload/catalog/model/checkout/order.php
+++ b/upload/catalog/model/checkout/order.php
@@ -173,6 +173,7 @@ class ModelCheckoutOrder extends Model {
 				'store_name'              => $order_query->row['store_name'],
 				'store_url'               => $order_query->row['store_url'],
 				'customer_id'             => $order_query->row['customer_id'],
+				'customer_group_id'       => $order_query->row['customer_group_id'],
 				'firstname'               => $order_query->row['firstname'],
 				'lastname'                => $order_query->row['lastname'],
 				'email'                   => $order_query->row['email'],


### PR DESCRIPTION
Customer group is missing on return array in get order function. If custom fields are needed in some modules, this is important field to have.. Else extra code in each module needs to be added for this.