### PR TITLE
Fix preg_match in step 3

### DIFF
--- a/upload/install/controller/install/step_3.php
+++ b/upload/install/controller/install/step_3.php
@@ -265,9 +265,9 @@ class ControllerInstallStep3 extends Controller {
 
 		if (!$this->request->post['db_port']) {
 			$this->error['db_port'] = $this->language->get('error_db_port');
-		}		
+		}
 
-		if ($this->request->post['db_prefix'] && preg_match('/^[a-z][a-z0-9]*_$/', $this->request->post['db_prefix'])) {
+        if ($this->request->post['db_prefix'] && preg_match('/[^a-z0-9_]/', $this->request->post['db_prefix'])) {
 			$this->error['db_prefix'] = $this->language->get('error_db_prefix');
 		}
 


### PR DESCRIPTION
Revert change made in opencart/opencart#6182

I noticed this in: opencart/opencart#6230.

The preg_match was wrong, it was preventing underscores from being used in the db_prefix.