### PR TITLE
Update encryption.php

### DIFF
--- a/upload/system/library/encryption.php
+++ b/upload/system/library/encryption.php
@@ -39,11 +39,15 @@ final class Encryption {
      * @return	string
      */
 	public function decrypt($key, $value) {
+		$result    = NULL;
 		$key       = openssl_digest($key, $this->digest, true);
 		$iv_length = openssl_cipher_iv_length($this->cipher);
 		$value     = base64_decode($value);
 		$iv        = substr($value, 0, $iv_length);
 		$value     = substr($value, $iv_length);
-		return openssl_decrypt($value, $this->cipher, $key, OPENSSL_RAW_DATA, $iv);
+		if (strlen($iv) == $iv_length) {
+			$result = openssl_decrypt($value, $this->cipher, $key, OPENSSL_RAW_DATA, $iv);
+		}
+		return $result;
 	}
 }

--- a/upload/system/library/encryption.php
+++ b/upload/system/library/encryption.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package		OpenCart
- * @author		Daniel Kerr
+ * @author		Daniel Kerr, Billy Noah
  * @copyright	Copyright (c) 2005 - 2017, OpenCart, Ltd. (https://www.opencart.com/)
  * @license		https://opensource.org/licenses/GPL-3.0
  * @link		https://www.opencart.com
@@ -11,27 +11,39 @@
 * Encryption class
 */
 final class Encryption {
-	/**
+	
+	private $cipher = 'aes-256-ctr';
+	private $digest = 'sha256';
+	
+    /**
      * 
      *
      * @param	string	$key
-	 * @param	string	$value
-	 * 
-	 * @return	string
+     * @param	string	$value
+     * 
+     * @return	string
      */	
 	public function encrypt($key, $value) {
-		return strtr(base64_encode(openssl_encrypt($value, 'aes-128-cbc', hash('sha256', $key, true))), '+/=', '-_,');
+		$key       = openssl_digest($key, $this->digest, true);
+		$iv_length = openssl_cipher_iv_length($this->cipher);
+		$iv        = openssl_random_pseudo_bytes($iv_length);
+		return base64_encode($iv . openssl_encrypt($value, $this->cipher, $key, OPENSSL_RAW_DATA, $iv));
 	}
 	
-	/**
+    /**
      * 
      *
      * @param	string	$key
-	 * @param	string	$value
-	 * 
-	 * @return	string
+     * @param	string	$value
+     * 
+     * @return	string
      */
 	public function decrypt($key, $value) {
-		return trim(openssl_decrypt(base64_decode(strtr($value, '-_,', '+/=')), 'aes-128-cbc', hash('sha256', $key, true)));
+		$key       = openssl_digest($key, $this->digest, true);
+		$iv_length = openssl_cipher_iv_length($this->cipher);
+		$value     = base64_decode($value);
+		$iv        = substr($value, 0, $iv_length);
+		$value     = substr($value, $iv_length);
+		return openssl_decrypt($value, $this->cipher, $key, OPENSSL_RAW_DATA, $iv);
 	}
 }


### PR DESCRIPTION
The current encryption class contains some legacy code and fails to implement an iv in such a way to satisfy the openssl functions.  Because of this, most modern versions of php will throw a warning which is visible to the admin user: "Warning: openssl_encrypt(): Using an empty Initialization Vector (iv) is potentially insecure and not recommended"

This is more or less a complete rewrite using all openssl library functions, sha256 digest and (currently) the strongest encryption cipher I know of 'aes-256-ctr'.  Both the cipher and digest are now class properties which should make this easy to update in the future should these become obsolete.

I've tested this on php 5.6, 7.0 and 7.1 with success.