### PR TITLE
Fixed View all extensions in Marketplace

### DIFF
--- a/upload/admin/controller/marketplace/marketplace.php
+++ b/upload/admin/controller/marketplace/marketplace.php
@@ -137,7 +137,7 @@ class ControllerMarketplaceMarketplace extends Controller {
 		}
 
 		if (isset($this->request->get['filter_member'])) {
-			$url .= '&filter_member=' . $this->request->get['filter_member'];
+			$url .= '&filter_member=' . urlencode($this->request->get['filter_member']);
 		}
 
 		if (isset($this->request->get['sort'])) {


### PR DESCRIPTION
Error:
When the member has a space in the name, the extensions are not displayed.

Added urlencode:
urlencode($this->request->get['filter_member'])