### PR TITLE
Regex add ( After OR Before ) - without ( Replace )

### DIFF
--- a/upload/admin/controller/extension/modification.php
+++ b/upload/admin/controller/extension/modification.php
@@ -225,8 +225,7 @@ class ControllerExtensionModification extends Controller {
 
 										$status = false;
 
-						
-										// Search and replace if regex without replace OR no regex else replace by regex
+										// Search and replace if regex without replace too
 										if ((($operation->getElementsByTagName('search')->item(0)->getAttribute('regex') == 'true') and ($operation->getElementsByTagName('add')->item(0)->getAttribute('position') != 'replace')) or ($operation->getElementsByTagName('search')->item(0)->getAttribute('regex') != 'true')) {
 											// Search
 											$search = $operation->getElementsByTagName('search')->item(0)->textContent;
@@ -274,15 +273,14 @@ class ControllerExtensionModification extends Controller {
 												// Status
 												$match = false;
 						  
-											// Check to see if the line matches the search code by regex
-												if ($operation->getElementsByTagName('search')->item(0)->getAttribute('regex') == 'true') { //(stripos($line, $search) !== false) {
+												// Check to see if the line matches the search code by regex
+												if ($operation->getElementsByTagName('search')->item(0)->getAttribute('regex') == 'true') {
 													// If indexes are not used then just set the found status to true.
 													if (preg_match($search, $line)) {
 														$match = true;
 													}
 
 													$i++;
-
 						  
 												// Check to see if the line matches the search code.
 												} elseif ((stripos($line, $search) !== false) and ($operation->getElementsByTagName('search')->item(0)->getAttribute('regex') != 'true')) {
@@ -431,12 +429,9 @@ class ControllerExtensionModification extends Controller {
 			}
 
 			// Maintance mode back to original settings
-			$this->model_setting_setting->editSettingValue('config', 'config_maintenance', $maintenance);
+			$this->model_setting_setting->editSettingValue('config', 'config_maintenance', $maintenance);		  
 
-																	  
-								   
 			$this->session->data['success'] = $this->language->get('text_success');
-	
 
 			$url = '';
 

--- a/upload/admin/controller/extension/modification.php
+++ b/upload/admin/controller/extension/modification.php
@@ -281,7 +281,6 @@ class ControllerExtensionModification extends Controller {
 													}
 
 													$i++;
-						  
 												// Check to see if the line matches the search code.
 												} elseif ((stripos($line, $search) !== false) and ($operation->getElementsByTagName('search')->item(0)->getAttribute('regex') != 'true')) {
 													// If indexes are not used then just set the found status to true.

--- a/upload/admin/controller/extension/modification.php
+++ b/upload/admin/controller/extension/modification.php
@@ -225,8 +225,9 @@ class ControllerExtensionModification extends Controller {
 
 										$status = false;
 
-										// Search and replace
-										if ($operation->getElementsByTagName('search')->item(0)->getAttribute('regex') != 'true') {
+						
+										// Search and replace if regex without replace OR no regex else replace by regex
+										if ((($operation->getElementsByTagName('search')->item(0)->getAttribute('regex') == 'true') and ($operation->getElementsByTagName('add')->item(0)->getAttribute('position') != 'replace')) or ($operation->getElementsByTagName('search')->item(0)->getAttribute('regex') != 'true')) {
 											// Search
 											$search = $operation->getElementsByTagName('search')->item(0)->textContent;
 											$trim = $operation->getElementsByTagName('search')->item(0)->getAttribute('trim');
@@ -272,9 +273,19 @@ class ControllerExtensionModification extends Controller {
 
 												// Status
 												$match = false;
+						  
+											// Check to see if the line matches the search code by regex
+												if ($operation->getElementsByTagName('search')->item(0)->getAttribute('regex') == 'true') { //(stripos($line, $search) !== false) {
+													// If indexes are not used then just set the found status to true.
+													if (preg_match($search, $line)) {
+														$match = true;
+													}
 
+													$i++;
+
+						  
 												// Check to see if the line matches the search code.
-												if (stripos($line, $search) !== false) {
+												} elseif ((stripos($line, $search) !== false) and ($operation->getElementsByTagName('search')->item(0)->getAttribute('regex') != 'true')) {
 													// If indexes are not used then just set the found status to true.
 													if (!$indexes) {
 														$match = true;
@@ -422,7 +433,10 @@ class ControllerExtensionModification extends Controller {
 			// Maintance mode back to original settings
 			$this->model_setting_setting->editSettingValue('config', 'config_maintenance', $maintenance);
 
+																	  
+								   
 			$this->session->data['success'] = $this->language->get('text_success');
+	
 
 			$url = '';
 

--- a/upload/admin/controller/extension/modification.php
+++ b/upload/admin/controller/extension/modification.php
@@ -429,7 +429,7 @@ class ControllerExtensionModification extends Controller {
 			}
 
 			// Maintance mode back to original settings
-			$this->model_setting_setting->editSettingValue('config', 'config_maintenance', $maintenance);		  
+			$this->model_setting_setting->editSettingValue('config', 'config_maintenance', $maintenance);
 
 			$this->session->data['success'] = $this->language->get('text_success');
 


### PR DESCRIPTION
it's helping developer to write less lines & code , Regex after or before that mean searching easier ! less search token "search tag" with same "add tag" codes .
e.g :
The following regex it could replace 8 different lines :
``~$this->load->language('(catalog|soconfig)/(mvd_|vdi_|m|)product~``
but if you don't want to replace , want to add before or after , this update for this purpose !
You can adapt many themes with your module in OCMOD !

Please @danielkerr Confirm it.
Say goodbye to VQMOD