### PR TITLE
Filemanager "Directory does not exist" fix.

### DIFF
--- a/upload/admin/controller/common/filemanager.php
+++ b/upload/admin/controller/common/filemanager.php
@@ -197,7 +197,7 @@ class ControllerCommonFileManager extends Controller {
 		}
 
 		// Check its a directory
-		if (!is_dir($directory) || substr(str_replace('\\', '/', realpath($directory)), 0, strlen(DIR_IMAGE . 'catalog/')) != str_replace('\\', '/', DIR_IMAGE . 'catalog/')) {
+		if (!is_dir($directory) || substr(str_replace('\\', '/', realpath($directory)), 0, strlen(DIR_IMAGE . 'catalog')) != str_replace('\\', '/', DIR_IMAGE . 'catalog')) {
 			$json['error'] = $this->language->get('error_directory');
 		}
 
@@ -292,7 +292,7 @@ class ControllerCommonFileManager extends Controller {
 		}
 
 		// Check its a directory
-		if (!is_dir($directory) || substr(str_replace('\\', '/', realpath($directory)), 0, strlen(DIR_IMAGE . 'catalog/')) != str_replace('\\', '/', DIR_IMAGE . 'catalog/')) {
+		if (!is_dir($directory) || substr(str_replace('\\', '/', realpath($directory)), 0, strlen(DIR_IMAGE . 'catalog')) != str_replace('\\', '/', DIR_IMAGE . 'catalog')) {
 			$json['error'] = $this->language->get('error_directory');
 		}
 


### PR DESCRIPTION
Fixed an issue wherin uploading files in the admin using the filemanager incorrectly states "Directory does not exist" (also referred by previously closed issue #5078 and more recently #6108 )