### PR TITLE
Small amendments for Realex / Global Payments integrations 

### DIFF
--- a/upload/admin/model/extension/payment/globalpay.php
+++ b/upload/admin/model/extension/payment/globalpay.php
@@ -66,7 +66,7 @@ class ModelExtensionPaymentGlobalpay extends Model {
 			curl_setopt($ch, CURLOPT_USERAGENT, "OpenCart " . VERSION);
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 			curl_setopt($ch, CURLOPT_POSTFIELDS, $xml);
-			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
 			$response = curl_exec ($ch);
 			curl_close ($ch);
 
@@ -131,7 +131,7 @@ class ModelExtensionPaymentGlobalpay extends Model {
 			curl_setopt($ch, CURLOPT_USERAGENT, "OpenCart " . VERSION);
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 			curl_setopt($ch, CURLOPT_POSTFIELDS, $xml);
-			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
 			$response = curl_exec ($ch);
 			curl_close ($ch);
 
@@ -199,7 +199,7 @@ class ModelExtensionPaymentGlobalpay extends Model {
 			curl_setopt($ch, CURLOPT_USERAGENT, "OpenCart " . VERSION);
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 			curl_setopt($ch, CURLOPT_POSTFIELDS, $xml);
-			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
 			$response = curl_exec ($ch);
 			curl_close ($ch);
 

--- a/upload/admin/model/extension/payment/globalpay_remote.php
+++ b/upload/admin/model/extension/payment/globalpay_remote.php
@@ -66,7 +66,7 @@ class ModelExtensionPaymentGlobalpayRemote extends Model {
 			curl_setopt($ch, CURLOPT_USERAGENT, "OpenCart " . VERSION);
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 			curl_setopt($ch, CURLOPT_POSTFIELDS, $xml);
-			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
 			$response = curl_exec ($ch);
 			curl_close ($ch);
 
@@ -130,7 +130,7 @@ class ModelExtensionPaymentGlobalpayRemote extends Model {
 			curl_setopt($ch, CURLOPT_USERAGENT, "OpenCart " . VERSION);
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 			curl_setopt($ch, CURLOPT_POSTFIELDS, $xml);
-			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
 			$response = curl_exec ($ch);
 			curl_close ($ch);
 
@@ -198,7 +198,7 @@ class ModelExtensionPaymentGlobalpayRemote extends Model {
 			curl_setopt($ch, CURLOPT_USERAGENT, "OpenCart " . VERSION);
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 			curl_setopt($ch, CURLOPT_POSTFIELDS, $xml);
-			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
 			$response = curl_exec ($ch);
 			curl_close ($ch);
 

--- a/upload/admin/model/extension/payment/realex.php
+++ b/upload/admin/model/extension/payment/realex.php
@@ -66,7 +66,7 @@ class ModelExtensionPaymentRealex extends Model {
 			curl_setopt($ch, CURLOPT_USERAGENT, "OpenCart " . VERSION);
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 			curl_setopt($ch, CURLOPT_POSTFIELDS, $xml);
-			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
 			$response = curl_exec ($ch);
 			curl_close ($ch);
 
@@ -131,7 +131,7 @@ class ModelExtensionPaymentRealex extends Model {
 			curl_setopt($ch, CURLOPT_USERAGENT, "OpenCart " . VERSION);
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 			curl_setopt($ch, CURLOPT_POSTFIELDS, $xml);
-			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
 			$response = curl_exec ($ch);
 			curl_close ($ch);
 
@@ -199,7 +199,7 @@ class ModelExtensionPaymentRealex extends Model {
 			curl_setopt($ch, CURLOPT_USERAGENT, "OpenCart " . VERSION);
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 			curl_setopt($ch, CURLOPT_POSTFIELDS, $xml);
-			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
 			$response = curl_exec ($ch);
 			curl_close ($ch);
 

--- a/upload/admin/model/extension/payment/realex_remote.php
+++ b/upload/admin/model/extension/payment/realex_remote.php
@@ -66,7 +66,7 @@ class ModelExtensionPaymentRealexRemote extends Model {
 			curl_setopt($ch, CURLOPT_USERAGENT, "OpenCart " . VERSION);
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 			curl_setopt($ch, CURLOPT_POSTFIELDS, $xml);
-			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
 			$response = curl_exec ($ch);
 			curl_close ($ch);
 
@@ -130,7 +130,7 @@ class ModelExtensionPaymentRealexRemote extends Model {
 			curl_setopt($ch, CURLOPT_USERAGENT, "OpenCart " . VERSION);
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 			curl_setopt($ch, CURLOPT_POSTFIELDS, $xml);
-			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
 			$response = curl_exec ($ch);
 			curl_close ($ch);
 
@@ -198,7 +198,7 @@ class ModelExtensionPaymentRealexRemote extends Model {
 			curl_setopt($ch, CURLOPT_USERAGENT, "OpenCart " . VERSION);
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 			curl_setopt($ch, CURLOPT_POSTFIELDS, $xml);
-			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
 			$response = curl_exec ($ch);
 			curl_close ($ch);
 

--- a/upload/catalog/model/extension/payment/globalpay_remote.php
+++ b/upload/catalog/model/extension/payment/globalpay_remote.php
@@ -64,7 +64,7 @@ class ModelExtensionPaymentGlobalpayRemote extends Model {
 		curl_setopt($ch, CURLOPT_USERAGENT, "OpenCart " . VERSION);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 		curl_setopt($ch, CURLOPT_POSTFIELDS, $xml);
-		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
 		$response = curl_exec ($ch);
 		curl_close ($ch);
 
@@ -112,7 +112,7 @@ class ModelExtensionPaymentGlobalpayRemote extends Model {
 		curl_setopt($ch, CURLOPT_USERAGENT, "OpenCart " . VERSION);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 		curl_setopt($ch, CURLOPT_POSTFIELDS, $xml);
-		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
 		$response = curl_exec ($ch);
 		curl_close ($ch);
 
@@ -151,8 +151,8 @@ class ModelExtensionPaymentGlobalpayRemote extends Model {
 				$xml .= '<type>' . $type . '</type>';
 				$xml .= '<chname>' . $name . '</chname>';
 				$xml .= '<cvn>';
-					$xml .= '<number>' . (int)$cvv . '</number>';
-					$xml .= '<presind>2</presind>';
+					$xml .= '<number>' . $cvv . '</number>';
+					$xml .= '<presind>1</presind>';
 				$xml .= '</cvn>';
 				if (!empty($issue)) {
 					$xml .= '<issueno>' . (int)$issue . '</issueno>';
@@ -226,7 +226,7 @@ class ModelExtensionPaymentGlobalpayRemote extends Model {
 		curl_setopt($ch, CURLOPT_USERAGENT, "OpenCart " . VERSION);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 		curl_setopt($ch, CURLOPT_POSTFIELDS, $xml);
-		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
 		$response = curl_exec ($ch);
 		curl_close ($ch);
 

--- a/upload/catalog/model/extension/payment/realex_remote.php
+++ b/upload/catalog/model/extension/payment/realex_remote.php
@@ -64,7 +64,7 @@ class ModelExtensionPaymentRealexRemote extends Model {
 		curl_setopt($ch, CURLOPT_USERAGENT, "OpenCart " . VERSION);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 		curl_setopt($ch, CURLOPT_POSTFIELDS, $xml);
-		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
 		$response = curl_exec ($ch);
 		curl_close ($ch);
 
@@ -112,7 +112,7 @@ class ModelExtensionPaymentRealexRemote extends Model {
 		curl_setopt($ch, CURLOPT_USERAGENT, "OpenCart " . VERSION);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 		curl_setopt($ch, CURLOPT_POSTFIELDS, $xml);
-		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
 		$response = curl_exec ($ch);
 		curl_close ($ch);
 
@@ -151,8 +151,8 @@ class ModelExtensionPaymentRealexRemote extends Model {
 				$xml .= '<type>' . $type . '</type>';
 				$xml .= '<chname>' . $name . '</chname>';
 				$xml .= '<cvn>';
-					$xml .= '<number>' . (int)$cvv . '</number>';
-					$xml .= '<presind>2</presind>';
+					$xml .= '<number>' . $cvv . '</number>';
+					$xml .= '<presind>1</presind>';
 				$xml .= '</cvn>';
 				if (!empty($issue)) {
 					$xml .= '<issueno>' . (int)$issue . '</issueno>';
@@ -226,7 +226,7 @@ class ModelExtensionPaymentRealexRemote extends Model {
 		curl_setopt($ch, CURLOPT_USERAGENT, "OpenCart " . VERSION);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 		curl_setopt($ch, CURLOPT_POSTFIELDS, $xml);
-		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
 		$response = curl_exec ($ch);
 		curl_close ($ch);
 


### PR DESCRIPTION
Amended cURL options to always verify peer, fixed security code presence indicator and treat the code itself as a string instead of an int.