### PR TITLE
Fix security.php PHP 7.0 and 7.1

### DIFF
--- a/upload/admin/controller/common/security.php
+++ b/upload/admin/controller/common/security.php
@@ -20,7 +20,7 @@ class ControllerCommonSecurity extends Controller {
 			
 		$data['paths'] = '';
 		
-		$path = '';
+		$path = array();
 			
 		$parts = explode('/', substr($this->request->server['DOCUMENT_ROOT'], 0, strrpos($this->request->server['DOCUMENT_ROOT'], '/')));	
 		


### PR DESCRIPTION
Fatal error: Uncaught Error: [] operator not supported for strings in ...admin\controller\common\security.php on line 30