### PR TITLE
Check prior to adding to user_group table to avoid duplicate entries

### DIFF
--- a/upload/admin/model/user/user_group.php
+++ b/upload/admin/model/user/user_group.php
@@ -65,9 +65,11 @@ class ModelUserUserGroup extends Model {
 		if ($user_group_query->num_rows) {
 			$data = json_decode($user_group_query->row['permission'], true);
 
-			$data[$type][] = $route;
+			if (!in_array($route, $data[$type])) {
+				$data[$type][] = $route;
 
-			$this->db->query("UPDATE " . DB_PREFIX . "user_group SET permission = '" . $this->db->escape(json_encode($data)) . "' WHERE user_group_id = '" . (int)$user_group_id . "'");
+				$this->db->query("UPDATE " . DB_PREFIX . "user_group SET permission = '" . $this->db->escape(json_encode($data)) . "' WHERE user_group_id = '" . (int)$user_group_id . "'");
+			}
 		}
 	}
 


### PR DESCRIPTION
I was looking at this table and noticed a lot of duplicate entries for software I was working on.  The reason is that the controllers in `admin/controller/extension/extension` do a call to `addPermission()` in their `install()` function, without a corresponding `deletePermission()` in the `uninstall()` function.