### PR TITLE
Update category.twig

### DIFF
--- a/upload/catalog/view/theme/default/template/product/category.twig
+++ b/upload/catalog/view/theme/default/template/product/category.twig
@@ -37,10 +37,10 @@
         </div>
       </div>
       {% else %}
-      <div class="row"> {% for category in categories|batch((categories|length / 4)|round(1, 'ceil')) %}
+      <div class="row"> {% for rows in categories|batch((categories|length / 4)|round(1, 'ceil')) %}
         <div class="col-sm-3">
           <ul>
-            {% for category in categories %}
+            {% for category in rows %}
             <li><a href="{{ category.href }}">{{ category.name }}</a></li>
             {% endfor %}
           </ul>


### PR DESCRIPTION
When there are more than 4 categories, all the categories are repeated in the "refine search" part instead of splitting  the categories in multi-columns.