### PR TITLE
Deleted two unnecessary queries

### DIFF
--- a/upload/admin/model/localisation/geo_zone.php
+++ b/upload/admin/model/localisation/geo_zone.php
@@ -7,8 +7,6 @@ class ModelLocalisationGeoZone extends Model {
 
 		if (isset($data['zone_to_geo_zone'])) {
 			foreach ($data['zone_to_geo_zone'] as $value) {
-				$this->db->query("DELETE FROM " . DB_PREFIX . "zone_to_geo_zone WHERE geo_zone_id = '" . (int)$geo_zone_id . "' AND country_id = '" . (int)$value['country_id'] . "' AND zone_id = '" . (int)$value['zone_id'] . "'");				
-
 				$this->db->query("INSERT INTO " . DB_PREFIX . "zone_to_geo_zone SET country_id = '" . (int)$value['country_id'] . "', zone_id = '" . (int)$value['zone_id'] . "', geo_zone_id = '" . (int)$geo_zone_id . "', date_added = NOW()");
 			}
 		}
@@ -25,8 +23,6 @@ class ModelLocalisationGeoZone extends Model {
 
 		if (isset($data['zone_to_geo_zone'])) {
 			foreach ($data['zone_to_geo_zone'] as $value) {
-				$this->db->query("DELETE FROM " . DB_PREFIX . "zone_to_geo_zone WHERE geo_zone_id = '" . (int)$geo_zone_id . "' AND country_id = '" . (int)$value['country_id'] . "' AND zone_id = '" . (int)$value['zone_id'] . "'");				
-
 				$this->db->query("INSERT INTO " . DB_PREFIX . "zone_to_geo_zone SET country_id = '" . (int)$value['country_id'] . "', zone_id = '" . (int)$value['zone_id'] . "', geo_zone_id = '" . (int)$geo_zone_id . "', date_added = NOW()");
 			}
 		}


### PR DESCRIPTION
The delete query in addGeoZone is unnecessary because the related record won't exist - the zone_id it's was just generated in the preceding query.

In editGeoZone  - there is already a DELETE query preceding the foreach loop which would have deleted anything that the more specific DELETE in the loop would have found.

Both unnecessary.