### PR TITLE
Fix admin missing backup language

### DIFF
--- a/upload/admin/language/en-gb/tool/backup.php
+++ b/upload/admin/language/en-gb/tool/backup.php
@@ -8,6 +8,7 @@ $_['text_success']      = 'Success: You have successfully modified your database
 $_['text_backup']       = 'Backing up table %s records %s to %s records';
 $_['text_restore']      = 'Restoring %s of %s';
 $_['text_option']       = 'Backup Options';
+$_['text_history']      = 'Backup History';
 $_['text_progress']     = 'Progress';
 $_['text_import']       = 'For large backup files its better to upload the sql file via ftp to the <strong>system/storage/backup/</strong> directory.';
 

--- a/upload/admin/view/template/tool/backup.twig
+++ b/upload/admin/view/template/tool/backup.twig
@@ -63,7 +63,7 @@
             </div>
           </fieldset>
           <fieldset>
-            <legend>Backup History</legend>
+            <legend>{{ text_history }}</legend>
             <div class="alert alert-info"><i class="fa fa fa-exclamation-circle"></i> {{ text_import }}</div>
             <div id="history"></div>
           </fieldset>


### PR DESCRIPTION
- Added in admin/language/en-gb/tool/**backup.php**:
`$_['text_history']      = 'Backup History';`

- Replacing in  admin/view/template/tool/**backup.twig**:
`Backup History`
For:
`{{ text_history }}`