### PR TITLE
fix: added DIR_STORAGE constant

### DIFF
--- a/upload/install/cli_install.php
+++ b/upload/install/cli_install.php
@@ -28,6 +28,7 @@ error_reporting(E_ALL);
 // DIR
 define('DIR_APPLICATION', str_replace('\\', '/', realpath(dirname(__FILE__))) . '/');
 define('DIR_SYSTEM', str_replace('\\', '/', realpath(dirname(__FILE__) . '/../')) . '/system/');
+define('DIR_STORAGE', DIR_SYSTEM . 'storage/');
 define('DIR_OPENCART', str_replace('\\', '/', realpath(DIR_APPLICATION . '../')) . '/');
 define('DIR_DATABASE', DIR_SYSTEM . 'database/');
 define('DIR_LANGUAGE', DIR_APPLICATION . 'language/');


### PR DESCRIPTION
the cli installer includes the startup.php script, which references the DIR_STORAGE constant. This is triggering a PHP_NOTICE. DIR_STORAGE was added to remove this behaviour.