### PR TITLE
Fix error security.php in PHP 7.0 and PHP 7.1

### DIFF
--- a/upload/admin/controller/common/security.php
+++ b/upload/admin/controller/common/security.php
@@ -11,7 +11,7 @@ class ControllerCommonSecurity extends Controller {
 		
 		$path = '';
 		
-		$data['paths'] = '';
+		$data['paths'] = array();
 			
 		$parts = explode('/', substr($this->request->server['DOCUMENT_ROOT'], 0, strrpos($this->request->server['DOCUMENT_ROOT'], '/')));	
 		


### PR DESCRIPTION
Fatal error: Uncaught Error: [] operator not supported for strings in ...\admin\controller\common\security.php on line 21