### PR TITLE
Hide the discounts if the user is not logged in and config_customer_p…

### DIFF
--- a/upload/catalog/controller/product/product.php
+++ b/upload/catalog/controller/product/product.php
@@ -296,12 +296,13 @@ class ControllerProductProduct extends Controller {
 			$discounts = $this->model_catalog_product->getProductDiscounts($this->request->get['product_id']);
 
 			$data['discounts'] = array();
-
+			if($discounts && ($this->customer->isLogged() || !$this->config->get('config_customer_price'))){
 			foreach ($discounts as $discount) {
 				$data['discounts'][] = array(
 					'quantity' => $discount['quantity'],
 					'price'    => $this->currency->format($this->tax->calculate($discount['price'], $product_info['tax_class_id'], $this->config->get('config_tax')), $this->session->data['currency'])
 				);
+			}
 			}
 
 			$data['options'] = array();


### PR DESCRIPTION
I noticed discounted prices were being displayed when the option show prices when logged in is on, this small change hides the discounts if the user is not logged in and config_customer_price = 1