### PR TITLE
We have to apply OCMOD ordered by it's date.

### DIFF
--- a/upload/admin/controller/extension/modification.php
+++ b/upload/admin/controller/extension/modification.php
@@ -123,7 +123,7 @@ class ControllerExtensionModification extends Controller {
 			}
 
 			// Get the default modification file
-			$results = $this->model_extension_modification->getModifications();
+			$results = $this->model_extension_modification->getModifications(array('sort'=>'date_added', 'order'=>'ASC'));
 
 			foreach ($results as $result) {
 				if ($result['status']) {


### PR DESCRIPTION
When we cleaning OCMOD cache, OpenCart applies all OCMOD-modifications. We have to keep OCMOD apply order or we can get unexpected OCMOD compatibility errors.