### PR TITLE
opencart.js filemanager url path token changed to user_token - Dev branch

### DIFF
--- a/upload/admin/view/javascript/summernote/opencart.js
+++ b/upload/admin/view/javascript/summernote/opencart.js
@@ -29,7 +29,7 @@ $(document).ready(function() {
 							$('#modal-image').remove();
 						
 							$.ajax({
-								url: 'index.php?route=common/filemanager&token=' + getURLVar('user_token'),
+								url: 'index.php?route=common/filemanager&user_token=' + getURLVar('user_token'),
 								dataType: 'html',
 								beforeSend: function() {
 									$('#button-image i').replaceWith('<i class="fa fa-circle-o-notch fa-spin"></i>');


### PR DESCRIPTION
Token name changed to user_token in opencart.js for summer note.
File manager won't open since token name is incorrect. Changed it to user_token.