### PR TITLE
Automatically determine TPL or TWIG

### DIFF
--- a/upload/system/engine/loader.php
+++ b/upload/system/engine/loader.php
@@ -120,7 +120,11 @@ final class Loader {
 		if ($result && !$result instanceof Exception) {
 			$output = $result;
 		} else {
-			$template = new Template($this->registry->get('config')->get('template_engine'));
+			if (is_file(DIR_TEMPLATE . $this->registry->get('config')->get('template_directory') . $route . '.tpl')) {
+				$template = new Template('template');
+			} else {
+				$template = new Template('twig');
+			}
 
 			foreach ($data as $key => $value) {
 				$template->set($key, $value);


### PR DESCRIPTION
Now 'template_engine' setting have no sense. Nobody will ever set it to 'template' and edit all default templates to revert them from twig.

This small fix allows to use both twig and tpl files at the same time.
If .tpl file is found it will be used, otherwise loader will try to load .twig template.
This will help developers and users move from OC 2.x tpl to OC 3.0 twig more easily. Most modules and templates will work on 3.0 with minor changes.