### PR TITLE
Update pagination.php

### DIFF
--- a/upload/system/library/pagination.php
+++ b/upload/system/library/pagination.php
@@ -33,10 +33,10 @@ class Pagination {
 		$output = '<ul class="pagination">';
 
 		if ($page > 1) {
-			$output .= '<li><a href="' . str_replace(array('&amp;page={page}', '&page={page}'), '', $this->url) . '">' . $this->text_first . '</a></li>';
+			$output .= '<li><a href="' . str_replace(array('&amp;page={page}', '&page={page}', '?page={page}'), '', $this->url) . '">' . $this->text_first . '</a></li>';
 			
-			if ($page - 1 === 1) {
-				$output .= '<li><a href="' . str_replace(array('&amp;page={page}', '&page={page}'), '', $this->url) . '">' . $this->text_prev . '</a></li>';
+			if ($page - 1 == 1) {
+				$output .= '<li><a href="' . str_replace(array('&amp;page={page}', '&page={page}', '?page={page}'), '', $this->url) . '">' . $this->text_prev . '</a></li>';
 			} else {
 				$output .= '<li><a href="' . str_replace('{page}', $page - 1, $this->url) . '">' . $this->text_prev . '</a></li>';
 			}
@@ -65,8 +65,8 @@ class Pagination {
 				if ($page == $i) {
 					$output .= '<li class="active"><span>' . $i . '</span></li>';
 				} else {
-					if ($i === 1) {
-					$output .= '<li><a href="' . str_replace(array('&amp;page={page}', '&page={page}'), '', $this->url) . '">' . $i . '</a></li>';
+					if ($i == 1) {
+						$output .= '<li><a href="' . str_replace(array('&amp;page={page}', '&page={page}', '?page={page}'), '', $this->url) . '">' . $i . '</a></li>';
 					} else {
 						$output .= '<li><a href="' . str_replace('{page}', $i, $this->url) . '">' . $i . '</a></li>';
 					}


### PR DESCRIPTION
lines 36, 39 & 69: Fix replacements in pagination url for page 1 when SEO Urls are enabled and current page is higher than 1
lines 38 & 68: use loose type comparison == instead of === since $i becomes type `double` and not an integer
fix indentation on line 69