### PR TITLE
Language class -> get() functions was removed from controllers [small part]

### DIFF
--- a/upload/catalog/controller/account/account.php
+++ b/upload/catalog/controller/account/account.php
@@ -6,9 +6,7 @@ class ControllerAccountAccount extends Controller {
 
 			$this->response->redirect($this->url->link('account/login', '', true));
 		}
-
-		$this->load->language('account/account');
-		$this->data = array_merge($this->data, $this->language->getData());
+		$this->language->load('account/account', $data);
 
 		$this->document->setTitle($this->language->get('heading_title'));
 
@@ -31,7 +29,7 @@ class ControllerAccountAccount extends Controller {
 		} else {
 			$data['success'] = '';
 		}
-		
+
 		$data['edit'] = $this->url->link('account/edit', '', true);
 		$data['password'] = $this->url->link('account/password', '', true);
 		$data['address'] = $this->url->link('account/address', '', true);

--- a/upload/catalog/controller/account/account.php
+++ b/upload/catalog/controller/account/account.php
@@ -8,6 +8,7 @@ class ControllerAccountAccount extends Controller {
 		}
 
 		$this->load->language('account/account');
+		$this->data = array_merge($this->data, $this->language->getData());
 
 		$this->document->setTitle($this->language->get('heading_title'));
 
@@ -29,37 +30,19 @@ class ControllerAccountAccount extends Controller {
 			unset($this->session->data['success']);
 		} else {
 			$data['success'] = '';
-		} 
-
-		$data['heading_title'] = $this->language->get('heading_title');
-
-		$data['text_my_account'] = $this->language->get('text_my_account');
-		$data['text_my_orders'] = $this->language->get('text_my_orders');
-		$data['text_my_newsletter'] = $this->language->get('text_my_newsletter');
-		$data['text_edit'] = $this->language->get('text_edit');
-		$data['text_password'] = $this->language->get('text_password');
-		$data['text_address'] = $this->language->get('text_address');
-		$data['text_credit_card'] = $this->language->get('text_credit_card');
-		$data['text_wishlist'] = $this->language->get('text_wishlist');
-		$data['text_order'] = $this->language->get('text_order');
-		$data['text_download'] = $this->language->get('text_download');
-		$data['text_reward'] = $this->language->get('text_reward');
-		$data['text_return'] = $this->language->get('text_return');
-		$data['text_transaction'] = $this->language->get('text_transaction');
-		$data['text_newsletter'] = $this->language->get('text_newsletter');
-		$data['text_recurring'] = $this->language->get('text_recurring');
-
+		}
+		
 		$data['edit'] = $this->url->link('account/edit', '', true);
 		$data['password'] = $this->url->link('account/password', '', true);
 		$data['address'] = $this->url->link('account/address', '', true);
-		
+
 		$data['credit_cards'] = array();
-		
+
 		$files = glob(DIR_APPLICATION . 'controller/extension/credit_card/*.php');
-		
+
 		foreach ($files as $file) {
 			$code = basename($file, '.php');
-			
+
 			if ($this->config->get($code . '_status') && $this->config->get($code . '_card')) {
 				$this->load->language('extension/credit_card/' . $code);
 
@@ -69,29 +52,29 @@ class ControllerAccountAccount extends Controller {
 				);
 			}
 		}
-		
+
 		$data['wishlist'] = $this->url->link('account/wishlist');
 		$data['order'] = $this->url->link('account/order', '', true);
 		$data['download'] = $this->url->link('account/download', '', true);
-		
+
 		if ($this->config->get('reward_status')) {
 			$data['reward'] = $this->url->link('account/reward', '', true);
 		} else {
 			$data['reward'] = '';
-		}		
-		
+		}
+
 		$data['return'] = $this->url->link('account/return', '', true);
 		$data['transaction'] = $this->url->link('account/transaction', '', true);
 		$data['newsletter'] = $this->url->link('account/newsletter', '', true);
 		$data['recurring'] = $this->url->link('account/recurring', '', true);
-		
+
 		$data['column_left'] = $this->load->controller('common/column_left');
 		$data['column_right'] = $this->load->controller('common/column_right');
 		$data['content_top'] = $this->load->controller('common/content_top');
 		$data['content_bottom'] = $this->load->controller('common/content_bottom');
 		$data['footer'] = $this->load->controller('common/footer');
 		$data['header'] = $this->load->controller('common/header');
-		
+
 		$this->response->setOutput($this->load->view('account/account', $data));
 	}
 }

--- a/upload/catalog/controller/account/edit.php
+++ b/upload/catalog/controller/account/edit.php
@@ -9,8 +9,7 @@ class ControllerAccountEdit extends Controller {
 			$this->response->redirect($this->url->link('account/login', '', true));
 		}
 
-		$this->load->language('account/edit');
-		$this->data = array_merge($this->data, $this->language->getData());
+		$this->language->load('account/edit', $data);
 
 		$this->document->setTitle($this->language->get('heading_title'));
 

--- a/upload/catalog/controller/account/edit.php
+++ b/upload/catalog/controller/account/edit.php
@@ -10,6 +10,7 @@ class ControllerAccountEdit extends Controller {
 		}
 
 		$this->load->language('account/edit');
+		$this->data = array_merge($this->data, $this->language->getData());
 
 		$this->document->setTitle($this->language->get('heading_title'));
 
@@ -55,23 +56,6 @@ class ControllerAccountEdit extends Controller {
 			'text'      => $this->language->get('text_edit'),
 			'href'      => $this->url->link('account/edit', '', true)
 		);
-
-		$data['heading_title'] = $this->language->get('heading_title');
-
-		$data['text_your_details'] = $this->language->get('text_your_details');
-		$data['text_additional'] = $this->language->get('text_additional');
-		$data['text_select'] = $this->language->get('text_select');
-		$data['text_loading'] = $this->language->get('text_loading');
-
-		$data['entry_firstname'] = $this->language->get('entry_firstname');
-		$data['entry_lastname'] = $this->language->get('entry_lastname');
-		$data['entry_email'] = $this->language->get('entry_email');
-		$data['entry_telephone'] = $this->language->get('entry_telephone');
-		$data['entry_fax'] = $this->language->get('entry_fax');
-
-		$data['button_continue'] = $this->language->get('button_continue');
-		$data['button_back'] = $this->language->get('button_back');
-		$data['button_upload'] = $this->language->get('button_upload');
 
 		if (isset($this->error['warning'])) {
 			$data['error_warning'] = $this->error['warning'];

--- a/upload/catalog/controller/account/login.php
+++ b/upload/catalog/controller/account/login.php
@@ -45,7 +45,7 @@ class ControllerAccountLogin extends Controller {
 			$this->response->redirect($this->url->link('account/account', '', true));
 		}
 
-		$this->load->language('account/login');
+		$this->load->language('account/login', $data);
 
 		$this->document->setTitle($this->language->get('heading_title'));
 
@@ -111,21 +111,6 @@ class ControllerAccountLogin extends Controller {
 			'text' => $this->language->get('text_login'),
 			'href' => $this->url->link('account/login', '', true)
 		);
-
-		$data['heading_title'] = $this->language->get('heading_title');
-
-		$data['text_new_customer'] = $this->language->get('text_new_customer');
-		$data['text_register'] = $this->language->get('text_register');
-		$data['text_register_account'] = $this->language->get('text_register_account');
-		$data['text_returning_customer'] = $this->language->get('text_returning_customer');
-		$data['text_i_am_returning_customer'] = $this->language->get('text_i_am_returning_customer');
-		$data['text_forgotten'] = $this->language->get('text_forgotten');
-
-		$data['entry_email'] = $this->language->get('entry_email');
-		$data['entry_password'] = $this->language->get('entry_password');
-
-		$data['button_continue'] = $this->language->get('button_continue');
-		$data['button_login'] = $this->language->get('button_login');
 
 		if (isset($this->session->data['error'])) {
 			$data['error_warning'] = $this->session->data['error'];

--- a/upload/catalog/controller/account/login.php
+++ b/upload/catalog/controller/account/login.php
@@ -45,7 +45,7 @@ class ControllerAccountLogin extends Controller {
 			$this->response->redirect($this->url->link('account/account', '', true));
 		}
 
-		$this->load->language('account/login', $data);
+		$this->language->load('account/login', $data);
 
 		$this->document->setTitle($this->language->get('heading_title'));
 

--- a/upload/system/library/language.php
+++ b/upload/system/library/language.php
@@ -11,11 +11,15 @@ class Language {
 	public function get($key) {
 		return (isset($this->data[$key]) ? $this->data[$key] : $key);
 	}
-	
+
+	public function getData() {
+		return $this->data;
+	}
+
 	public function set($key, $value) {
 		$this->data[$key] = $value;
 	}
-			
+
 	public function load($filename, &$data = array()) {
 		$_ = array();
 
@@ -26,10 +30,10 @@ class Language {
 		}
 
 		$file = DIR_LANGUAGE . $this->directory . '/' . $filename . '.php';
-		
+
 		if (is_file($file)) {
 			require($file);
-		} 
+		}
 
 		$this->data = array_merge($this->data, $_);
 

--- a/upload/system/library/language.php
+++ b/upload/system/library/language.php
@@ -35,6 +35,10 @@ class Language {
 			require($file);
 		}
 
+		if(!isset($data)){
+			$data = array();
+		}
+
 		$this->data = array_merge($this->data, $_);
 
 		$data = array_merge($data, $this->data);


### PR DESCRIPTION
get() function callings was removed  from Controller classes which uses get function in the Language class .Instead of this, data array variable in Language class, was encapsulated to get it from another class. And this was used to merge with controller data. After merging, no need to call get function of Language class. Notice: This commit just contains small part of refactoring of controllers which use get function of Language class. If this commit is accepted, we will continue to refactor controllers.