### PR TITLE
Update image.php

### DIFF
--- a/upload/system/library/image.php
+++ b/upload/system/library/image.php
@@ -118,14 +118,23 @@ class Image {
 
 		if (is_resource($this->image)) {
 			if ($extension == 'jpeg' || $extension == 'jpg') {
-				imagejpeg($this->image, $file, $quality);
+				imageinterlace($this->image, true);
+				$result = imagejpeg($this->image, $file, $quality);
 			} elseif ($extension == 'png') {
-				imagepng($this->image, $file);
+				$result = imagepng($this->image, $file);
 			} elseif ($extension == 'gif') {
-				imagegif($this->image, $file);
+				$result = imagegif($this->image, $file);
 			}
 
 			imagedestroy($this->image);
+			if (class_exists('Imagick') && !empty($result)) {
+				$img = new Imagick($file);
+				if (!empty($img)) {
+					$img->stripImage();
+					$img->writeImage($file);
+					$img->destroy();
+				}
+			}
 		}
 	}
 	


### PR DESCRIPTION
These changes will make images in OpenCart 100% optimized for Google Page Speed Insights from the box.
https://developers.google.com/speed/pagespeed/insights/
imageinterlace($this->image, true);  // reduces image size up to 10%
$img->stripImage(); // removes GD banner