### PR TITLE
Fix Notice: date_default_timezone_set()

### DIFF
--- a/upload/install/opencart.sql
+++ b/upload/install/opencart.sql
@@ -1440,6 +1440,7 @@ INSERT INTO `oc_setting` (`store_id`, `code`, `key`, `value`, `serialized`) VALU
 (0, 'config', 'config_layout_id', '4', 0),
 (0, 'config', 'config_country_id', '222', 0),
 (0, 'config', 'config_zone_id', '3563', 0),
+(0, 'config', 'config_timezone', 'UTC', 0),
 (0, 'config', 'config_language', 'en-gb', 0),
 (0, 'config', 'config_admin_language', 'en-gb', 0),
 (0, 'config', 'config_currency', 'USD', 0),


### PR DESCRIPTION
Errors:

Notice: date_default_timezone_set(): Timezone ID '' is invalid in admin\controller\startup\startup.php on line 16
Notice: date_default_timezone_set(): Timezone ID '' is invalid in catalog\controller\startup\startup.php on line 31

Added in opencart.sql:

(0, 'config', 'config_timezone', 'UTC', 0),