### PR TITLE
Fix spaces before php tag

### DIFF
--- a/upload/admin/controller/marketplace/installer.php
+++ b/upload/admin/controller/marketplace/installer.php
@@ -1,4 +1,4 @@
-   <?php
+<?php
 class ControllerMarketplaceInstaller extends Controller {
 	public function index() {
 		$this->load->language('marketplace/installer');


### PR DESCRIPTION
Fix spaces before php tag
PHP Warning:  Cannot modify header information - headers already sent by (output started at ...\system\storage\modification\admin\controller\marketplace\installer.php:1) in ...\system\library\response.php on line 36