### PR TITLE
Missed one Prefix of Dashboard

### DIFF
--- a/upload/admin/controller/extension/extension/dashboard.php
+++ b/upload/admin/controller/extension/extension/dashboard.php
@@ -38,7 +38,7 @@ class ControllerExtensionExtensionDashboard extends Controller {
 		$this->load->model('setting/extension');
 
 		if ($this->validate()) {
-			$this->model_setting_extension->uninstall('dashboard', 'dashboard_' . $this->request->get['extension']);
+			$this->model_setting_extension->uninstall('dashboard', $this->request->get['extension']);
 
 			// Call uninstall method if it exsits
 			$this->load->controller('extension/dashboard/' . $this->request->get['extension'] . '/uninstall');


### PR DESCRIPTION
Hi, I believe you have missed one prefix of Dashboard which needs to be removed for the extension to be uninstalled.