### PR TITLE
Cart Library getProducts function executing database query multiple time

### DIFF
--- a/upload/system/library/cart/cart.php
+++ b/upload/system/library/cart/cart.php
@@ -278,19 +278,27 @@ class Cart {
 		} else {
 			$this->db->query("UPDATE " . DB_PREFIX . "cart SET quantity = (quantity + " . (int)$quantity . ") WHERE api_id = '" . (isset($this->session->data['api_id']) ? (int)$this->session->data['api_id'] : 0) . "' AND customer_id = '" . (int)$this->customer->getId() . "' AND session_id = '" . $this->db->escape($this->session->getId()) . "' AND product_id = '" . (int)$product_id . "' AND recurring_id = '" . (int)$recurring_id . "' AND `option` = '" . $this->db->escape(json_encode($option)) . "'");
 		}
+
+                $this->data = array();
 	}
 
 	public function update($cart_id, $quantity) {
 		$this->db->query("UPDATE " . DB_PREFIX . "cart SET quantity = '" . (int)$quantity . "' WHERE cart_id = '" . (int)$cart_id . "' AND api_id = '" . (isset($this->session->data['api_id']) ? (int)$this->session->data['api_id'] : 0) . "' AND customer_id = '" . (int)$this->customer->getId() . "' AND session_id = '" . $this->db->escape($this->session->getId()) . "'");
-	}
+
+                $this->data = array();
+        }
 
 	public function remove($cart_id) {
 		$this->db->query("DELETE FROM " . DB_PREFIX . "cart WHERE cart_id = '" . (int)$cart_id . "' AND api_id = '" . (isset($this->session->data['api_id']) ? (int)$this->session->data['api_id'] : 0) . "' AND customer_id = '" . (int)$this->customer->getId() . "' AND session_id = '" . $this->db->escape($this->session->getId()) . "'");
-	}
+
+                $this->data = array();
+        }
 
 	public function clear() {
 		$this->db->query("DELETE FROM " . DB_PREFIX . "cart WHERE api_id = '" . (isset($this->session->data['api_id']) ? (int)$this->session->data['api_id'] : 0) . "' AND customer_id = '" . (int)$this->customer->getId() . "' AND session_id = '" . $this->db->escape($this->session->getId()) . "'");
-	}
+
+                $this->data = array();
+        }
 
 	public function getRecurringProducts() {
 		$product_data = array();

--- a/upload/system/library/cart/cart.php
+++ b/upload/system/library/cart/cart.php
@@ -31,242 +31,243 @@ class Cart {
 	}
 
 	public function getProducts() {
-		$product_data = array();
+		if (!$this->data) {
 
-		$cart_query = $this->db->query("SELECT * FROM " . DB_PREFIX . "cart WHERE api_id = '" . (isset($this->session->data['api_id']) ? (int)$this->session->data['api_id'] : 0) . "' AND customer_id = '" . (int)$this->customer->getId() . "' AND session_id = '" . $this->db->escape($this->session->getId()) . "'");
+                    $cart_query = $this->db->query("SELECT * FROM " . DB_PREFIX . "cart WHERE api_id = '" . (isset($this->session->data['api_id']) ? (int)$this->session->data['api_id'] : 0) . "' AND customer_id = '" . (int)$this->customer->getId() . "' AND session_id = '" . $this->db->escape($this->session->getId()) . "'");
 
-		foreach ($cart_query->rows as $cart) {
-			$stock = true;
+                    foreach ($cart_query->rows as $cart) {
+                            $stock = true;
 
-			$product_query = $this->db->query("SELECT * FROM " . DB_PREFIX . "product_to_store p2s LEFT JOIN " . DB_PREFIX . "product p ON (p2s.product_id = p.product_id) LEFT JOIN " . DB_PREFIX . "product_description pd ON (p.product_id = pd.product_id) WHERE p2s.store_id = '" . (int)$this->config->get('config_store_id') . "' AND p2s.product_id = '" . (int)$cart['product_id'] . "' AND pd.language_id = '" . (int)$this->config->get('config_language_id') . "' AND p.date_available <= NOW() AND p.status = '1'");
+                            $product_query = $this->db->query("SELECT * FROM " . DB_PREFIX . "product_to_store p2s LEFT JOIN " . DB_PREFIX . "product p ON (p2s.product_id = p.product_id) LEFT JOIN " . DB_PREFIX . "product_description pd ON (p.product_id = pd.product_id) WHERE p2s.store_id = '" . (int)$this->config->get('config_store_id') . "' AND p2s.product_id = '" . (int)$cart['product_id'] . "' AND pd.language_id = '" . (int)$this->config->get('config_language_id') . "' AND p.date_available <= NOW() AND p.status = '1'");
 
-			if ($product_query->num_rows && ($cart['quantity'] > 0)) {
-				$option_price = 0;
-				$option_points = 0;
-				$option_weight = 0;
+                            if ($product_query->num_rows && ($cart['quantity'] > 0)) {
+                                    $option_price = 0;
+                                    $option_points = 0;
+                                    $option_weight = 0;
 
-				$option_data = array();
+                                    $option_data = array();
 
-				foreach (json_decode($cart['option']) as $product_option_id => $value) {
-					$option_query = $this->db->query("SELECT po.product_option_id, po.option_id, od.name, o.type FROM " . DB_PREFIX . "product_option po LEFT JOIN `" . DB_PREFIX . "option` o ON (po.option_id = o.option_id) LEFT JOIN " . DB_PREFIX . "option_description od ON (o.option_id = od.option_id) WHERE po.product_option_id = '" . (int)$product_option_id . "' AND po.product_id = '" . (int)$cart['product_id'] . "' AND od.language_id = '" . (int)$this->config->get('config_language_id') . "'");
+                                    foreach (json_decode($cart['option']) as $product_option_id => $value) {
+                                            $option_query = $this->db->query("SELECT po.product_option_id, po.option_id, od.name, o.type FROM " . DB_PREFIX . "product_option po LEFT JOIN `" . DB_PREFIX . "option` o ON (po.option_id = o.option_id) LEFT JOIN " . DB_PREFIX . "option_description od ON (o.option_id = od.option_id) WHERE po.product_option_id = '" . (int)$product_option_id . "' AND po.product_id = '" . (int)$cart['product_id'] . "' AND od.language_id = '" . (int)$this->config->get('config_language_id') . "'");
 
-					if ($option_query->num_rows) {
-						if ($option_query->row['type'] == 'select' || $option_query->row['type'] == 'radio') {
-							$option_value_query = $this->db->query("SELECT pov.option_value_id, ovd.name, pov.quantity, pov.subtract, pov.price, pov.price_prefix, pov.points, pov.points_prefix, pov.weight, pov.weight_prefix FROM " . DB_PREFIX . "product_option_value pov LEFT JOIN " . DB_PREFIX . "option_value ov ON (pov.option_value_id = ov.option_value_id) LEFT JOIN " . DB_PREFIX . "option_value_description ovd ON (ov.option_value_id = ovd.option_value_id) WHERE pov.product_option_value_id = '" . (int)$value . "' AND pov.product_option_id = '" . (int)$product_option_id . "' AND ovd.language_id = '" . (int)$this->config->get('config_language_id') . "'");
+                                            if ($option_query->num_rows) {
+                                                    if ($option_query->row['type'] == 'select' || $option_query->row['type'] == 'radio') {
+                                                            $option_value_query = $this->db->query("SELECT pov.option_value_id, ovd.name, pov.quantity, pov.subtract, pov.price, pov.price_prefix, pov.points, pov.points_prefix, pov.weight, pov.weight_prefix FROM " . DB_PREFIX . "product_option_value pov LEFT JOIN " . DB_PREFIX . "option_value ov ON (pov.option_value_id = ov.option_value_id) LEFT JOIN " . DB_PREFIX . "option_value_description ovd ON (ov.option_value_id = ovd.option_value_id) WHERE pov.product_option_value_id = '" . (int)$value . "' AND pov.product_option_id = '" . (int)$product_option_id . "' AND ovd.language_id = '" . (int)$this->config->get('config_language_id') . "'");
 
-							if ($option_value_query->num_rows) {
-								if ($option_value_query->row['price_prefix'] == '+') {
-									$option_price += $option_value_query->row['price'];
-								} elseif ($option_value_query->row['price_prefix'] == '-') {
-									$option_price -= $option_value_query->row['price'];
-								}
+                                                            if ($option_value_query->num_rows) {
+                                                                    if ($option_value_query->row['price_prefix'] == '+') {
+                                                                            $option_price += $option_value_query->row['price'];
+                                                                    } elseif ($option_value_query->row['price_prefix'] == '-') {
+                                                                            $option_price -= $option_value_query->row['price'];
+                                                                    }
 
-								if ($option_value_query->row['points_prefix'] == '+') {
-									$option_points += $option_value_query->row['points'];
-								} elseif ($option_value_query->row['points_prefix'] == '-') {
-									$option_points -= $option_value_query->row['points'];
-								}
+                                                                    if ($option_value_query->row['points_prefix'] == '+') {
+                                                                            $option_points += $option_value_query->row['points'];
+                                                                    } elseif ($option_value_query->row['points_prefix'] == '-') {
+                                                                            $option_points -= $option_value_query->row['points'];
+                                                                    }
 
-								if ($option_value_query->row['weight_prefix'] == '+') {
-									$option_weight += $option_value_query->row['weight'];
-								} elseif ($option_value_query->row['weight_prefix'] == '-') {
-									$option_weight -= $option_value_query->row['weight'];
-								}
+                                                                    if ($option_value_query->row['weight_prefix'] == '+') {
+                                                                            $option_weight += $option_value_query->row['weight'];
+                                                                    } elseif ($option_value_query->row['weight_prefix'] == '-') {
+                                                                            $option_weight -= $option_value_query->row['weight'];
+                                                                    }
 
-								if ($option_value_query->row['subtract'] && (!$option_value_query->row['quantity'] || ($option_value_query->row['quantity'] < $cart['quantity']))) {
-									$stock = false;
-								}
+                                                                    if ($option_value_query->row['subtract'] && (!$option_value_query->row['quantity'] || ($option_value_query->row['quantity'] < $cart['quantity']))) {
+                                                                            $stock = false;
+                                                                    }
 
-								$option_data[] = array(
-									'product_option_id'       => $product_option_id,
-									'product_option_value_id' => $value,
-									'option_id'               => $option_query->row['option_id'],
-									'option_value_id'         => $option_value_query->row['option_value_id'],
-									'name'                    => $option_query->row['name'],
-									'value'                   => $option_value_query->row['name'],
-									'type'                    => $option_query->row['type'],
-									'quantity'                => $option_value_query->row['quantity'],
-									'subtract'                => $option_value_query->row['subtract'],
-									'price'                   => $option_value_query->row['price'],
-									'price_prefix'            => $option_value_query->row['price_prefix'],
-									'points'                  => $option_value_query->row['points'],
-									'points_prefix'           => $option_value_query->row['points_prefix'],
-									'weight'                  => $option_value_query->row['weight'],
-									'weight_prefix'           => $option_value_query->row['weight_prefix']
-								);
-							}
-						} elseif ($option_query->row['type'] == 'checkbox' && is_array($value)) {
-							foreach ($value as $product_option_value_id) {
-								$option_value_query = $this->db->query("SELECT pov.option_value_id, pov.quantity, pov.subtract, pov.price, pov.price_prefix, pov.points, pov.points_prefix, pov.weight, pov.weight_prefix, ovd.name FROM " . DB_PREFIX . "product_option_value pov LEFT JOIN " . DB_PREFIX . "option_value_description ovd ON (pov.option_value_id = ovd.option_value_id) WHERE pov.product_option_value_id = '" . (int)$product_option_value_id . "' AND pov.product_option_id = '" . (int)$product_option_id . "' AND ovd.language_id = '" . (int)$this->config->get('config_language_id') . "'");
+                                                                    $option_data[] = array(
+                                                                            'product_option_id'       => $product_option_id,
+                                                                            'product_option_value_id' => $value,
+                                                                            'option_id'               => $option_query->row['option_id'],
+                                                                            'option_value_id'         => $option_value_query->row['option_value_id'],
+                                                                            'name'                    => $option_query->row['name'],
+                                                                            'value'                   => $option_value_query->row['name'],
+                                                                            'type'                    => $option_query->row['type'],
+                                                                            'quantity'                => $option_value_query->row['quantity'],
+                                                                            'subtract'                => $option_value_query->row['subtract'],
+                                                                            'price'                   => $option_value_query->row['price'],
+                                                                            'price_prefix'            => $option_value_query->row['price_prefix'],
+                                                                            'points'                  => $option_value_query->row['points'],
+                                                                            'points_prefix'           => $option_value_query->row['points_prefix'],
+                                                                            'weight'                  => $option_value_query->row['weight'],
+                                                                            'weight_prefix'           => $option_value_query->row['weight_prefix']
+                                                                    );
+                                                            }
+                                                    } elseif ($option_query->row['type'] == 'checkbox' && is_array($value)) {
+                                                            foreach ($value as $product_option_value_id) {
+                                                                    $option_value_query = $this->db->query("SELECT pov.option_value_id, pov.quantity, pov.subtract, pov.price, pov.price_prefix, pov.points, pov.points_prefix, pov.weight, pov.weight_prefix, ovd.name FROM " . DB_PREFIX . "product_option_value pov LEFT JOIN " . DB_PREFIX . "option_value_description ovd ON (pov.option_value_id = ovd.option_value_id) WHERE pov.product_option_value_id = '" . (int)$product_option_value_id . "' AND pov.product_option_id = '" . (int)$product_option_id . "' AND ovd.language_id = '" . (int)$this->config->get('config_language_id') . "'");
 
-								if ($option_value_query->num_rows) {
-									if ($option_value_query->row['price_prefix'] == '+') {
-										$option_price += $option_value_query->row['price'];
-									} elseif ($option_value_query->row['price_prefix'] == '-') {
-										$option_price -= $option_value_query->row['price'];
-									}
+                                                                    if ($option_value_query->num_rows) {
+                                                                            if ($option_value_query->row['price_prefix'] == '+') {
+                                                                                    $option_price += $option_value_query->row['price'];
+                                                                            } elseif ($option_value_query->row['price_prefix'] == '-') {
+                                                                                    $option_price -= $option_value_query->row['price'];
+                                                                            }
 
-									if ($option_value_query->row['points_prefix'] == '+') {
-										$option_points += $option_value_query->row['points'];
-									} elseif ($option_value_query->row['points_prefix'] == '-') {
-										$option_points -= $option_value_query->row['points'];
-									}
+                                                                            if ($option_value_query->row['points_prefix'] == '+') {
+                                                                                    $option_points += $option_value_query->row['points'];
+                                                                            } elseif ($option_value_query->row['points_prefix'] == '-') {
+                                                                                    $option_points -= $option_value_query->row['points'];
+                                                                            }
 
-									if ($option_value_query->row['weight_prefix'] == '+') {
-										$option_weight += $option_value_query->row['weight'];
-									} elseif ($option_value_query->row['weight_prefix'] == '-') {
-										$option_weight -= $option_value_query->row['weight'];
-									}
+                                                                            if ($option_value_query->row['weight_prefix'] == '+') {
+                                                                                    $option_weight += $option_value_query->row['weight'];
+                                                                            } elseif ($option_value_query->row['weight_prefix'] == '-') {
+                                                                                    $option_weight -= $option_value_query->row['weight'];
+                                                                            }
 
-									if ($option_value_query->row['subtract'] && (!$option_value_query->row['quantity'] || ($option_value_query->row['quantity'] < $cart['quantity']))) {
-										$stock = false;
-									}
+                                                                            if ($option_value_query->row['subtract'] && (!$option_value_query->row['quantity'] || ($option_value_query->row['quantity'] < $cart['quantity']))) {
+                                                                                    $stock = false;
+                                                                            }
 
-									$option_data[] = array(
-										'product_option_id'       => $product_option_id,
-										'product_option_value_id' => $product_option_value_id,
-										'option_id'               => $option_query->row['option_id'],
-										'option_value_id'         => $option_value_query->row['option_value_id'],
-										'name'                    => $option_query->row['name'],
-										'value'                   => $option_value_query->row['name'],
-										'type'                    => $option_query->row['type'],
-										'quantity'                => $option_value_query->row['quantity'],
-										'subtract'                => $option_value_query->row['subtract'],
-										'price'                   => $option_value_query->row['price'],
-										'price_prefix'            => $option_value_query->row['price_prefix'],
-										'points'                  => $option_value_query->row['points'],
-										'points_prefix'           => $option_value_query->row['points_prefix'],
-										'weight'                  => $option_value_query->row['weight'],
-										'weight_prefix'           => $option_value_query->row['weight_prefix']
-									);
-								}
-							}
-						} elseif ($option_query->row['type'] == 'text' || $option_query->row['type'] == 'textarea' || $option_query->row['type'] == 'file' || $option_query->row['type'] == 'date' || $option_query->row['type'] == 'datetime' || $option_query->row['type'] == 'time') {
-							$option_data[] = array(
-								'product_option_id'       => $product_option_id,
-								'product_option_value_id' => '',
-								'option_id'               => $option_query->row['option_id'],
-								'option_value_id'         => '',
-								'name'                    => $option_query->row['name'],
-								'value'                   => $value,
-								'type'                    => $option_query->row['type'],
-								'quantity'                => '',
-								'subtract'                => '',
-								'price'                   => '',
-								'price_prefix'            => '',
-								'points'                  => '',
-								'points_prefix'           => '',
-								'weight'                  => '',
-								'weight_prefix'           => ''
-							);
-						}
-					}
-				}
+                                                                            $option_data[] = array(
+                                                                                    'product_option_id'       => $product_option_id,
+                                                                                    'product_option_value_id' => $product_option_value_id,
+                                                                                    'option_id'               => $option_query->row['option_id'],
+                                                                                    'option_value_id'         => $option_value_query->row['option_value_id'],
+                                                                                    'name'                    => $option_query->row['name'],
+                                                                                    'value'                   => $option_value_query->row['name'],
+                                                                                    'type'                    => $option_query->row['type'],
+                                                                                    'quantity'                => $option_value_query->row['quantity'],
+                                                                                    'subtract'                => $option_value_query->row['subtract'],
+                                                                                    'price'                   => $option_value_query->row['price'],
+                                                                                    'price_prefix'            => $option_value_query->row['price_prefix'],
+                                                                                    'points'                  => $option_value_query->row['points'],
+                                                                                    'points_prefix'           => $option_value_query->row['points_prefix'],
+                                                                                    'weight'                  => $option_value_query->row['weight'],
+                                                                                    'weight_prefix'           => $option_value_query->row['weight_prefix']
+                                                                            );
+                                                                    }
+                                                            }
+                                                    } elseif ($option_query->row['type'] == 'text' || $option_query->row['type'] == 'textarea' || $option_query->row['type'] == 'file' || $option_query->row['type'] == 'date' || $option_query->row['type'] == 'datetime' || $option_query->row['type'] == 'time') {
+                                                            $option_data[] = array(
+                                                                    'product_option_id'       => $product_option_id,
+                                                                    'product_option_value_id' => '',
+                                                                    'option_id'               => $option_query->row['option_id'],
+                                                                    'option_value_id'         => '',
+                                                                    'name'                    => $option_query->row['name'],
+                                                                    'value'                   => $value,
+                                                                    'type'                    => $option_query->row['type'],
+                                                                    'quantity'                => '',
+                                                                    'subtract'                => '',
+                                                                    'price'                   => '',
+                                                                    'price_prefix'            => '',
+                                                                    'points'                  => '',
+                                                                    'points_prefix'           => '',
+                                                                    'weight'                  => '',
+                                                                    'weight_prefix'           => ''
+                                                            );
+                                                    }
+                                            }
+                                    }
 
-				$price = $product_query->row['price'];
+                                    $price = $product_query->row['price'];
 
-				// Product Discounts
-				$discount_quantity = 0;
+                                    // Product Discounts
+                                    $discount_quantity = 0;
 
-				foreach ($cart_query->rows as $cart_2) {
-					if ($cart_2['product_id'] == $cart['product_id']) {
-						$discount_quantity += $cart_2['quantity'];
-					}
-				}
+                                    foreach ($cart_query->rows as $cart_2) {
+                                            if ($cart_2['product_id'] == $cart['product_id']) {
+                                                    $discount_quantity += $cart_2['quantity'];
+                                            }
+                                    }
 
-				$product_discount_query = $this->db->query("SELECT price FROM " . DB_PREFIX . "product_discount WHERE product_id = '" . (int)$cart['product_id'] . "' AND customer_group_id = '" . (int)$this->config->get('config_customer_group_id') . "' AND quantity <= '" . (int)$discount_quantity . "' AND ((date_start = '0000-00-00' OR date_start < NOW()) AND (date_end = '0000-00-00' OR date_end > NOW())) ORDER BY quantity DESC, priority ASC, price ASC LIMIT 1");
+                                    $product_discount_query = $this->db->query("SELECT price FROM " . DB_PREFIX . "product_discount WHERE product_id = '" . (int)$cart['product_id'] . "' AND customer_group_id = '" . (int)$this->config->get('config_customer_group_id') . "' AND quantity <= '" . (int)$discount_quantity . "' AND ((date_start = '0000-00-00' OR date_start < NOW()) AND (date_end = '0000-00-00' OR date_end > NOW())) ORDER BY quantity DESC, priority ASC, price ASC LIMIT 1");
 
-				if ($product_discount_query->num_rows) {
-					$price = $product_discount_query->row['price'];
-				}
+                                    if ($product_discount_query->num_rows) {
+                                            $price = $product_discount_query->row['price'];
+                                    }
 
-				// Product Specials
-				$product_special_query = $this->db->query("SELECT price FROM " . DB_PREFIX . "product_special WHERE product_id = '" . (int)$cart['product_id'] . "' AND customer_group_id = '" . (int)$this->config->get('config_customer_group_id') . "' AND ((date_start = '0000-00-00' OR date_start < NOW()) AND (date_end = '0000-00-00' OR date_end > NOW())) ORDER BY priority ASC, price ASC LIMIT 1");
+                                    // Product Specials
+                                    $product_special_query = $this->db->query("SELECT price FROM " . DB_PREFIX . "product_special WHERE product_id = '" . (int)$cart['product_id'] . "' AND customer_group_id = '" . (int)$this->config->get('config_customer_group_id') . "' AND ((date_start = '0000-00-00' OR date_start < NOW()) AND (date_end = '0000-00-00' OR date_end > NOW())) ORDER BY priority ASC, price ASC LIMIT 1");
 
-				if ($product_special_query->num_rows) {
-					$price = $product_special_query->row['price'];
-				}
+                                    if ($product_special_query->num_rows) {
+                                            $price = $product_special_query->row['price'];
+                                    }
 
-				// Reward Points
-				$product_reward_query = $this->db->query("SELECT points FROM " . DB_PREFIX . "product_reward WHERE product_id = '" . (int)$cart['product_id'] . "' AND customer_group_id = '" . (int)$this->config->get('config_customer_group_id') . "'");
+                                    // Reward Points
+                                    $product_reward_query = $this->db->query("SELECT points FROM " . DB_PREFIX . "product_reward WHERE product_id = '" . (int)$cart['product_id'] . "' AND customer_group_id = '" . (int)$this->config->get('config_customer_group_id') . "'");
 
-				if ($product_reward_query->num_rows) {
-					$reward = $product_reward_query->row['points'];
-				} else {
-					$reward = 0;
-				}
+                                    if ($product_reward_query->num_rows) {
+                                            $reward = $product_reward_query->row['points'];
+                                    } else {
+                                            $reward = 0;
+                                    }
 
-				// Downloads
-				$download_data = array();
+                                    // Downloads
+                                    $download_data = array();
 
-				$download_query = $this->db->query("SELECT * FROM " . DB_PREFIX . "product_to_download p2d LEFT JOIN " . DB_PREFIX . "download d ON (p2d.download_id = d.download_id) LEFT JOIN " . DB_PREFIX . "download_description dd ON (d.download_id = dd.download_id) WHERE p2d.product_id = '" . (int)$cart['product_id'] . "' AND dd.language_id = '" . (int)$this->config->get('config_language_id') . "'");
+                                    $download_query = $this->db->query("SELECT * FROM " . DB_PREFIX . "product_to_download p2d LEFT JOIN " . DB_PREFIX . "download d ON (p2d.download_id = d.download_id) LEFT JOIN " . DB_PREFIX . "download_description dd ON (d.download_id = dd.download_id) WHERE p2d.product_id = '" . (int)$cart['product_id'] . "' AND dd.language_id = '" . (int)$this->config->get('config_language_id') . "'");
 
-				foreach ($download_query->rows as $download) {
-					$download_data[] = array(
-						'download_id' => $download['download_id'],
-						'name'        => $download['name'],
-						'filename'    => $download['filename'],
-						'mask'        => $download['mask']
-					);
-				}
+                                    foreach ($download_query->rows as $download) {
+                                            $download_data[] = array(
+                                                    'download_id' => $download['download_id'],
+                                                    'name'        => $download['name'],
+                                                    'filename'    => $download['filename'],
+                                                    'mask'        => $download['mask']
+                                            );
+                                    }
 
-				// Stock
-				if (!$product_query->row['quantity'] || ($product_query->row['quantity'] < $cart['quantity'])) {
-					$stock = false;
-				}
+                                    // Stock
+                                    if (!$product_query->row['quantity'] || ($product_query->row['quantity'] < $cart['quantity'])) {
+                                            $stock = false;
+                                    }
 
-				$recurring_query = $this->db->query("SELECT * FROM " . DB_PREFIX . "recurring r LEFT JOIN " . DB_PREFIX . "product_recurring pr ON (r.recurring_id = pr.recurring_id) LEFT JOIN " . DB_PREFIX . "recurring_description rd ON (r.recurring_id = rd.recurring_id) WHERE r.recurring_id = '" . (int)$cart['recurring_id'] . "' AND pr.product_id = '" . (int)$cart['product_id'] . "' AND rd.language_id = " . (int)$this->config->get('config_language_id') . " AND r.status = 1 AND pr.customer_group_id = '" . (int)$this->config->get('config_customer_group_id') . "'");
+                                    $recurring_query = $this->db->query("SELECT * FROM " . DB_PREFIX . "recurring r LEFT JOIN " . DB_PREFIX . "product_recurring pr ON (r.recurring_id = pr.recurring_id) LEFT JOIN " . DB_PREFIX . "recurring_description rd ON (r.recurring_id = rd.recurring_id) WHERE r.recurring_id = '" . (int)$cart['recurring_id'] . "' AND pr.product_id = '" . (int)$cart['product_id'] . "' AND rd.language_id = " . (int)$this->config->get('config_language_id') . " AND r.status = 1 AND pr.customer_group_id = '" . (int)$this->config->get('config_customer_group_id') . "'");
 
-				if ($recurring_query->num_rows) {
-					$recurring = array(
-						'recurring_id'    => $cart['recurring_id'],
-						'name'            => $recurring_query->row['name'],
-						'frequency'       => $recurring_query->row['frequency'],
-						'price'           => $recurring_query->row['price'],
-						'cycle'           => $recurring_query->row['cycle'],
-						'duration'        => $recurring_query->row['duration'],
-						'trial'           => $recurring_query->row['trial_status'],
-						'trial_frequency' => $recurring_query->row['trial_frequency'],
-						'trial_price'     => $recurring_query->row['trial_price'],
-						'trial_cycle'     => $recurring_query->row['trial_cycle'],
-						'trial_duration'  => $recurring_query->row['trial_duration']
-					);
-				} else {
-					$recurring = false;
-				}
+                                    if ($recurring_query->num_rows) {
+                                            $recurring = array(
+                                                    'recurring_id'    => $cart['recurring_id'],
+                                                    'name'            => $recurring_query->row['name'],
+                                                    'frequency'       => $recurring_query->row['frequency'],
+                                                    'price'           => $recurring_query->row['price'],
+                                                    'cycle'           => $recurring_query->row['cycle'],
+                                                    'duration'        => $recurring_query->row['duration'],
+                                                    'trial'           => $recurring_query->row['trial_status'],
+                                                    'trial_frequency' => $recurring_query->row['trial_frequency'],
+                                                    'trial_price'     => $recurring_query->row['trial_price'],
+                                                    'trial_cycle'     => $recurring_query->row['trial_cycle'],
+                                                    'trial_duration'  => $recurring_query->row['trial_duration']
+                                            );
+                                    } else {
+                                            $recurring = false;
+                                    }
 
-				$product_data[] = array(
-					'cart_id'         => $cart['cart_id'],
-					'product_id'      => $product_query->row['product_id'],
-					'name'            => $product_query->row['name'],
-					'model'           => $product_query->row['model'],
-					'shipping'        => $product_query->row['shipping'],
-					'image'           => $product_query->row['image'],
-					'option'          => $option_data,
-					'download'        => $download_data,
-					'quantity'        => $cart['quantity'],
-					'minimum'         => $product_query->row['minimum'],
-					'subtract'        => $product_query->row['subtract'],
-					'stock'           => $stock,
-					'price'           => ($price + $option_price),
-					'total'           => ($price + $option_price) * $cart['quantity'],
-					'reward'          => $reward * $cart['quantity'],
-					'points'          => ($product_query->row['points'] ? ($product_query->row['points'] + $option_points) * $cart['quantity'] : 0),
-					'tax_class_id'    => $product_query->row['tax_class_id'],
-					'weight'          => ($product_query->row['weight'] + $option_weight) * $cart['quantity'],
-					'weight_class_id' => $product_query->row['weight_class_id'],
-					'length'          => $product_query->row['length'],
-					'width'           => $product_query->row['width'],
-					'height'          => $product_query->row['height'],
-					'length_class_id' => $product_query->row['length_class_id'],
-					'recurring'       => $recurring
-				);
-			} else {
-				$this->remove($cart['cart_id']);
-			}
-		}
+                                    $this->data[] = array(
+                                            'cart_id'         => $cart['cart_id'],
+                                            'product_id'      => $product_query->row['product_id'],
+                                            'name'            => $product_query->row['name'],
+                                            'model'           => $product_query->row['model'],
+                                            'shipping'        => $product_query->row['shipping'],
+                                            'image'           => $product_query->row['image'],
+                                            'option'          => $option_data,
+                                            'download'        => $download_data,
+                                            'quantity'        => $cart['quantity'],
+                                            'minimum'         => $product_query->row['minimum'],
+                                            'subtract'        => $product_query->row['subtract'],
+                                            'stock'           => $stock,
+                                            'price'           => ($price + $option_price),
+                                            'total'           => ($price + $option_price) * $cart['quantity'],
+                                            'reward'          => $reward * $cart['quantity'],
+                                            'points'          => ($product_query->row['points'] ? ($product_query->row['points'] + $option_points) * $cart['quantity'] : 0),
+                                            'tax_class_id'    => $product_query->row['tax_class_id'],
+                                            'weight'          => ($product_query->row['weight'] + $option_weight) * $cart['quantity'],
+                                            'weight_class_id' => $product_query->row['weight_class_id'],
+                                            'length'          => $product_query->row['length'],
+                                            'width'           => $product_query->row['width'],
+                                            'height'          => $product_query->row['height'],
+                                            'length_class_id' => $product_query->row['length_class_id'],
+                                            'recurring'       => $recurring
+                                    );
+                            } else {
+                                    $this->remove($cart['cart_id']);
+                            }
+                    }
+                }
 
-		return $product_data;
+		return $this->data;
 	}
 
 	public function add($product_id, $quantity = 1, $option = array(), $recurring_id = 0) {


### PR DESCRIPTION
The cart library is executing the same query multiple time.
if you check the 
`public function getProducts() {`

you will find that the function is called multiple time and each time is is executing database queries. The previous version of opencart have this covered and didn't have this issue. The previous version(1.5.6) set the $data variable and then use that variable for later function call. 

I think we should do the same for new version.

