### PR TITLE
Update usps.php

### DIFF
--- a/upload/catalog/model/extension/shipping/usps.php
+++ b/upload/catalog/model/extension/shipping/usps.php
@@ -355,10 +355,11 @@ class ModelExtensionShippingUsps extends Model {
 					$error = $dom->getElementsByTagName('Error')->item(0);
 
 					$firstclasses = array (
-						'First-Class Mail Parcel',
-						'First-Class Mail Large Envelope',
-						'First-Class Mail Stamped Letter',
-						'First-Class Mail Postcards'
+						'First-Class Mail Parcel'              => '0',
+						'First-Class Package Service - Retail' => '0',
+						'First-Class Mail Large Envelope'      => '1',
+						'First-Class Mail Stamped Letter'      => '2',
+						'First-Class Mail Postcards'           => '3'
 					);
 
 					if ($rate_response || $intl_rate_response) {
@@ -377,9 +378,9 @@ class ModelExtensionShippingUsps extends Model {
 										if ($classid == '0') {
 											$mailservice = $postage->getElementsByTagName('MailService')->item(0)->nodeValue;
 
-											foreach ($firstclasses as $k => $firstclass)  {
-												if ($firstclass == $mailservice) {
-													$classid = $classid . $k;
+											foreach ($firstclasses as $serviceName => $serviceCode)  {
+												if ($serviceName == $mailservice) {
+													$classid = $classid . $serviceCode;
 													break;
 												}
 											}


### PR DESCRIPTION
There USPS service named 'First-Class Mail Parcel' is now appearing as 'First-Class Package Service - Retail' - which causes the former to **not show up** when in front end rate requests.  I've made some slight revisions to how we are appending the service code to include both when user selects 'First-Class Mail Parcel' in the admin settings.