### PR TITLE
Fix for state code not being sent to PayPal shopping in PayPal Payments Standard extension

### DIFF
--- a/upload/catalog/controller/extension/payment/pp_standard.php
+++ b/upload/catalog/controller/extension/payment/pp_standard.php
@@ -79,6 +79,7 @@ class ControllerExtensionPaymentPPStandard extends Controller {
 			$data['address1'] = html_entity_decode($order_info['payment_address_1'], ENT_QUOTES, 'UTF-8');
 			$data['address2'] = html_entity_decode($order_info['payment_address_2'], ENT_QUOTES, 'UTF-8');
 			$data['city'] = html_entity_decode($order_info['payment_city'], ENT_QUOTES, 'UTF-8');
+			$data['state'] = html_entity_decode($order_info['payment_zone_code'], ENT_QUOTES, 'UTF-8');
 			$data['zip'] = html_entity_decode($order_info['payment_postcode'], ENT_QUOTES, 'UTF-8');
 			$data['country'] = $order_info['payment_iso_code_2'];
 			$data['email'] = $order_info['email'];

--- a/upload/catalog/view/theme/default/template/extension/payment/pp_standard.twig
+++ b/upload/catalog/view/theme/default/template/extension/payment/pp_standard.twig
@@ -29,6 +29,7 @@
   <input type="hidden" name="address1" value="{{ address1 }}" />
   <input type="hidden" name="address2" value="{{ address2 }}" />
   <input type="hidden" name="city" value="{{ city }}" />
+  <input type="hidden" name="state" value="{{ state }}" />
   <input type="hidden" name="zip" value="{{ zip }}" />
   <input type="hidden" name="country" value="{{ country }}" />
   <input type="hidden" name="address_override" value="0" />


### PR DESCRIPTION
Fix for state code not being sent to PayPal shopping cart in 'confirm' stage of shopping cart when using PayPal Payments Pro extension. Issue #5861