### PR TITLE
Enabling code completion for common magic properties

### DIFF
--- a/upload/system/engine/controller.php
+++ b/upload/system/engine/controller.php
@@ -9,6 +9,15 @@
 
 /**
 * Controller class
+*
+* @property Document document
+* @property Loader load
+* @property Request request
+* @property Language language
+* @property Session session
+* @property Response response
+* @property Url url
+* @property Config config
 */
 abstract class Controller {
 	protected $registry;


### PR DESCRIPTION
This PR enables code completion for common magic properties by adding the @property in the DocBlock of the Controller class.

https://stackoverflow.com/questions/3814733/code-completion-for-private-protected-member-variables-when-using-magic-get/3815198#3815198

If you agree I will add @property annotations to other classes.