### PR TITLE
bootstrap toggles2 - use opacity in btn-group only for btn-success & btn-danger

### DIFF
--- a/upload/admin/view/stylesheet/stylesheet.css
+++ b/upload/admin/view/stylesheet/stylesheet.css
@@ -335,6 +335,15 @@ div.required .control-label:not(span):before, td.required:before {
 .btn-group {
 	white-space: nowrap;
 }
+.btn-group > .btn-success, .btn-group-vertical > .btn-success, .btn-group > .btn-danger, .btn-group-vertical > .btn-danger {
+	opacity: 0.3;
+}
+.btn-group > .btn-success:hover, .btn-group-vertical > .btn-success:hover, .btn-group > .btn-danger:hover, .btn-group-vertical > .btn-danger:hover {
+	opacity: 0.7;
+}
+.btn-group > .btn.active, .btn-group-vertical > .btn.active {
+	opacity: 1;
+}
 .table thead td span[data-toggle="tooltip"]:after, label.control-label span:after {
 	font-family: FontAwesome;
 	color: #1E91CF;


### PR DESCRIPTION
use opacity in btn-group only for btn-success & btn-danger
in this case on|off are contrast and marketplace group switch doesn't change