### PR TITLE
Fixed Extension Updating

### DIFF
--- a/upload/admin/controller/marketplace/install.php
+++ b/upload/admin/controller/marketplace/install.php
@@ -177,12 +177,6 @@ class ControllerMarketplaceInstall extends Controller {
 						if (substr($destination, 0, 6) == 'system') {
 							$destination = DIR_SYSTEM . substr($destination, 7);
 						}
-	
-						if (is_file($destination)) {
-							$json['error'] = sprintf($this->language->get('error_exists'), $destination);
-	
-							break;
-						}
 					} else {
 						$json['error'] = sprintf($this->language->get('error_allowed'), $destination);
 	
@@ -292,7 +286,7 @@ class ControllerMarketplaceInstall extends Controller {
 							$modification_info = $this->model_setting_modification->getModificationByCode($code);
 	
 							if ($modification_info) {
-								$json['error'] = sprintf($this->language->get('error_xml'), $modification_info['name']);
+								$this->model_setting_modification->deleteModification($modification_info['modification_id']);
 							}
 						} else {
 							$json['error'] = $this->language->get('error_code');


### PR DESCRIPTION
- Removed check for existing extension files as this prevents customers from being able to update extensions.

- Changed if modification already exists, the existing modification is deleted and the new modification file is installed.  Before, any extension with an install.xml file would be blocked from updating unless the customer manually deleted the existing modification prior to uploading the new extension files.