### PR TITLE
Double function getOrderProducts in checkout.

### DIFF
--- a/upload/catalog/model/checkout/order.php
+++ b/upload/catalog/model/checkout/order.php
@@ -242,12 +242,6 @@ class ModelCheckoutOrder extends Model {
 		
 		return $query->rows;
 	}
-
-	public function getOrderProducts($order_id) {
-		$query = $this->db->query("SELECT * FROM " . DB_PREFIX . "order_product WHERE order_id = '" . (int)$order_id . "'");
-		
-		return $query->rows;
-	}
 	
 	public function getOrderOptions($order_id, $order_product_id) {
 		$query = $this->db->query("SELECT * FROM " . DB_PREFIX . "order_option WHERE order_id = '" . (int)$order_id . "' AND order_product_id = '" . (int)$order_product_id . "'");


### PR DESCRIPTION
Remove double public function getOrderProducts($order_id) at lines 246-250.