### PR TITLE
Dashboard map update

### DIFF
--- a/upload/admin/controller/extension/dashboard/map.php
+++ b/upload/admin/controller/extension/dashboard/map.php
@@ -114,7 +114,7 @@ class ControllerExtensionDashboardMap extends Controller {
 
 		$this->load->model('report/sale');
 
-		$results = $this->model_report_sale->getTotalOrdersByCountry();
+		$results = $this->model_report_sale->getTotalOrdersByCountry($this->config->get('config_complete_status'));
 
 		foreach ($results as $result) {
 			$json[strtolower($result['iso_code_2'])] = array(

--- a/upload/admin/controller/extension/dashboard/map.php
+++ b/upload/admin/controller/extension/dashboard/map.php
@@ -114,7 +114,7 @@ class ControllerExtensionDashboardMap extends Controller {
 
 		$this->load->model('report/sale');
 
-		$results = $this->model_report_sale->getTotalOrdersByCountry($this->config->get('config_complete_status'));
+		$results = $this->model_report_sale->getTotalOrdersByCountry(true);
 
 		foreach ($results as $result) {
 			$json[strtolower($result['iso_code_2'])] = array(

--- a/upload/admin/model/report/sale.php
+++ b/upload/admin/model/report/sale.php
@@ -12,9 +12,9 @@ class ModelReportSale extends Model {
 		return $query->row['total'];
 	}
 
-	public function getTotalOrdersByCountry($order_status_id = array()) {
-		if(!empty($order_status_id)){
-			$query = $this->db->query("SELECT COUNT(*) AS total, SUM(o.total) AS amount, c.iso_code_2 FROM `" . DB_PREFIX . "order` o LEFT JOIN `" . DB_PREFIX . "country` c ON (o.payment_country_id = c.country_id) WHERE o.order_status_id IN(" . implode(",", $order_status_id) . ") GROUP BY o.payment_country_id");
+	public function getTotalOrdersByCountry($complete = false) {
+		if($complete){
+			$query = $this->db->query("SELECT COUNT(*) AS total, SUM(o.total) AS amount, c.iso_code_2 FROM `" . DB_PREFIX . "order` o LEFT JOIN `" . DB_PREFIX . "country` c ON (o.payment_country_id = c.country_id) WHERE o.order_status_id IN(" . implode(",", array_map('intval', $this->config->get('config_complete_status'))) . ") GROUP BY o.payment_country_id");
 		} else {
 			$query = $this->db->query("SELECT COUNT(*) AS total, SUM(o.total) AS amount, c.iso_code_2 FROM `" . DB_PREFIX . "order` o LEFT JOIN `" . DB_PREFIX . "country` c ON (o.payment_country_id = c.country_id) WHERE o.order_status_id > '0' GROUP BY o.payment_country_id");
 		}

--- a/upload/admin/model/report/sale.php
+++ b/upload/admin/model/report/sale.php
@@ -12,8 +12,12 @@ class ModelReportSale extends Model {
 		return $query->row['total'];
 	}
 
-	public function getTotalOrdersByCountry() {
-		$query = $this->db->query("SELECT COUNT(*) AS total, SUM(o.total) AS amount, c.iso_code_2 FROM `" . DB_PREFIX . "order` o LEFT JOIN `" . DB_PREFIX . "country` c ON (o.payment_country_id = c.country_id) WHERE o.order_status_id > '0' GROUP BY o.payment_country_id");
+	public function getTotalOrdersByCountry($order_status_id = array()) {
+		if(!empty($order_status_id)){
+			$query = $this->db->query("SELECT COUNT(*) AS total, SUM(o.total) AS amount, c.iso_code_2 FROM `" . DB_PREFIX . "order` o LEFT JOIN `" . DB_PREFIX . "country` c ON (o.payment_country_id = c.country_id) WHERE o.order_status_id IN(" . implode(",", $order_status_id) . ") GROUP BY o.payment_country_id");
+		} else {
+			$query = $this->db->query("SELECT COUNT(*) AS total, SUM(o.total) AS amount, c.iso_code_2 FROM `" . DB_PREFIX . "order` o LEFT JOIN `" . DB_PREFIX . "country` c ON (o.payment_country_id = c.country_id) WHERE o.order_status_id > '0' GROUP BY o.payment_country_id");
+		}
 
 		return $query->rows;
 	}


### PR DESCRIPTION
**Issue**
The map on the dashboard is slightly misleading as it includes country summaries across all orders including failed/declined etc. This pull request adds an order_status_id filter to the getTotalOrdersByCountry model function and passes the config_complete_status details to only pass back amounts from orders which have actually been completed/shipped.

Store owners can then see a country breakdown from successful orders and get a better insight into actual totals.

**Original Commit Details**
Updated the getTotalOrdersByCountry function to use an order_status_id filter.

Applied to dashboard map model call to ensure that only completed orders show up on the map dashboard extension.