### PR TITLE
Change extension/openbay/fba charset & collation to utf8_unicode_ci

### DIFF
--- a/upload/admin/model/extension/openbay/fba.php
+++ b/upload/admin/model/extension/openbay/fba.php
@@ -14,7 +14,7 @@ class ModelExtensionOpenBayFba extends Model {
 					`status` CHAR(10) NOT NULL,
 				    `created` DATETIME NOT NULL,
   				    KEY `fba_order_id` (`order_id`)
-				) ENGINE=InnoDB  DEFAULT CHARSET=latin1;");
+				) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;");
 
         $this->db->query("
 				CREATE TABLE IF NOT EXISTS `" . DB_PREFIX . "fba_order_fulfillment` (
@@ -27,7 +27,7 @@ class ModelExtensionOpenBayFba extends Model {
 					`type` INT(3) NOT NULL,
 					PRIMARY KEY (`fba_order_fulfillment_id`),
   				    KEY `order_id` (`order_id`)
-				) ENGINE=InnoDB  DEFAULT CHARSET=latin1;");
+				) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;");
 
         // Default settings
         $setting = array();


### PR DESCRIPTION
 - confirmed that utf8 is widely used elsewhere in Opencart
   (checked with grep)

 - utf8_unicode_ci because http://stackoverflow.com/q/766809