### PR TITLE
Comparing with wrong total

### DIFF
--- a/upload/catalog/model/extension/total/coupon.php
+++ b/upload/catalog/model/extension/total/coupon.php
@@ -165,8 +165,8 @@ class ModelExtensionTotalCoupon extends Model {
 				}
 
 				// If discount greater than total
-				if ($discount_total > $total) {
-					$discount_total = $total;
+				if ($discount_total > $total['total']) {
+					$discount_total = $total['total'];
 				}
 
 				if ($discount_total > 0) {


### PR DESCRIPTION
Since OC 2.2.x, $total is an Array so $discount_total should be compared with $total['total'] instead of $total which is an Array.
