### PR TITLE
Fix event path for add affiliate

### DIFF
--- a/upload/install/opencart.sql
+++ b/upload/install/opencart.sql
@@ -677,9 +677,9 @@ INSERT INTO `oc_event` (`event_id`, `code`, `trigger`, `action`, `status`) VALUE
 INSERT INTO `oc_event` (`event_id`, `code`, `trigger`, `action`, `status`) VALUES
 (17, 'mail_customer_alert', 'catalog/model/account/customer/addCustomer/after', 'mail/register/alert', 1);
 INSERT INTO `oc_event` (`event_id`, `code`, `trigger`, `action`, `status`) VALUES
-(18, 'mail_affiliate_add', 'catalog/model/account/customer/addAffiliate/after', 'mail/affiliate', 1);
+(18, 'mail_affiliate_add', 'catalog/model/account/affiliate/addAffiliate/after', 'mail/affiliate', 1);
 INSERT INTO `oc_event` (`event_id`, `code`, `trigger`, `action`, `status`) VALUES
-(19, 'mail_affiliate_alert', 'catalog/model/account/customer/addAffiliate/after', 'mail/affiliate/alert', 1);
+(19, 'mail_affiliate_alert', 'catalog/model/account/affiliate/addAffiliate/after', 'mail/affiliate/alert', 1);
 INSERT INTO `oc_event` (`event_id`, `code`, `trigger`, `action`, `status`) VALUES
 (20, 'mail_voucher', 'catalog/model/checkout/order/addOrderHistory/after', 'extension/total/voucher/send', 1);
 INSERT INTO `oc_event` (`event_id`, `code`, `trigger`, `action`, `status`) VALUES


### PR DESCRIPTION
Put this together for testing and I couldn't find any other incorrect event paths.

```php
$sql = "SELECT * FROM " . DB_PREFIX . "event";
$result = $db->query($sql);

foreach ($result->rows as $event) {
	if (!$event['trigger']) continue;

	$trigger = preg_replace('/[^a-zA-Z0-9_\/]/', '', (string)$event['trigger']);

	// Break apart the route
	$parts = explode('/', $trigger);

	$route = false;
	$method = false;

	while ($parts) {
		$file = $root . implode('/', $parts) . '.php';

		if (is_file($file)) {
			$route = implode('/', $parts);

			break;
		} else {
			$method = array_pop($parts);
		}
	}

	// Remove everything before first slash e.g catalog/admin
	$class = preg_replace('/[^a-zA-Z0-9]/', '', substr($route, strpos($route, '/')));

	// Initialize the class
	if (is_file($file)) {
		include_once($file);

		$controller = new $class($registry);
	} else {
		echo '<br />Error: Could not call ' . $route . '/' . $method . '!';
	}

	$reflection = new ReflectionClass($class);

	if (!$reflection->hasMethod($method)) {
		echo '<br />Error: Could not call ' . $route . '/' . $method . '!';
	}
}
```