### PR TITLE
Fixed uploads pagination bug

### DIFF
--- a/upload/admin/model/sale/recurring.php
+++ b/upload/admin/model/sale/recurring.php
@@ -157,7 +157,8 @@ class ModelSaleRecurring extends Model {
 		return $result;
 	}
 	
-	public function getTotalRecurrings($data) {
+	public function getTotalRecurrings($data = array()) {
+
 		$sql = "SELECT COUNT(*) AS `total` FROM `" . DB_PREFIX . "order_recurring` `or` LEFT JOIN `" . DB_PREFIX . "order` o ON (`or`.order_id = `o`.order_id)";
 		
 		$implode = array();

--- a/upload/admin/model/sale/recurring.php
+++ b/upload/admin/model/sale/recurring.php
@@ -158,7 +158,6 @@ class ModelSaleRecurring extends Model {
 	}
 	
 	public function getTotalRecurrings($data = array()) {
-
 		$sql = "SELECT COUNT(*) AS `total` FROM `" . DB_PREFIX . "order_recurring` `or` LEFT JOIN `" . DB_PREFIX . "order` o ON (`or`.order_id = `o`.order_id)";
 		
 		$implode = array();

--- a/upload/admin/model/tool/upload.php
+++ b/upload/admin/model/tool/upload.php
@@ -80,7 +80,7 @@ class ModelToolUpload extends Model {
 		return $query->rows;
 	}
 
-	public function getTotalUploads() {
+	public function getTotalUploads($data = array()) {
 		$sql = "SELECT COUNT(*) AS total FROM " . DB_PREFIX . "upload";
 
 		$implode = array();


### PR DESCRIPTION
There was missing argument in getTotalUploads() function, causing uploads pagination not showing correctly after filtering data. Also for consistency added variable type in getTotalRecurrings() function, cause  all similar functions was using that.