### PR TITLE
Add support for vendor libraries in system/vendor/

### DIFF
--- a/upload/system/engine/loader.php
+++ b/upload/system/engine/loader.php
@@ -91,16 +91,23 @@ final class Loader {
 		// Sanitize the call
 		$route = preg_replace('/[^a-zA-Z0-9_\/]/', '', (string)$route);
 			
-		$file = DIR_SYSTEM . 'library/' . $route . '.php';
+        $files = array(
+            DIR_SYSTEM . 'vendor/' . $route . '.php',
+            DIR_SYSTEM . 'library/' . $route . '.php'
+        );
+
 		$class = str_replace('/', '\\', $route);
 
-		if (is_file($file)) {
-			include_once($file);
+        foreach ($files as $file) {
+            if (is_file($file)) {
+                include_once($file);
 
-			$this->registry->set(basename($route), new $class($this->registry));
-		} else {
-			throw new \Exception('Error: Could not load library ' . $route . '!');
-		}
+                $this->registry->set(basename($route), new $class($this->registry));
+                return;
+            }
+        }
+
+        throw new \Exception('Error: Could not load library ' . $route . '!');
 	}
 	
 	public function helper($route) {

--- a/upload/system/startup.php
+++ b/upload/system/startup.php
@@ -72,15 +72,20 @@ if (is_file(DIR_SYSTEM . '../../vendor/autoload.php')) {
 }
 
 function library($class) {
-	$file = DIR_SYSTEM . 'library/' . str_replace('\\', '/', strtolower($class)) . '.php';
+    $files = array(
+        DIR_SYSTEM . 'vendor/' . str_replace('\\', '/', strtolower($class)) . '.php',
+        DIR_SYSTEM . 'library/' . str_replace('\\', '/', strtolower($class)) . '.php'
+    );
 
-	if (is_file($file)) {
-		include_once(modification($file));
+    foreach ($files as $file) {
+        if (is_file($file)) {
+            include_once(modification($file));
 
-		return true;
-	} else {
-		return false;
-	}
+            return true;
+        }
+    }
+
+    return false;
 }
 
 spl_autoload_register('library');


### PR DESCRIPTION
In this implementation the **vendor/** directory is being checked before the **library/** one, to allow replacing native libraries with 3rd party ones in an "elegant" way. Not sure if this is okay though. The order might need to be reversed if such an override is not going to be allowed.

