### PR TITLE
Fixed  #5798: Undefined variables in new password hashing code

### DIFF
--- a/upload/catalog/model/account/customer.php
+++ b/upload/catalog/model/account/customer.php
@@ -27,7 +27,7 @@ class ModelAccountCustomer extends Model {
 	}
 
 	public function editPassword($email, $password) {
-		$this->db->query("UPDATE " . DB_PREFIX . "customer SET salt = '', password = '" . $this->db->escape(password_hash($data['password'], PASSWORD_DEFAULT)) . "', code = '' WHERE LOWER(email) = '" . $this->db->escape(utf8_strtolower($email)) . "'");
+		$this->db->query("UPDATE " . DB_PREFIX . "customer SET salt = '', password = '" . $this->db->escape(password_hash($password, PASSWORD_DEFAULT)) . "', code = '' WHERE LOWER(email) = '" . $this->db->escape(utf8_strtolower($email)) . "'");
 	}
 
 	public function editAddressId($customer_id, $address_id) {

--- a/upload/system/library/cart/customer.php
+++ b/upload/system/library/cart/customer.php
@@ -49,7 +49,7 @@ class Customer {
 
 			if (!$override) {
 				if (password_verify($password, $customer_query->row['password'])) {
-					if (password_needs_rehash($password_hashed, PASSWORD_DEFAULT)) {
+					if (password_needs_rehash($customer_query->row['password'], PASSWORD_DEFAULT)) {
 						$new_password_hashed = password_hash($password, PASSWORD_DEFAULT);
 					}
 				} elseif ($customer_query->row['password'] == sha1($customer_query->row['salt'] . sha1($customer_query->row['salt'] . sha1($password))) || $customer_query->row['password'] == md5($password)) {

--- a/upload/system/library/cart/user.php
+++ b/upload/system/library/cart/user.php
@@ -42,7 +42,7 @@ class User {
 		if ($user_query->num_rows) {
 			
 			if (password_verify($password, $user_query->row['password'])) {
-				if (password_needs_rehash($password_hashed, PASSWORD_DEFAULT)) {
+				if (password_needs_rehash($user_query->row['password'], PASSWORD_DEFAULT)) {
 					$new_password_hashed = password_hash($password, PASSWORD_DEFAULT);
 				}
 			} elseif ($user_query->row['password'] == sha1($user_query->row['salt'] . sha1($user_query->row['salt'] . sha1($password))) || $user_query->row['password'] == md5($password)) {


### PR DESCRIPTION
In pull request #5798, my code for updating the password hashing to use PHP's password_hash() function used a few undefined variables instead of the data from the database query.