### PR TITLE
Translation Fix: New language error_exists text fix

### DIFF
--- a/upload/admin/language/en-gb/localisation/language.php
+++ b/upload/admin/language/en-gb/localisation/language.php
@@ -27,7 +27,7 @@ $_['help_status']       = 'Hide/Show it in language dropdown.';
 
 // Error
 $_['error_permission']  = 'Warning: You do not have permission to modify languages!';
-$_['error_exists']      = 'Warning: You added before the language!';
+$_['error_exists']      = 'Warning: You have added this language already!';
 $_['error_name']        = 'Language Name must be between 3 and 32 characters!';
 $_['error_code']        = 'Language Code must at least 2 characters!';
 $_['error_locale']      = 'Locale required!';


### PR DESCRIPTION
Fixed an error message which was output to the user when trying to add a new language where a code had already been assigned. This error message didn't make sense or tell the user what had happened.