### PR TITLE
Upgrade fixes

### DIFF
--- a/upload/install/model/upgrade/1001.php
+++ b/upload/install/model/upgrade/1001.php
@@ -250,7 +250,7 @@ class ModelUpgrade1001 extends Model {
 					$output = '';
 
 					foreach ($lines as $line_id => $line) {
-						if (strpos($line, "'mysql'") !== false) {
+						if (strpos($line, "define('DB_DRIVER', 'mysql'") !== false) {
 							$new_line = "define('DB_DRIVER', 'mysqli');";
 							$output .= $new_line . "\n";
 						} else {

--- a/upload/install/model/upgrade/1010.php
+++ b/upload/install/model/upgrade/1010.php
@@ -1,5 +1,5 @@
 <?php
-class ModelUpgrade1009 extends Model {
+class ModelUpgrade1010 extends Model {
 	public function upgrade() {
 		// Add missing core events
 		$events = array();


### PR DESCRIPTION
- WAMP default password is 'mysql' breaks upgrade 1001.
- Typo 1010 class name.