### PR TITLE
Fixed issue with gift voucher for failed orders

### DIFF
--- a/upload/catalog/model/extension/total/voucher.php
+++ b/upload/catalog/model/extension/total/voucher.php
@@ -25,7 +25,7 @@ class ModelExtensionTotalVoucher extends Model {
 
 				$order_query = $this->db->query("SELECT order_id FROM `" . DB_PREFIX . "order` WHERE order_id = '" . (int)$voucher_query->row['order_id'] . "' AND order_status_id IN(" . implode(",", $implode) . ")");
 
-				if (!$order_query->num_rows) {
+				if ($order_query->num_rows) {
 					$status = false;
 				}
 


### PR DESCRIPTION
If gift voucher was added to order. And suppose order was cancelled at payment page or it failed.
So the gift voucher should be allowed to use again since order is not made.

But the negative if statement is doing the reverse. So it should be made positive.

If there is some other logic to this. Then i am sorry for this commit.