### PR TITLE
Square payment extension: Add integration_id parameter to API charge() requests.

### DIFF
--- a/upload/catalog/controller/extension/payment/squareup.php
+++ b/upload/catalog/controller/extension/payment/squareup.php
@@ -147,7 +147,8 @@ class ControllerExtensionPaymentSquareup extends Controller {
                 ),
                 'billing_address' => $billing_address,
                 'buyer_email_address' => $order_info['email'],
-                'delay_capture' => !$this->cart->hasRecurringProducts() && $this->config->get('payment_squareup_delay_capture')
+                'delay_capture' => !$this->cart->hasRecurringProducts() && $this->config->get('payment_squareup_delay_capture'),
+                'integration_id' => Squareup::SQUARE_INTEGRATION_ID
             );
             
             if (!empty($shipping_address)) {

--- a/upload/catalog/model/extension/payment/squareup.php
+++ b/upload/catalog/model/extension/payment/squareup.php
@@ -229,6 +229,8 @@ class ModelExtensionPaymentSquareup extends Model {
     public function nextRecurringPayments() {
         $payments = array();
 
+        $this->load->library('squareup');
+
         $recurring_sql = "SELECT * FROM `" . DB_PREFIX . "order_recurring` `or` INNER JOIN `" . DB_PREFIX . "squareup_transaction` st ON (st.transaction_id = `or`.reference) WHERE `or`.status='" . self::RECURRING_ACTIVE . "'";
 
         $this->load->model('checkout/order');
@@ -266,7 +268,8 @@ class ModelExtensionPaymentSquareup extends Model {
                 'buyer_email_address' => $order_info['email'],
                 'delay_capture' => false,
                 'customer_id' => $transaction_tenders[0]['customer_id'],
-                'customer_card_id' => $transaction_tenders[0]['card_details']['card']['id']
+                'customer_card_id' => $transaction_tenders[0]['card_details']['card']['id'],
+                'integration_id' => Squareup::SQUARE_INTEGRATION_ID
             );
 
             $payments[] = array(

--- a/upload/system/library/squareup.php
+++ b/upload/system/library/squareup.php
@@ -26,6 +26,7 @@ class Squareup {
     const PAYMENT_FORM_URL = 'https://js.squareup.com/v2/paymentform';
     const SCOPE = 'MERCHANT_PROFILE_READ PAYMENTS_READ SETTLEMENTS_READ CUSTOMERS_READ CUSTOMERS_WRITE';
     const VIEW_TRANSACTION_URL = 'https://squareup.com/dashboard/sales/transactions/%s/by-unit/%s';
+    const SQUARE_INTEGRATION_ID = 'sqi_65a5ac54459940e3600a8561829fd970';
 
     public function __construct($registry) {
         $this->session = $registry->get('session');


### PR DESCRIPTION
As per the requirements of Square, they need this in order to track revenue share transaction attribution from 3rd party merchant/developer hosted apps (where the application id will not be known up front).