### PR TITLE
Update Marketplace  - folders that allow all extension to work

### DIFF
--- a/upload/admin/controller/marketplace/marketplace.php
+++ b/upload/admin/controller/marketplace/marketplace.php
@@ -930,10 +930,19 @@ class ControllerMarketplaceMarketplace extends Controller {
 				$allowed = array(
 					'admin/controller/extension/',
 					'admin/model/extension/',
+					'admin/view/image/extension/',
+					'admin/view/javascript/extension/',
+					'admin/view/stylesheet/extension/',
 					'admin/view/template/extension/',
 					'catalog/controller/extension/',
 					'catalog/model/extension/',
-					'catalog/view/theme/'
+					'catalog/view/javascript/extension/',
+					'catalog/view/theme/',
+					'system/config/extension/',
+					'system/library/extension/',
+					'system/extension/',
+					'system/storage/logs/extension/',
+					'image/catalog/extension/'
 				);
 
 				// Language Admin


### PR DESCRIPTION
For most of the modules the list of allowed folders is not enough. it will create duplicate code which is not good practice. 

to avoid this we would suggest adding the follwoing folders 


$allowed = array(
    'admin/controller/extension/',
    'admin/model/extension/',
    'admin/view/image/extension/',
    'admin/view/javascript/extension/',
    'admin/view/stylesheet/extension/',
    'admin/view/template/extension/',
    'catalog/controller/extension/',
    'catalog/model/extension/',
    'catalog/view/javascript/extension/',
    'catalog/view/theme/',
    'system/config/extension/',
    'system/library/extension/',
    'system/storage/logs/extension/',
    'system/extension/',
    'image/catalog/extension/',
);

from the code I assume language is not an issue - it has its own logic.