### PR TITLE
Fix possible SQL injection vulnerability

### DIFF
--- a/upload/system/library/db/mysql.php
+++ b/upload/system/library/db/mysql.php
@@ -14,7 +14,7 @@ final class MySQL {
 		}
 
 		mysql_query("SET NAMES 'utf8'", $this->connection);
-		mysql_query("SET CHARACTER SET utf8", $this->connection);
+		mysql_set_charset('utf8', $this->connection);
 		mysql_query("SET CHARACTER_SET_CONNECTION=utf8", $this->connection);
 		mysql_query("SET SQL_MODE = ''", $this->connection);
 	}


### PR DESCRIPTION
should fix vulnerability to SQL injection via multi-byte attack when improper character set is set at the server level,
see http://php.net/manual/en/mysqlinfo.concepts.charset.php for details

I have spotted this issue while answering a question on Stack Overflow https://stackoverflow.com/questions/45378258/php-sql-injection-possibility/45379001.

I hope I am not mistaken as it is some time I've worked with `mysql_*` functions.