### PR TITLE
Fix issue with random string breaking the request data array

### DIFF
--- a/upload/catalog/controller/extension/payment/divido.php
+++ b/upload/catalog/controller/extension/payment/divido.php
@@ -207,8 +207,7 @@ class ControllerExtensionPaymentDivido extends Controller {
 		$hash = $this->model_extension_payment_divido->hashOrderId($order_id, $salt);
 
 		$request_data = array(
-			'merchant' => $api_key, mexico44
-
+			'merchant' => $api_key,
 			'deposit'  => $deposit_amount,
 			'finance'  => $finance,
 			'country'  => $country,


### PR DESCRIPTION
Removed the string mexico44 from the request data array. It was causing a PHP Parse error
