### PR TITLE
Missing $_['error_custom_field']

### DIFF
--- a/upload/admin/language/en-gb/customer/customer.php
+++ b/upload/admin/language/en-gb/customer/customer.php
@@ -71,4 +71,5 @@ $_['error_address_1']       = 'Address 1 must be between 3 and 128 characters!';
 $_['error_city']            = 'City must be between 2 and 128 characters!';
 $_['error_postcode']        = 'Postcode must be between 2 and 10 characters for this country!';
 $_['error_country']         = 'Please select a country!';
-$_['error_zone']            = '%s required!';
+$_['error_zone']            = 'Please select a region / state!';
+$_['error_custom_field']    = '%s required!';


### PR DESCRIPTION
$_['error_custom_field'] is missing and $_['error_zone'] was pointing to $_['error_custom_field'] error message. I think it was removed unintentionally when doing https://github.com/opencart/opencart/commit/0ecb05e6d49686fcbe426e857ad640d19d7fb298.