### PR TITLE
Add catalog/model/catalog/option.php

### DIFF
--- a/upload/catalog/model/catalog/option.php
+++ b/upload/catalog/model/catalog/option.php
@@ -1,0 +1,116 @@
+<?php
+class ModelCatalogOption extends Model {
+	public function getOption($option_id) {
+		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "option` o LEFT JOIN " . DB_PREFIX . "option_description od ON (o.option_id = od.option_id) WHERE o.option_id = '" . (int)$option_id . "' AND od.language_id = '" . (int)$this->config->get('config_language_id') . "'");
+
+		return $query->row;
+	}
+
+	public function getOptions($data = array()) {
+		$sql = "SELECT * FROM `" . DB_PREFIX . "option` o LEFT JOIN " . DB_PREFIX . "option_description od ON (o.option_id = od.option_id) WHERE od.language_id = '" . (int)$this->config->get('config_language_id') . "'";
+
+		if (!empty($data['filter_name'])) {
+			$sql .= " AND od.name LIKE '" . $this->db->escape($data['filter_name']) . "%'";
+		}
+
+		$sort_data = array(
+			'od.name',
+			'o.type',
+			'o.sort_order'
+		);
+
+		if (isset($data['sort']) && in_array($data['sort'], $sort_data)) {
+			$sql .= " ORDER BY " . $data['sort'];
+		} else {
+			$sql .= " ORDER BY od.name";
+		}
+
+		if (isset($data['order']) && ($data['order'] == 'DESC')) {
+			$sql .= " DESC";
+		} else {
+			$sql .= " ASC";
+		}
+
+		if (isset($data['start']) || isset($data['limit'])) {
+			if ($data['start'] < 0) {
+				$data['start'] = 0;
+			}
+
+			if ($data['limit'] < 1) {
+				$data['limit'] = 20;
+			}
+
+			$sql .= " LIMIT " . (int)$data['start'] . "," . (int)$data['limit'];
+		}
+
+		$query = $this->db->query($sql);
+
+		return $query->rows;
+	}
+
+	public function getOptionDescriptions($option_id) {
+		$option_data = array();
+
+		$query = $this->db->query("SELECT * FROM " . DB_PREFIX . "option_description WHERE option_id = '" . (int)$option_id . "'");
+
+		foreach ($query->rows as $result) {
+			$option_data[$result['language_id']] = array('name' => $result['name']);
+		}
+
+		return $option_data;
+	}
+
+	public function getOptionValue($option_value_id) {
+		$query = $this->db->query("SELECT * FROM " . DB_PREFIX . "option_value ov LEFT JOIN " . DB_PREFIX . "option_value_description ovd ON (ov.option_value_id = ovd.option_value_id) WHERE ov.option_value_id = '" . (int)$option_value_id . "' AND ovd.language_id = '" . (int)$this->config->get('config_language_id') . "'");
+
+		return $query->row;
+	}
+
+	public function getOptionValues($option_id) {
+		$option_value_data = array();
+
+		$option_value_query = $this->db->query("SELECT * FROM " . DB_PREFIX . "option_value ov LEFT JOIN " . DB_PREFIX . "option_value_description ovd ON (ov.option_value_id = ovd.option_value_id) WHERE ov.option_id = '" . (int)$option_id . "' AND ovd.language_id = '" . (int)$this->config->get('config_language_id') . "' ORDER BY ov.sort_order, ovd.name");
+
+		foreach ($option_value_query->rows as $option_value) {
+			$option_value_data[] = array(
+				'option_value_id' => $option_value['option_value_id'],
+				'name'            => $option_value['name'],
+				'image'           => $option_value['image'],
+				'sort_order'      => $option_value['sort_order']
+			);
+		}
+
+		return $option_value_data;
+	}
+
+	public function getOptionValueDescriptions($option_id) {
+		$option_value_data = array();
+
+		$option_value_query = $this->db->query("SELECT * FROM " . DB_PREFIX . "option_value WHERE option_id = '" . (int)$option_id . "' ORDER BY sort_order");
+
+		foreach ($option_value_query->rows as $option_value) {
+			$option_value_description_data = array();
+
+			$option_value_description_query = $this->db->query("SELECT * FROM " . DB_PREFIX . "option_value_description WHERE option_value_id = '" . (int)$option_value['option_value_id'] . "'");
+
+			foreach ($option_value_description_query->rows as $option_value_description) {
+				$option_value_description_data[$option_value_description['language_id']] = array('name' => $option_value_description['name']);
+			}
+
+			$option_value_data[] = array(
+				'option_value_id'          => $option_value['option_value_id'],
+				'option_value_description' => $option_value_description_data,
+				'image'                    => $option_value['image'],
+				'sort_order'               => $option_value['sort_order']
+			);
+		}
+
+		return $option_value_data;
+	}
+
+	public function getTotalOptions() {
+		$query = $this->db->query("SELECT COUNT(*) AS total FROM `" . DB_PREFIX . "option`");
+
+		return $query->row['total'];
+	}
+}


### PR DESCRIPTION
The file I'm submitting is an edited down copy of [`/admin/model/catalog/option.php`](https://github.com/opencart/opencart/blob/master/upload/admin/model/catalog/option.php), so it's 100% your code.

There are scenarios where people will need access to options while in catalog, like building a product filter module. 

For example, we needed a search by colour feature, and to make it work we had to add this file via vQmod. I believe it's much better and more reliable to have it there by default.

Please review this pull request.