### PR TITLE
Update download.php

### DIFF
--- a/upload/catalog/controller/account/download.php
+++ b/upload/catalog/controller/account/download.php
@@ -143,7 +143,7 @@ class ControllerAccountDownload extends Controller {
 						ob_end_clean();
 					}
 
-					readfile($file, 'rb');
+					readfile($file);
 
 					exit();
 				} else {


### PR DESCRIPTION
function `readfile()` does not take a `$mode` argument like `fopen()`.  The argument `'rb'` should be removed.