### PR TITLE
Replacement currency->refresh function

### DIFF
--- a/upload/admin/model/localisation/currency.php
+++ b/upload/admin/model/localisation/currency.php
@@ -119,8 +119,8 @@ class ModelLocalisationCurrency extends Model {
 	    
         $zip = new \ZipArchive();
         $ecb_source_url = 'http://www.ecb.europa.eu/stats/eurofxref/eurofxref.zip';
-        $path_to_zip = DIR_STORAGE . 'download/ecb-data.zip';
-        $path_to_csv = DIR_STORAGE . 'download/eurofxref.csv';
+        $path_to_zip = DIR_DOWNLOAD . 'ecb-data.zip';
+        $path_to_csv = DIR_DOWNLOAD . 'eurofxref.csv';
 
         $compressed = file_get_contents($ecb_source_url);
         file_put_contents($path_to_zip, $compressed);
@@ -130,7 +130,7 @@ class ModelLocalisationCurrency extends Model {
         // Make sure that we downloaded a valid zip archive
         if($res === TRUE) {
 
-            $zip->extractTo(DIR_STORAGE . 'download/');
+            $zip->extractTo(DIR_DOWNLOAD);
             $zip->close();
             $data = file_get_contents($path_to_csv);
 


### PR DESCRIPTION
Fix for opencart/opencart#6179

Resolves issue I first mentioned in opencart/opencart#5911

This retrieves end of day exchange rates from the European Central Bank. It doesn't execute any more than once per day.  The currencies it updates are as follows:

EUR  /  USD  /  JPY  /  BGN  /  CZK  /  DKK  /  GBP  /  HUF  /  PLN  /  
RON  /  SEK  /  CHF  /  NOK  /  HRK  /  RUB  /  TRY  /  AUD  /  BRL / 
CAD  /  CNY  /  HKD  /  IDR  /  INR  /  KRW  /  MXN  /  MYR  /  NZD / 
PHP  /  SGD  /  THB  /  ZAR  /  ILS

Operates a little differently than the original refresh function, but from my (little bit of) testing, it looks like it should resolve the current issues people are facing.