### PR TITLE
Return error if not isset g-recaptcha-response

### DIFF
--- a/upload/catalog/controller/extension/captcha/google.php
+++ b/upload/catalog/controller/extension/captcha/google.php
@@ -17,13 +17,17 @@ class ControllerExtensionCaptchaGoogle extends Controller {
     }
 
     public function validate() {
-		if (empty($this->session->data['gcapcha']) && isset($this->request->post['g-recaptcha-response'])) {
+		if (empty($this->session->data['gcapcha'])) {
 			$this->load->language('extension/captcha/google');
 
+			if (!isset($this->request->post['g-recaptcha-response'])) {
+				return $this->language->get('error_captcha');
+			}
+
 			$recaptcha = file_get_contents('https://www.google.com/recaptcha/api/siteverify?secret=' . urlencode($this->config->get('captcha_google_secret')) . '&response=' . $this->request->post['g-recaptcha-response'] . '&remoteip=' . $this->request->server['REMOTE_ADDR']);
-	
+
 			$recaptcha = json_decode($recaptcha, true);
-	
+
 			if ($recaptcha['success']) {
 				$this->session->data['gcapcha']	= true;
 			} else {


### PR DESCRIPTION
Return error if not isset g-recaptcha-response, because maybe captcha was removed from the form.