### PR TITLE
Square payments: Video tutorial button now has text. Video link changed.

### DIFF
--- a/upload/admin/controller/extension/payment/squareup.php
+++ b/upload/admin/controller/extension/payment/squareup.php
@@ -269,7 +269,7 @@ class ControllerExtensionPaymentSquareup extends Controller {
 
         $data['url_list_transactions'] = html_entity_decode($this->url->link('extension/payment/squareup/transactions', 'user_token=' . $this->session->data['user_token'] . '&page={PAGE}', true));
         $data['help'] = 'http://docs.isenselabs.com/square';
-        $data['url_video_help'] = 'http://bit.ly/2uYGoTA';
+        $data['url_video_help'] = 'https://www.youtube.com/watch?v=YVJyBrNb-BU';
         $data['url_integration_settings_help'] = 'http://docs.isenselabs.com/square/integration_settings';
 
         $this->load->model('localisation/language');

--- a/upload/admin/language/en-gb/extension/payment/squareup.php
+++ b/upload/admin/language/en-gb/extension/payment/squareup.php
@@ -219,4 +219,5 @@ $_['button_help']                                       = 'Documentation';
 $_['button_reconnect']                                  = 'Reconnect';
 $_['button_refresh']                                    = 'Refresh token';
 $_['button_refund']                                     = 'Refund';
+$_['button_video_help']                                 = 'Installation Video';
 $_['button_void']                                       = 'Void';

--- a/upload/admin/view/template/extension/payment/squareup.twig
+++ b/upload/admin/view/template/extension/payment/squareup.twig
@@ -55,7 +55,7 @@
                                         {% endif %}
                                     </span>
                                     <div class="pull-right">
-                                        <a target="_blank" href="{{ url_video_help }}" data-toggle="tooltip" title="{{ text_video_help }}" class="btn btn-info btn-sm"><i class="fa fa-video-camera"></i></a>
+                                        <a target="_blank" href="{{ url_video_help }}" data-toggle="tooltip" title="{{ text_video_help }}" class="btn btn-info btn-sm"><i class="fa fa-video-camera"></i>&nbsp;&nbsp;{{ button_video_help }}</a>
                                         <a target="_blank" href="{{ url_integration_settings_help }}" data-toggle="tooltip" title="{{ text_integration_settings_help }}" class="btn btn-info btn-sm"><i class="fa fa-question-circle"></i></a>
                                     </div>
                                 </legend>


### PR DESCRIPTION
This change is in accordance with Square's latest requirements.