### PR TITLE
When using CDN remote addr is same, added http_x_real_ip 

### DIFF
--- a/upload/catalog/controller/common/footer.php
+++ b/upload/catalog/controller/common/footer.php
@@ -41,7 +41,9 @@ class ControllerCommonFooter extends Controller {
 		if ($this->config->get('config_customer_online')) {
 			$this->load->model('tool/online');
 
-			if (isset($this->request->server['REMOTE_ADDR'])) {
+			if (isset($this->request->server['HTTP_X_REAL_IP'])) {
+				$ip = $this->request->server['HTTP_X_REAL_IP'];
+			} else if (isset($this->request->server['REMOTE_ADDR'])) {
 				$ip = $this->request->server['REMOTE_ADDR'];
 			} else {
 				$ip = '';


### PR DESCRIPTION
When using CDN remote addr is same, added http_x_real_ip for customer online. So it is possible to see the total number of customers online. Else it always shows 1 as Ip remains same.