### PR TITLE
don't show disabled custom field on order form page

### DIFF
--- a/upload/admin/controller/sale/order.php
+++ b/upload/admin/controller/sale/order.php
@@ -641,6 +641,7 @@ class ControllerSaleOrder extends Controller {
 		$data['custom_fields'] = array();
 
 		$filter_data = array(
+			'filter_status'  => 1,
 			'sort'  => 'cf.sort_order',
 			'order' => 'ASC'
 		);

--- a/upload/admin/model/customer/custom_field.php
+++ b/upload/admin/model/customer/custom_field.php
@@ -96,6 +96,10 @@ class ModelCustomerCustomField extends Model {
 			$sql .= " AND cfd.name LIKE '" . $this->db->escape((string)$data['filter_name']) . "%'";
 		}
 
+		if (isset($data['filter_status'])) {
+			$sql .= " AND cf.status = '" . (int)$data['filter_status'] . "'";
+		}
+
 		if (!empty($data['filter_customer_group_id'])) {
 			$sql .= " AND cfcg.customer_group_id = '" . (int)$data['filter_customer_group_id'] . "'";
 		}


### PR DESCRIPTION
If custom field is disabled it should not be shown on order form page. Currently the method get custom fields gets all custom fields even if status is disabled. So have added a filter code to filter by status. And then sending filter status as 1 for order form. So only enabled status would be shown on order form page.