### PR TITLE
Update modification.php

### DIFF
--- a/upload/admin/controller/marketplace/modification.php
+++ b/upload/admin/controller/marketplace/modification.php
@@ -194,15 +194,15 @@ class ControllerMarketplaceModification extends Controller {
 										$key = 'system/' . substr($file, strlen(DIR_SYSTEM));
 									}
 
+									// Log
+									$log[] = PHP_EOL . 'FILE: ' . $key;
+									
 									// If file contents is not already in the modification array we need to load it.
 									if (!isset($modification[$key])) {
 										$content = file_get_contents($file);
 
 										$modification[$key] = preg_replace('~\r?\n~', "\n", $content);
 										$original[$key] = preg_replace('~\r?\n~', "\n", $content);
-
-										// Log
-										$log[] = PHP_EOL . 'FILE: ' . $key;
 									}
 
 									foreach ($operations as $operation) {


### PR DESCRIPTION
Logs are written not correctly

If file was already loaded by one of modifications, another modification changing this file will never write it to log and we get strange log like this:

```
MOD: My mod for OC3
CODE: $data['add'] = $this->url->link(
LINE: 326
```

But it should be:

```
MOD: My mod for OC3

FILE: admin/controller/catalog/product.php
CODE: $data['add'] = $this->url->link(
LINE: 326
```

It's hard to debug if you have many modifications. Also I'm working on ocmod.log parser extension and this problem doesn't allow me to parse what file was changed by what modification.