### PR TITLE
Increased Code character limit in Event table

### DIFF
--- a/upload/install/opencart.sql
+++ b/upload/install/opencart.sql
@@ -1341,7 +1341,7 @@ CREATE TABLE `oc_download_description` (
 DROP TABLE IF EXISTS `oc_event`;
 CREATE TABLE `oc_event` (
   `event_id` int(11) NOT NULL AUTO_INCREMENT,
-  `code` varchar(32) NOT NULL,
+  `code` varchar(64) NOT NULL,
   `trigger` text NOT NULL,
   `action` text NOT NULL,
   `status` tinyint(1) NOT NULL,


### PR DESCRIPTION
Increased Event `code` column to 64 chars.  Allows for longer code names and will help prevent duplicate names.