### PR TITLE
Square Payment Extension bug fix

### DIFF
--- a/upload/catalog/view/theme/default/template/extension/payment/squareup.twig
+++ b/upload/catalog/view/theme/default/template/extension/payment/squareup.twig
@@ -74,6 +74,10 @@
         margin-top: 10px;
         cursor: pointer;
     }
+
+    #squareup_card_details_form .form-control {
+        min-height: 22px;
+    }
 </style>
 <script type="text/javascript">
     $(document).ready(function() {


### PR DESCRIPTION
On some themes, the checkout inputs are initialized with height=0. This fix adds a min-height style to the checkout input fields.