### PR TITLE
Update session.php

### DIFF
--- a/upload/system/library/session.php
+++ b/upload/system/library/session.php
@@ -59,7 +59,7 @@ class Session {
 	
 	public function createId() {
 		if (version_compare(phpversion(), '5.5.4', '>') == true && method_exists($this->adaptor,'create_sid')) {
-			return $this->adaptor->create_sid();
+			return substr($this->adaptor->create_sid(), 0, 26);
 		} elseif (function_exists('random_bytes')) {
         	return substr(bin2hex(random_bytes(26)), 0, 26);
 		} elseif (function_exists('openssl_random_pseudo_bytes')) {


### PR DESCRIPTION
Вероятно, с какой-то версии PHP увеличилась длина генерируемого SessionHandler::create_sid 
Убил два дня разбираясь с проблемой. На чистой установке сразу не работает корзина.
Причина - длина id который передается в куках больше чем записан в базе (образается при записи в базу).
В базе session_id имеет тип VARCHAR(32)
Воспроизводится на PHP 5.5.14 MariaDB 10.0.31  Apache/2.4.23
Судя по оригинальному коду рандом обрезают до 26, так и сделал для create_sid()