### PR TITLE
Add autofocus to the admin login form username input

### DIFF
--- a/upload/admin/view/template/common/login.tpl
+++ b/upload/admin/view/template/common/login.tpl
@@ -23,7 +23,7 @@
               <div class="form-group">
                 <label for="input-username"><?php echo $entry_username; ?></label>
                 <div class="input-group"><span class="input-group-addon"><i class="fa fa-user"></i></span>
-                  <input type="text" name="username" value="<?php echo $username; ?>" placeholder="<?php echo $entry_username; ?>" id="input-username" class="form-control" />
+                  <input type="text" name="username" value="<?php echo $username; ?>" placeholder="<?php echo $entry_username; ?>" id="input-username" class="form-control" autofocus="autofocus" />
                 </div>
               </div>
               <div class="form-group">


### PR DESCRIPTION
If you have your logins saved in your browser, this update will make it
faster for you to log in -- you just press the arrow down and submit.
This gets better if you have only one login saved -- the browser will
choose it by default for you and all you will have to do to log in is
just press the return/enter key

References:

 - https://developer.mozilla.org/en/docs/Web/HTML/Element/input#attr-autofocus

 - http://stackoverflow.com/a/4445824