### PR TITLE
Fix: Catalog account/account credit card extensions list now working.

### DIFF
--- a/upload/catalog/controller/account/account.php
+++ b/upload/catalog/controller/account/account.php
@@ -42,7 +42,7 @@ class ControllerAccountAccount extends Controller {
 		foreach ($files as $file) {
 			$code = basename($file, '.php');
 			
-			if ($this->config->get('payment_' . $code . '_status') && $this->config->get($code . '_card')) {
+			if ($this->config->get('payment_' . $code . '_status') && $this->config->get('payment_' . $code . '_card')) {
 				$this->load->language('extension/credit_card/' . $code, 'extension');
 
 				$data['credit_cards'][] = array(


### PR DESCRIPTION
Catalog account/account page now properly lists payment extensions supporting credit card management.