### PR TITLE
PHP Warning:  preg_match(): ...

### DIFF
--- a/upload/admin/controller/design/seo_url.php
+++ b/upload/admin/controller/design/seo_url.php
@@ -548,7 +548,7 @@ class ControllerDesignSeoUrl extends Controller {
 		}
 
 		if ($this->request->post['keyword']) {
-			if (preg_match('/[^a-Z0-9_-]+/', $this->request->post['keyword'])) {
+			if (preg_match('/[^a-zA-Z0-9_-]+/', $this->request->post['keyword'])) {
 				$this->error['keyword'] = $this->language->get('error_keyword');
 			}
 


### PR DESCRIPTION
Compilation failed: range out of order in character class at offset 4

При добавлении `URL SEO` выдает белый экран и:
PHP Warning:  preg_match(): Compilation failed: range out of order in character class at offset 4 in ./upload/admin/controller/design/seo_url.php on line 551
--------
Если дефис внутри символьного класса используется для обозначения самого дефиса, то его лучше ставить в самое начало [-0-9.] и [^-0-9.] , чтобы его не нужно было экранировать. В противном случае его необходимо экранировать [0-9.\-], иначе подобная невнимательность рано или поздно обязательно приведет к образованию диапазона и, как следствие, к ненужным символам. Типичная ошибка: [A-z] не то же самое, что [A-Za-z] , ибо между «Z» и «a» есть символы «[», «\», «]», «^», «_», и «`».