### PR TITLE
Fix email delivery

### DIFF
--- a/upload/admin/controller/mail/affiliate.php
+++ b/upload/admin/controller/mail/affiliate.php
@@ -31,28 +31,22 @@ class ControllerMailAffiliate extends Controller {
 			$language = new Language($language_code);
 			$language->load($language_code);
 			$language->load('mail/affiliate_approve');
-							
-			$subject = sprintf($language->get('text_subject'), $store_name);
 			
 			$data['text_welcome'] = sprintf($language->get('text_welcome'), $store_name);
-						
+
 			$data['login'] = $store_url . 'index.php?route=account/login';
 			$data['store'] = $store_name;
-	
-			$mail = new Mail($this->config->get('config_mail_engine'));
-			$mail->parameter = $this->config->get('config_mail_parameter');
-			$mail->smtp_hostname = $this->config->get('config_mail_smtp_hostname');
-			$mail->smtp_username = $this->config->get('config_mail_smtp_username');
-			$mail->smtp_password = html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8');
-			$mail->smtp_port = $this->config->get('config_mail_smtp_port');
-			$mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
-	
-			$mail->setTo($customer_info['email']);
-			$mail->setFrom($this->config->get('config_email'));
-			$mail->setSender($store_name);
-			$mail->setSubject($subject);
-			$mail->setText($this->load->view('mail/affiliate_approve', $data));
-			$mail->send();
+			
+			$this->load->model('tool/mail');
+			
+			$mail_data = array(
+				'to'		=> $customer_info['email'],
+				'sender'	=> $store_name,
+				'subject'	=> sprintf($language->get('text_subject'), html_entity_decode($store_name, ENT_QUOTES, 'UTF-8')),
+				'text'		=> $this->load->view('mail/affiliate_approve', $data)
+			);
+			
+			$this->model_tool_mail->sendMail($mail_data);
 		}
 	}
 	
@@ -87,28 +81,22 @@ class ControllerMailAffiliate extends Controller {
 			$language = new Language($language_code);
 			$language->load($language_code);
 			$language->load('mail/affiliate_deny');
-				
-			$subject = sprintf($language->get('text_subject'), $store_name);	
-				
+
 			$data['text_welcome'] = sprintf($language->get('text_welcome'), $store_name);
 			
 			$data['contact'] = $store_url . 'index.php?route=information/contact';	
 			$data['store'] = $store_name;
 			
-			$mail = new Mail($this->config->get('config_mail_engine'));
-			$mail->parameter = $this->config->get('config_mail_parameter');
-			$mail->smtp_hostname = $this->config->get('config_mail_smtp_hostname');
-			$mail->smtp_username = $this->config->get('config_mail_smtp_username');
-			$mail->smtp_password = html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8');
-			$mail->smtp_port = $this->config->get('config_mail_smtp_port');
-			$mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
-
-			$mail->setTo($customer_info['email']);
-			$mail->setFrom($this->config->get('config_email'));
-			$mail->setSender($store_name);
-			$mail->setSubject($subject);
-			$mail->setText($this->load->view('mail/affiliate_deny', $data));
-			$mail->send();
+			$this->load->model('tool/mail');
+			
+			$mail_data = array(
+				'to'		=> $customer_info['email'],
+				'sender'	=> $store_name,
+				'subject'	=> sprintf($language->get('text_subject'), html_entity_decode($store_name, ENT_QUOTES, 'UTF-8')),
+				'text'		=> $this->load->view('mail/affiliate_deny', $data)
+			);
+			
+			$this->model_tool_mail->sendMail($mail_data);
 		}
 	}
 }	

--- a/upload/admin/controller/mail/customer.php
+++ b/upload/admin/controller/mail/customer.php
@@ -32,8 +32,6 @@ class ControllerMailCustomer extends Controller {
 			$language->load($language_code);
 			$language->load('mail/customer_approve');
 
-			$subject = sprintf($language->get('text_subject'), $store_name);
-
 			$data['text_welcome'] = sprintf($language->get('text_welcome'), $store_name);
 			$data['text_login'] = $language->get('text_login');
 			$data['text_service'] = $language->get('text_service');
@@ -52,21 +50,17 @@ class ControllerMailCustomer extends Controller {
 			} else {
 				$data['logo'] = '';
 			}
-
-			$mail = new Mail($this->config->get('config_mail_engine'));
-			$mail->parameter = $this->config->get('config_mail_parameter');
-			$mail->smtp_hostname = $this->config->get('config_mail_smtp_hostname');
-			$mail->smtp_username = $this->config->get('config_mail_smtp_username');
-			$mail->smtp_password = html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8');
-			$mail->smtp_port = $this->config->get('config_mail_smtp_port');
-			$mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
-
-			$mail->setTo($customer_info['email']);
-			$mail->setFrom($this->config->get('config_email'));
-			$mail->setSender($store_name);
-			$mail->setSubject($subject);
-			$mail->setHtml($this->load->view('mail/customer_approve', $data));
-			$mail->send();
+		
+			$this->load->model('tool/mail');
+			
+			$mail_data = array(
+				'to'		=> $customer_info['email'],
+				'sender'	=> $store_name,
+				'subject'	=> sprintf($language->get('text_subject'), $store_name),
+				'text'		=> $this->load->view('mail/customer_approve', $data)
+			);
+			
+			$this->model_tool_mail->sendMail($mail_data);
 		}
 	}
 

--- a/upload/admin/controller/mail/forgotten.php
+++ b/upload/admin/controller/mail/forgotten.php
@@ -9,20 +9,15 @@ class ControllerMailForgotten extends Controller {
 			$data['reset'] = str_replace('&amp;', '&', $this->url->link('common/reset', 'email=' . urlencode($args[0]) . '&code=' . $args[1]));
 			$data['ip'] = $this->request->server['REMOTE_ADDR'];
 
-			$mail = new Mail($this->config->get('config_mail_engine'));
-			$mail->parameter = $this->config->get('config_mail_parameter');
-			$mail->smtp_hostname = $this->config->get('config_mail_smtp_hostname');
-			$mail->smtp_username = $this->config->get('config_mail_smtp_username');
-			$mail->smtp_password = html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8');
-			$mail->smtp_port = $this->config->get('config_mail_smtp_port');
-			$mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
-
-			$mail->setTo($args[0]);
-			$mail->setFrom($this->config->get('config_email'));
-			$mail->setSender(html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8'));
-			$mail->setSubject(html_entity_decode(sprintf($this->language->get('text_subject'), html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8')), ENT_QUOTES, 'UTF-8'));
-			$mail->setText($this->load->view('mail/forgotten', $data));
-			$mail->send();
+			$this->load->model('tool/mail');
+			
+			$mail_data = array(
+				'to'		=> $args[0],
+				'subject'	=> sprintf($this->language->get('text_subject'), html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8')),
+				'text'		=> $this->load->view('mail/forgotten', $data)
+			);
+			
+			$this->model_tool_mail->sendMail($mail_data);
 		}
 	}
 }

--- a/upload/admin/controller/mail/return.php
+++ b/upload/admin/controller/mail/return.php
@@ -48,20 +48,15 @@ class ControllerMailReturn extends Controller {
 				$data['return_status'] = $return_info['return_status'];
 				$data['comment'] = strip_tags(html_entity_decode($comment, ENT_QUOTES, 'UTF-8'));
 
-				$mail = new Mail($this->config->get('config_mail_engine'));
-				$mail->parameter = $this->config->get('config_mail_parameter');
-				$mail->smtp_hostname = $this->config->get('config_mail_smtp_hostname');
-				$mail->smtp_username = $this->config->get('config_mail_smtp_username');
-				$mail->smtp_password = html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8');
-				$mail->smtp_port = $this->config->get('config_mail_smtp_port');
-				$mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
-
-				$mail->setTo($return_info['email']);
-				$mail->setFrom($this->config->get('config_email'));
-				$mail->setSender(html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8'));
-				$mail->setSubject(sprintf($language->get('text_subject'), html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8'), $return_id));
-				$mail->setText($this->load->view('mail/return', $data));
-				$mail->send();
+				$this->load->model('tool/mail');
+				
+				$mail_data = array(
+					'to'		=> $return_info['email'],
+					'subject'	=> sprintf($language->get('text_subject'), html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8')),
+					'text'		=> $this->load->view('mail/return', $data)
+				);
+				
+				$this->model_tool_mail->sendMail($mail_data);
 			}
 		}
 	}

--- a/upload/admin/controller/mail/reward.php
+++ b/upload/admin/controller/mail/reward.php
@@ -59,21 +59,16 @@ class ControllerMailReward extends Controller {
 			$data['text_received'] = sprintf($language->get('text_received'), $points);
 			$data['text_total'] = sprintf($language->get('text_total'), $this->model_customer_customer->getRewardTotal($customer_id));
 
-			$mail = new Mail($this->config->get('config_mail_engine'));
-			$mail->protocol = $this->config->get('config_mail_protocol');
-			$mail->parameter = $this->config->get('config_mail_parameter');
-			$mail->smtp_hostname = $this->config->get('config_mail_smtp_hostname');
-			$mail->smtp_username = $this->config->get('config_mail_smtp_username');
-			$mail->smtp_password = html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8');
-			$mail->smtp_port = $this->config->get('config_mail_smtp_port');
-			$mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
-
-			$mail->setTo($customer_info['email']);
-			$mail->setFrom($this->config->get('config_email'));
-			$mail->setSender(html_entity_decode($store_name, ENT_QUOTES, 'UTF-8'));
-			$mail->setSubject(sprintf($language->get('text_subject'), html_entity_decode($store_name, ENT_QUOTES, 'UTF-8')));
-			$mail->setText($this->load->view('mail/reward', $data));
-			$mail->send();
+			$this->load->model('tool/mail');
+			
+			$mail_data = array(
+				'to'		=> $customer_info['email'],
+				'sender'	=> $store_name,
+				'subject'	=> sprintf($language->get('text_subject'), html_entity_decode($store_name, ENT_QUOTES, 'UTF-8')),
+				'text'		=> $this->load->view('mail/reward', $data)
+			);
+			
+			$this->model_tool_mail->sendMail($mail_data);
 		}
 	}
 }

--- a/upload/admin/controller/mail/transaction.php
+++ b/upload/admin/controller/mail/transaction.php
@@ -59,20 +59,16 @@ class ControllerMailTransaction extends Controller {
 			$data['text_received'] = sprintf($language->get('text_received'), $this->currency->format($amount, $this->config->get('config_currency')));
 			$data['text_total'] = sprintf($language->get('text_total'), $this->currency->format($this->model_customer_customer->getTransactionTotal($customer_id), $this->config->get('config_currency')));
 			
-			$mail = new Mail($this->config->get('config_mail_engine'));
-			$mail->parameter = $this->config->get('config_mail_parameter');
-			$mail->smtp_hostname = $this->config->get('config_mail_smtp_hostname');
-			$mail->smtp_username = $this->config->get('config_mail_smtp_username');
-			$mail->smtp_password = html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8');
-			$mail->smtp_port = $this->config->get('config_mail_smtp_port');
-			$mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
-
-			$mail->setTo($customer_info['email']);
-			$mail->setFrom($this->config->get('config_email'));
-			$mail->setSender(html_entity_decode($store_name, ENT_QUOTES, 'UTF-8'));
-			$mail->setSubject(sprintf($language->get('text_subject'), html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8')));
-			$mail->setText($this->load->view('mail/transaction', $data));
-			$mail->send();
+			$this->load->model('tool/mail');
+			
+			$mail_data = array(
+				'to'		=> $customer_info['email'],
+				'sender'	=> $store_name,
+				'subject'	=> sprintf($language->get('text_subject'), html_entity_decode($store_name, ENT_QUOTES, 'UTF-8')),
+				'text'		=> $this->load->view('mail/transaction', $data)
+			);
+			
+			$this->model_tool_mail->sendMail($mail_data);
 		}
 	}		
 }	

--- a/upload/admin/controller/marketing/contact.php
+++ b/upload/admin/controller/marketing/contact.php
@@ -218,23 +218,21 @@ class ControllerMarketingContact extends Controller {
 					$message .= '  </head>' . "\n";
 					$message .= '  <body>' . html_entity_decode($this->request->post['message'], ENT_QUOTES, 'UTF-8') . '</body>' . "\n";
 					$message .= '</html>' . "\n";
+		
+					$this->load->model('tool/mail');
 
 					foreach ($emails as $email) {
 						if (filter_var($email, FILTER_VALIDATE_EMAIL)) {
-							$mail = new Mail($this->config->get('config_mail_engine'));
-							$mail->parameter = $this->config->get('config_mail_parameter');
-							$mail->smtp_hostname = $this->config->get('config_mail_smtp_hostname');
-							$mail->smtp_username = $this->config->get('config_mail_smtp_username');
-							$mail->smtp_password = html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8');
-							$mail->smtp_port = $this->config->get('config_mail_smtp_port');
-							$mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
-
-							$mail->setTo($email);
-							$mail->setFrom($store_email);
-							$mail->setSender(html_entity_decode($store_name, ENT_QUOTES, 'UTF-8'));
-							$mail->setSubject(html_entity_decode($this->request->post['subject'], ENT_QUOTES, 'UTF-8'));
-							$mail->setHtml($message);
-							$mail->send();
+							
+							$mail_data = array(
+								'to'		=> $email,
+								'from'		=> $store_email,
+								'sender'	=> $store_name,
+								'subject'	=> $this->request->post['subject'],
+								'html'		=> $message
+							);
+							
+							$this->model_tool_mail->sendMail($mail_data);
 						}
 					}
 				} else {

--- a/upload/admin/controller/sale/voucher.php
+++ b/upload/admin/controller/sale/voucher.php
@@ -611,21 +611,16 @@ class ControllerSaleVoucher extends Controller {
 							$data['store_name'] = $order_info['store_name'];
 							$data['store_url'] = $order_info['store_url'];
 							$data['message'] = nl2br($voucher_info['message']);
-			
-							$mail = new Mail($this->config->get('config_mail_engine'));
-							$mail->parameter = $this->config->get('config_mail_parameter');
-							$mail->smtp_hostname = $this->config->get('config_mail_smtp_hostname');
-							$mail->smtp_username = $this->config->get('config_mail_smtp_username');
-							$mail->smtp_password = html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8');
-							$mail->smtp_port = $this->config->get('config_mail_smtp_port');
-							$mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
-			
-							$mail->setTo($voucher_info['to_email']);
-							$mail->setFrom($this->config->get('config_email'));
-							$mail->setSender(html_entity_decode($order_info['store_name'], ENT_QUOTES, 'UTF-8'));
-							$mail->setSubject(sprintf($language->get('text_subject'), html_entity_decode($voucher_info['from_name'], ENT_QUOTES, 'UTF-8')));
-							$mail->setHtml($this->load->view('mail/voucher', $data));
-							$mail->send();
+
+							$this->load->model('tool/mail');
+							
+							$mail_data = array(
+								'to'		=> $voucher_info['to_email'],
+								'subject'	=> sprintf($language->get('text_subject'), html_entity_decode($voucher_info['from_name'], ENT_QUOTES, 'UTF-8')),
+								'text'		=> $this->load->view('mail/voucher', $data)
+							);
+							
+							$this->model_tool_mail->sendMail($mail_data);
 			
 						// If voucher does not belong to an order
 						}  else {
@@ -650,21 +645,16 @@ class ControllerSaleVoucher extends Controller {
 							$data['store_name'] = $this->config->get('config_name');
 							$data['store_url'] = HTTP_CATALOG;
 							$data['message'] = nl2br($voucher_info['message']);
-			
-							$mail = new Mail($this->config->get('config_mail_engine'));
-							$mail->parameter = $this->config->get('config_mail_parameter');
-							$mail->smtp_hostname = $this->config->get('config_mail_smtp_hostname');
-							$mail->smtp_username = $this->config->get('config_mail_smtp_username');
-							$mail->smtp_password = html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8');
-							$mail->smtp_port = $this->config->get('config_mail_smtp_port');
-							$mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
-			
-							$mail->setTo($voucher_info['to_email']);
-							$mail->setFrom($this->config->get('config_email'));
-							$mail->setSender(html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8'));
-							$mail->setSubject(html_entity_decode(sprintf($this->language->get('text_subject'), $voucher_info['from_name']), ENT_QUOTES, 'UTF-8'));
-							$mail->setHtml($this->load->view('mail/voucher', $data));
-							$mail->send();
+							
+							$this->load->model('tool/mail');
+							
+							$mail_data = array(
+								'to'		=> $voucher_info['to_email'],
+								'subject'	=> sprintf($language->get('text_subject'), html_entity_decode($voucher_info['from_name'], ENT_QUOTES, 'UTF-8')),
+								'text'		=> $this->load->view('mail/voucher', $data)
+							);
+							
+							$this->model_tool_mail->sendMail($mail_data);
 						}
 					}
 				}

--- a/upload/admin/model/tool/mail.php
+++ b/upload/admin/model/tool/mail.php
@@ -1,0 +1,83 @@
+<?php
+class ModelToolMail extends Model {
+	public function sendMail($data) {
+		
+		$defaults = array(
+			'config_mail_engine'		=> $this->config->get('config_mail_engine'),
+			'config_mail_parameter'		=> $this->config->get('config_mail_parameter'),
+			'config_mail_smtp_hostname'	=> $this->config->get('config_mail_smtp_hostname'),
+			'config_mail_smtp_username'	=> $this->config->get('config_mail_smtp_username'),
+			'config_mail_smtp_password'	=> html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8'),
+			'config_mail_smtp_port'		=> $this->config->get('config_mail_smtp_port'),
+			'config_mail_smtp_timeout'	=> $this->config->get('config_mail_smtp_timeout'),
+			'to'						=> $this->config->get('config_email'),
+			'from'						=> $this->config->get('config_email'),
+			'alerts'					=> false,
+			'reply_to'					=> false,
+			'sender'					=> $this->config->get('config_name'),
+			'subject'					=> false,
+			'text'						=> false,
+			'html'						=> false,
+			'attachments'				=> array(),
+		);
+		
+		foreach($defaults as $k => $v) {
+			if (!isset($data[$k])) {
+				$data[$k] = $v;
+			}
+		}
+		
+		if (strstr($this->config->get('config_mail_smtp_hostname'),'@') && filter_var($email, FILTER_VALIDATE_EMAIL)) {
+			$data['from'] = $this->config->get('config_mail_smtp_hostname');
+			if (!$data['reply_to']) {
+				$data['reply_to'] = $data['from'];
+			}
+		}
+		
+		$mail = new Mail($data['config_mail_engine']);
+		$mail->parameter = $data['config_mail_parameter'];
+		$mail->smtp_hostname = $data['config_mail_smtp_hostname'];
+		$mail->smtp_username = $data['config_mail_smtp_username'];
+		$mail->smtp_password = html_entity_decode($data['config_mail_smtp_password'], ENT_QUOTES, 'UTF-8');
+		$mail->smtp_port = $data['config_mail_smtp_port'];
+		$mail->smtp_timeout = $data['config_mail_smtp_timeout'];
+
+		$mail->setTo($data['config_email']);
+		$mail->setFrom($data['config_email']);
+		
+		if ($data['reply_to']) {
+			$mail->setReplyTo($data['reply_to']);
+		}
+		
+		$mail->setSender(html_entity_decode($data['sender'], ENT_QUOTES, 'UTF-8'));
+		$mail->setSubject(html_entity_decode($data['subject'], ENT_QUOTES, 'UTF-8'));
+		
+		if ($data['text']) {
+			$mail->setText($data['text']);
+		}
+		
+		if ($data['html']) {
+			$mail->setHtml($data['html']);
+		}
+		
+		if ($data['attachments']) {
+			foreach($data['attachments'] as $attachment) {
+				$mail->addAttachment($attachment);
+			}
+		}
+		
+		$mail->send();
+		
+		if ($data['alerts']) {
+			// Send to additional alert emails
+			$emails = explode(',', $this->config->get('config_mail_alert_email'));
+
+			foreach ($emails as $email) {
+				if (utf8_strlen($email) > 0 && filter_var($email, FILTER_VALIDATE_EMAIL)) {
+					$mail->setTo($email);
+					$mail->send();
+				}
+			}
+		}
+	}
+}

--- a/upload/admin/model/tool/mail.php
+++ b/upload/admin/model/tool/mail.php
@@ -27,8 +27,8 @@ class ModelToolMail extends Model {
 			}
 		}
 		
-		if (strstr($this->config->get('config_mail_smtp_hostname'),'@') && filter_var($email, FILTER_VALIDATE_EMAIL)) {
-			$data['from'] = $this->config->get('config_mail_smtp_hostname');
+		if (strstr($this->config->get('config_mail_smtp_username'),'@') && filter_var($email, FILTER_VALIDATE_EMAIL)) {
+			$data['from'] = $this->config->get('config_mail_smtp_username');
 			if (!$data['reply_to']) {
 				$data['reply_to'] = $data['from'];
 			}

--- a/upload/catalog/controller/extension/total/voucher.php
+++ b/upload/catalog/controller/extension/total/voucher.php
@@ -83,21 +83,17 @@ class ControllerExtensionTotalVoucher extends Controller {
 					$data['store_name'] = $order_info['store_name'];
 					$data['store_url'] = $order_info['store_url'];
 					$data['message'] = nl2br($voucher['message']);
-
-					$mail = new Mail($this->config->get('config_mail_engine'));
-					$mail->parameter = $this->config->get('config_mail_parameter');
-					$mail->smtp_hostname = $this->config->get('config_mail_smtp_hostname');
-					$mail->smtp_username = $this->config->get('config_mail_smtp_username');
-					$mail->smtp_password = html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8');
-					$mail->smtp_port = $this->config->get('config_mail_smtp_port');
-					$mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
-
-					$mail->setTo($voucher['to_email']);
-					$mail->setFrom($this->config->get('config_email'));
-					$mail->setSender(html_entity_decode($order_info['store_name'], ENT_QUOTES, 'UTF-8'));
-					$mail->setSubject(html_entity_decode(sprintf($language->get('text_subject'), $voucher['from_name']), ENT_QUOTES, 'UTF-8'));
-					$mail->setHtml($this->load->view('mail/voucher', $data));
-					$mail->send();
+					
+					$this->load->model('tool/mail');
+					
+					$mail_data = array(
+						'to'		=> $voucher['to_email'],
+						'sender'	=> $order_info['store_name'],
+						'subject'	=> sprintf($language->get('text_subject'), html_entity_decode($voucher['from_name'], ENT_QUOTES, 'UTF-8')),
+						'html'		=> $this->load->view('mail/voucher', $data)
+					);
+					
+					$this->model_tool_mail->sendMail($mail_data);
 				}
 			}
 		}

--- a/upload/catalog/controller/information/contact.php
+++ b/upload/catalog/controller/information/contact.php
@@ -8,21 +8,17 @@ class ControllerInformationContact extends Controller {
 		$this->document->setTitle($this->language->get('heading_title'));
 
 		if (($this->request->server['REQUEST_METHOD'] == 'POST') && $this->validate()) {
-			$mail = new Mail($this->config->get('config_mail_engine'));
-			$mail->parameter = $this->config->get('config_mail_parameter');
-			$mail->smtp_hostname = $this->config->get('config_mail_smtp_hostname');
-			$mail->smtp_username = $this->config->get('config_mail_smtp_username');
-			$mail->smtp_password = html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8');
-			$mail->smtp_port = $this->config->get('config_mail_smtp_port');
-			$mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
-
-			$mail->setTo($this->config->get('config_email'));
-			$mail->setFrom($this->config->get('config_email'));
-			$mail->setReplyTo($this->request->post['email']);
-			$mail->setSender(html_entity_decode($this->request->post['name'], ENT_QUOTES, 'UTF-8'));
-			$mail->setSubject(html_entity_decode(sprintf($this->language->get('email_subject'), $this->request->post['name']), ENT_QUOTES, 'UTF-8'));
-			$mail->setText($this->request->post['enquiry']);
-			$mail->send();
+		
+			$this->load->model('tool/mail');
+			
+			$mail_data = array(
+				'to'		=> $this->request->post['email'],
+				'sender'	=> $this->request->post['name'],
+				'subject'	=> sprintf($this->language->get('email_subject'), $this->request->post['name']),
+				'text'		=> $this->request->post['enquiry']
+			);
+			
+			$this->model_tool_mail->sendMail($mail_data);
 
 			$this->response->redirect($this->url->link('information/contact/success', 'language=' . $this->config->get('config_language')));
 		}

--- a/upload/catalog/controller/mail/affiliate.php
+++ b/upload/catalog/controller/mail/affiliate.php
@@ -38,25 +38,21 @@ class ControllerMailAffiliate extends Controller {
 			$data['logo'] = '';
 		}
 
-		$mail = new Mail($this->config->get('config_mail_engine'));
-		$mail->parameter = $this->config->get('config_mail_parameter');
-		$mail->smtp_hostname = $this->config->get('config_mail_smtp_hostname');
-		$mail->smtp_username = $this->config->get('config_mail_smtp_username');
-		$mail->smtp_password = html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8');
-		$mail->smtp_port = $this->config->get('config_mail_smtp_port');
-		$mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
-
 		if ($this->customer->isLogged()) {
-			$mail->setTo($this->customer->getEmail());
+			$to = $this->customer->getEmail();
 		} else {
-			$mail->setTo($args[1]['email']);
+			$to = $args[1]['email'];
 		}
-
-		$mail->setFrom($this->config->get('config_email'));
-		$mail->setSender(html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8'));
-		$mail->setSubject(sprintf($this->language->get('text_subject'), html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8')));
-		$mail->setHtml($this->load->view('mail/affiliate', $data));
-		$mail->send();
+		
+		$this->load->model('tool/mail');
+		
+		$mail_data = array(
+			'to'		=> $to,
+			'subject'	=> sprintf($language->get('text_subject'), html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8')),
+			'text'		=> $this->load->view('mail/affiliate', $data)
+		);
+		
+		$this->model_tool_mail->sendMail($mail_data);
  	}
 
 	public function alert(&$route, &$args, &$output) {
@@ -112,31 +108,16 @@ class ControllerMailAffiliate extends Controller {
 			} else {
 				$data['customer_group'] = '';
 			}
-
-			$mail = new Mail($this->config->get('config_mail_engine'));
-			$mail->parameter = $this->config->get('config_mail_parameter');
-			$mail->smtp_hostname = $this->config->get('config_mail_smtp_hostname');
-			$mail->smtp_username = $this->config->get('config_mail_smtp_username');
-			$mail->smtp_password = html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8');
-			$mail->smtp_port = $this->config->get('config_mail_smtp_port');
-			$mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
-
-			$mail->setTo($this->config->get('config_email'));
-			$mail->setFrom($this->config->get('config_email'));
-			$mail->setSender(html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8'));
-			$mail->setSubject(html_entity_decode($this->language->get('text_new_affiliate'), ENT_QUOTES, 'UTF-8'));
-			$mail->setHtml($this->load->view('mail/affiliate_alert', $data));
-			$mail->send();
-
-			// Send to additional alert emails if new affiliate email is enabled
-			$emails = explode(',', $this->config->get('config_mail_alert_email'));
-
-			foreach ($emails as $email) {
-				if (utf8_strlen($email) > 0 && filter_var($email, FILTER_VALIDATE_EMAIL)) {
-					$mail->setTo($email);
-					$mail->send();
-				}
-			}
+		
+			$this->load->model('tool/mail');
+			
+			$mail_data = array(
+				'alerts'	=> true,
+				'subject'	=> $this->language->get('text_new_affiliate'),
+				'text'		=> $this->load->view('mail/affiliate_alert', $data)
+			);
+			
+			$this->model_tool_mail->sendMail($mail_data);
 		}
 	}
 }

--- a/upload/catalog/controller/mail/forgotten.php
+++ b/upload/catalog/controller/mail/forgotten.php
@@ -21,21 +21,16 @@ class ControllerMailForgotten extends Controller {
 			} else {
 				$data['logo'] = '';
 			}
-
-			$mail = new Mail($this->config->get('config_mail_engine'));
-			$mail->parameter = $this->config->get('config_mail_parameter');
-			$mail->smtp_hostname = $this->config->get('config_mail_smtp_hostname');
-			$mail->smtp_username = $this->config->get('config_mail_smtp_username');
-			$mail->smtp_password = html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8');
-			$mail->smtp_port = $this->config->get('config_mail_smtp_port');
-			$mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
-
-			$mail->setTo($args[0]);
-			$mail->setFrom($this->config->get('config_email'));
-			$mail->setSender(html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8'));
-			$mail->setSubject(html_entity_decode(sprintf($this->language->get('text_subject'), html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8')), ENT_QUOTES, 'UTF-8'));
-			$mail->setHtml($this->load->view('mail/forgotten', $data));
-			$mail->send();
+			
+			$this->load->model('tool/mail');
+			
+			$mail_data = array(
+				'to'		=> $args[0],
+				'subject'	=> sprintf($language->get('text_subject'), html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8')),
+				'text'		=> $this->load->view('mail/forgotten', $data)
+			);
+			
+			$this->model_tool_mail->sendMail($mail_data);
 		}
 	}
 }

--- a/upload/catalog/controller/mail/order.php
+++ b/upload/catalog/controller/mail/order.php
@@ -258,21 +258,18 @@ class ControllerMailOrder extends Controller {
 		if (!$from) {
 			$from = $this->config->get('config_email');
 		}
-
-		$mail = new Mail($this->config->get('config_mail_engine'));
-		$mail->parameter = $this->config->get('config_mail_parameter');
-		$mail->smtp_hostname = $this->config->get('config_mail_smtp_hostname');
-		$mail->smtp_username = $this->config->get('config_mail_smtp_username');
-		$mail->smtp_password = html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8');
-		$mail->smtp_port = $this->config->get('config_mail_smtp_port');
-		$mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
-
-		$mail->setTo($order_info['email']);
-		$mail->setFrom($from);
-		$mail->setSender(html_entity_decode($order_info['store_name'], ENT_QUOTES, 'UTF-8'));
-		$mail->setSubject(html_entity_decode(sprintf($language->get('text_subject'), $order_info['store_name'], $order_info['order_id']), ENT_QUOTES, 'UTF-8'));
-		$mail->setHtml($this->load->view('mail/order_add', $data));
-		$mail->send();
+		
+		$this->load->model('tool/mail');
+		
+		$mail_data = array(
+			'to'		=> $order_info['email'],
+			'from'		=> $from,
+			'sender'	=> $order_info['store_name'],
+			'subject'	=> sprintf($language->get('text_subject'), $order_info['store_name'], $order_info['order_id']),
+			'html'		=> $this->load->view('mail/order_add', $data)
+		);
+		
+		$this->model_tool_mail->sendMail($mail_data);
 	}
 
 	public function edit($order_info, $order_status_id, $comment) {

--- a/upload/catalog/controller/mail/register.php
+++ b/upload/catalog/controller/mail/register.php
@@ -37,21 +37,16 @@ class ControllerMailRegister extends Controller {
 		} else {
 			$data['logo'] = '';
 		}
-
-		$mail = new Mail($this->config->get('config_mail_engine'));
-		$mail->parameter = $this->config->get('config_mail_parameter');
-		$mail->smtp_hostname = $this->config->get('config_mail_smtp_hostname');
-		$mail->smtp_username = $this->config->get('config_mail_smtp_username');
-		$mail->smtp_password = html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8');
-		$mail->smtp_port = $this->config->get('config_mail_smtp_port');
-		$mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
-
-		$mail->setTo($args[0]['email']);
-		$mail->setFrom($this->config->get('config_email'));
-		$mail->setSender(html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8'));
-		$mail->setSubject(sprintf($this->language->get('text_subject'), html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8')));
-		$mail->setHtml($this->load->view('mail/register', $data));
-		$mail->send();
+		
+		$this->load->model('tool/mail');
+		
+		$mail_data = array(
+			'to'		=> $args[0]['email'],
+			'subject'	=> sprintf($this->language->get('text_subject'), html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8')),
+			'text'		=> $this->load->view('mail/register', $data)
+		);
+		
+		$this->model_tool_mail->sendMail($mail_data);
 	}
 
 	public function alert(&$route, &$args, &$output) {
@@ -99,31 +94,16 @@ class ControllerMailRegister extends Controller {
 
 			$data['email'] = $args[0]['email'];
 			$data['telephone'] = $args[0]['telephone'];
-
-			$mail = new Mail($this->config->get('config_mail_engine'));
-			$mail->parameter = $this->config->get('config_mail_parameter');
-			$mail->smtp_hostname = $this->config->get('config_mail_smtp_hostname');
-			$mail->smtp_username = $this->config->get('config_mail_smtp_username');
-			$mail->smtp_password = html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8');
-			$mail->smtp_port = $this->config->get('config_mail_smtp_port');
-			$mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
-
-			$mail->setTo($this->config->get('config_email'));
-			$mail->setFrom($this->config->get('config_email'));
-			$mail->setSender(html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8'));
-			$mail->setSubject(html_entity_decode($this->language->get('text_new_customer'), ENT_QUOTES, 'UTF-8'));
-			$mail->setHtml($this->load->view('mail/register_alert', $data));
-			$mail->send();
-
-			// Send to additional alert emails if new account email is enabled
-			$emails = explode(',', $this->config->get('config_mail_alert_email'));
-
-			foreach ($emails as $email) {
-				if (utf8_strlen($email) > 0 && filter_var($email, FILTER_VALIDATE_EMAIL)) {
-					$mail->setTo($email);
-					$mail->send();
-				}
-			}
+			
+			$this->load->model('tool/mail');
+			
+			$mail_data = array(
+				'alerts'	=> true,
+				'subject'	=> $this->language->get('text_new_customer'),
+				'text'		=> $this->load->view('mail/register_alert', $data)
+			);
+			
+			$this->model_tool_mail->sendMail($mail_data);
 		}
 	}
 }

--- a/upload/catalog/controller/mail/transaction.php
+++ b/upload/catalog/controller/mail/transaction.php
@@ -26,20 +26,15 @@ class ControllerMailTransaction extends Controller {
 				$data['logo'] = '';
 			}
 			
-			$mail = new Mail($this->config->get('config_mail_engine'));
-			$mail->parameter = $this->config->get('config_mail_parameter');
-			$mail->smtp_hostname = $this->config->get('config_mail_smtp_hostname');
-			$mail->smtp_username = $this->config->get('config_mail_smtp_username');
-			$mail->smtp_password = html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8');
-			$mail->smtp_port = $this->config->get('config_mail_smtp_port');
-			$mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
-
-			$mail->setTo($customer_info['email']);
-			$mail->setFrom($this->config->get('config_email'));
-			$mail->setSender(html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8'));
-			$mail->setSubject(html_entity_decode(sprintf($this->language->get('text_subject'), $this->config->get('config_name')), ENT_QUOTES, 'UTF-8'));
-			$mail->setHtml($this->load->view('mail/transaction', $data));
-			$mail->send();
+			$this->load->model('tool/mail');
+			
+			$mail_data = array(
+				'to'		=> $customer_info['email'],
+				'subject'	=> sprintf($language->get('text_subject'), html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8')),
+				'text'		=> $this->load->view('mail/transaction', $data)
+			);
+			
+			$this->model_tool_mail->sendMail($mail_data);
 		}
 	}
 }

--- a/upload/catalog/model/catalog/review.php
+++ b/upload/catalog/model/catalog/review.php
@@ -11,29 +11,21 @@ class ModelCatalogReview extends Model {
 			
 			$product_info = $this->model_catalog_product->getProduct($product_id);
 
-			$subject = sprintf($this->language->get('text_subject'), html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8'));
-
 			$message  = $this->language->get('text_waiting') . "\n";
 			$message .= sprintf($this->language->get('text_product'), html_entity_decode($product_info['name'], ENT_QUOTES, 'UTF-8')) . "\n";
 			$message .= sprintf($this->language->get('text_reviewer'), html_entity_decode($data['name'], ENT_QUOTES, 'UTF-8')) . "\n";
 			$message .= sprintf($this->language->get('text_rating'), $data['rating']) . "\n";
 			$message .= $this->language->get('text_review') . "\n";
 			$message .= html_entity_decode($data['text'], ENT_QUOTES, 'UTF-8') . "\n\n";
-
-			$mail = new Mail($this->config->get('config_mail_engine'));
-			$mail->parameter = $this->config->get('config_mail_parameter');
-			$mail->smtp_hostname = $this->config->get('config_mail_smtp_hostname');
-			$mail->smtp_username = $this->config->get('config_mail_smtp_username');
-			$mail->smtp_password = html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8');
-			$mail->smtp_port = $this->config->get('config_mail_smtp_port');
-			$mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
-
-			$mail->setTo($this->config->get('config_email'));
-			$mail->setFrom($this->config->get('config_email'));
-			$mail->setSender(html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8'));
-			$mail->setSubject($subject);
-			$mail->setText($message);
-			$mail->send();
+			
+			$this->load->model('tool/mail');
+			
+			$mail_data = array(
+				'subject'	=> sprintf($language->get('text_subject'), html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8')),
+				'text'		=> $message
+			);
+			
+			$this->model_tool_mail->sendMail($mail_data);
 
 			// Send to additional alert emails
 			$emails = explode(',', $this->config->get('config_mail_alert_email'));

--- a/upload/catalog/model/extension/openbay/ebay_order.php
+++ b/upload/catalog/model/extension/openbay/ebay_order.php
@@ -782,8 +782,6 @@ class ModelExtensionOpenBayEbayOrder extends Model{
 				$language->load($language_code);
 				$language->load('mail/order');
 
-				$subject = sprintf($language->get('text_update_subject'), html_entity_decode($order_info['store_name'], ENT_QUOTES, 'UTF-8'), $order_id);
-
 				$message  = $language->get('text_update_order') . ' ' . $order_id . "\n";
 				$message .= $language->get('text_update_date_added') . ' ' . date($language->get('date_format_short'), strtotime($order_info['date_added'])) . "\n\n";
 
@@ -808,22 +806,17 @@ class ModelExtensionOpenBayEbayOrder extends Model{
 
 				$message .= "\n\n";
 				$message .= 'eBay and Amazon order management - http://www.openbaypro.com/';
-
-				$mail = new Mail($this->config->get('config_mail_engine'));
-				$mail->protocol = $this->config->get('config_mail_protocol');
-				$mail->parameter = $this->config->get('config_mail_parameter');
-				$mail->smtp_hostname = $this->config->get('config_mail_smtp_hostname');
-				$mail->smtp_username = $this->config->get('config_mail_smtp_username');
-				$mail->smtp_password = html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8');
-				$mail->smtp_port = $this->config->get('config_mail_smtp_port');
-				$mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
-
-				$mail->setTo($order_info['email']);
-				$mail->setFrom($this->config->get('config_email'));
-				$mail->setSender(html_entity_decode($order_info['store_name'], ENT_QUOTES, 'UTF-8'));
-				$mail->setSubject(html_entity_decode($subject, ENT_QUOTES, 'UTF-8'));
-				$mail->setText($message);
-				$mail->send();
+		
+				$this->load->model('tool/mail');
+				
+				$mail_data = array(
+					'to'		=> $order_info['email'],
+					'sender'	=> $order_info['store_name'],
+					'subject'	=> sprintf($language->get('text_update_subject'), html_entity_decode($order_info['store_name'], ENT_QUOTES, 'UTF-8'), $order_id),
+					'text'		=> $message
+				);
+				
+				$this->model_tool_mail->sendMail($mail_data);
 			}
 		}
 	}
@@ -870,8 +863,6 @@ class ModelExtensionOpenBayEbayOrder extends Model{
 				} else {
 					$order_status = '';
 				}
-
-				$subject = sprintf($language->get('text_new_subject'), html_entity_decode($order_info['store_name'], ENT_QUOTES, 'UTF-8'), $order_id);
 
 				// HTML Mail
 				$data = array();
@@ -1081,21 +1072,17 @@ class ModelExtensionOpenBayEbayOrder extends Model{
 				$text .= $language->get('text_new_footer') . "\n\n";
 
 				if ($notify == 1) {
-					$mail = new Mail($this->config->get('config_mail_engine'));
-					$mail->parameter = $this->config->get('config_mail_parameter');
-					$mail->smtp_hostname = $this->config->get('config_mail_smtp_hostname');
-					$mail->smtp_username = $this->config->get('config_mail_smtp_username');
-					$mail->smtp_password = html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8');
-					$mail->smtp_port = $this->config->get('config_mail_smtp_port');
-					$mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
-
-					$mail->setTo($order_info['email']);
-					$mail->setFrom($this->config->get('config_email'));
-					$mail->setSender(html_entity_decode($order_info['store_name'], ENT_QUOTES, 'UTF-8'));
-					$mail->setSubject($subject);
-					$mail->setHtml($this->load->view('mail/order', $data));
-					$mail->setText($text);
-					$mail->send();
+					$this->load->model('tool/mail');
+					
+					$mail_data = array(
+						'to'		=> $order_info['email'],
+						'sender'	=> $order_info['store_name'],
+						'subject'	=> sprintf($language->get('text_new_subject'), html_entity_decode($order_info['store_name'], ENT_QUOTES, 'UTF-8'), $order_id),
+						'text'		=> $text,
+						'html'		=> $this->load->view('mail/order', $data)
+					);
+					
+					$this->model_tool_mail->sendMail($mail_data);
 				}
 			}
 		}

--- a/upload/catalog/model/extension/payment/amazon_login_pay.php
+++ b/upload/catalog/model/extension/payment/amazon_login_pay.php
@@ -27,8 +27,6 @@ class ModelExtensionPaymentAmazonLoginPay extends Model {
 
 		$this->load->language('mail/customer');
 
-		$subject = sprintf($this->language->get('text_subject'), html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8'));
-
 		$message = sprintf($this->language->get('text_welcome'), html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8')) . "\n\n";
 
 		if (!$customer_group_info['approval']) {
@@ -41,21 +39,16 @@ class ModelExtensionPaymentAmazonLoginPay extends Model {
 		$message .= $this->language->get('text_services') . "\n\n";
 		$message .= $this->language->get('text_thanks') . "\n";
 		$message .= html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8');
-
-		$mail = new Mail($this->config->get('config_mail_engine'));
-		$mail->parameter = $this->config->get('config_mail_parameter');
-		$mail->smtp_hostname = $this->config->get('config_mail_smtp_hostname');
-		$mail->smtp_username = $this->config->get('config_mail_smtp_username');
-		$mail->smtp_password = html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8');
-		$mail->smtp_port = $this->config->get('config_mail_smtp_port');
-		$mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
-
-		$mail->setTo($data['email']);
-		$mail->setFrom($this->config->get('config_email'));
-		$mail->setSender(html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8'));
-		$mail->setSubject($subject);
-		$mail->setText($message);
-		$mail->send();
+		
+		$this->load->model('tool/mail');
+		
+		$mail_data = array(
+			'to'		=> $data['email'],
+			'subject'	=> sprintf($this->language->get('text_subject'), html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8'),
+			'text'		=> $message
+		);
+		
+		$this->model_tool_mail->sendMail($mail_data);
 
 		// Send to main admin email if new account email is enabled
 		if (in_array('account', (array)$this->config->get('config_mail_alert'))) {
@@ -67,30 +60,13 @@ class ModelExtensionPaymentAmazonLoginPay extends Model {
 			$message .= $this->language->get('text_email') . ' '  .  $data['email'] . "\n";
 			$message .= $this->language->get('text_telephone') . ' ' . $data['telephone'] . "\n";
 
-			$mail = new Mail($this->config->get('config_mail_engine'));
-			$mail->parameter = $this->config->get('config_mail_parameter');
-			$mail->smtp_hostname = $this->config->get('config_mail_smtp_hostname');
-			$mail->smtp_username = $this->config->get('config_mail_smtp_username');
-			$mail->smtp_password = html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8');
-			$mail->smtp_port = $this->config->get('config_mail_smtp_port');
-			$mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
-
-			$mail->setTo($this->config->get('config_email'));
-			$mail->setFrom($this->config->get('config_email'));
-			$mail->setSender(html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8'));
-			$mail->setSubject(html_entity_decode($this->language->get('text_new_customer'), ENT_QUOTES, 'UTF-8'));
-			$mail->setText($message);
-			$mail->send();
-
-			// Send to additional alert emails if new account email is enabled
-			$emails = explode(',', $this->config->get('config_mail_alert_email'));
-
-			foreach ($emails as $email) {
-				if (utf8_strlen($email) > 0 && filter_var($email, FILTER_VALIDATE_EMAIL)) {
-					$mail->setTo($email);
-					$mail->send();
-				}
-			}
+			$mail_data = array(
+				'alerts'	=> true,
+				'subject'	=> $this->language->get('text_new_customer'),
+				'text'		=> $message
+			);
+			
+			$this->model_tool_mail->sendMail($mail_data);
 		}
 
 		return $customer_id;

--- a/upload/catalog/model/extension/payment/squareup.php
+++ b/upload/catalog/model/extension/payment/squareup.php
@@ -70,75 +70,37 @@ class ModelExtensionPaymentSquareup extends Model {
         if (!$this->mailResendPeriodExpired('token_expired')) {
             return;
         }
-
-        $mail = new Mail();
-
-        $mail->protocol = $this->config->get('config_mail_protocol');
-        $mail->parameter = $this->config->get('config_mail_parameter');
-
-        $mail->smtp_hostname = $this->config->get('config_mail_smtp_hostname');
-        $mail->smtp_username = $this->config->get('config_mail_smtp_username');
-        $mail->smtp_password = html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8');
-        $mail->smtp_port = $this->config->get('config_mail_smtp_port');
-        $mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
-
-        $subject = $this->language->get('text_token_expired_subject');
-        $message = $this->language->get('text_token_expired_message');
-
-        $mail->setTo($this->config->get('config_email'));
-        $mail->setFrom($this->config->get('config_email'));
-        $mail->setSender($this->config->get('config_name'));
-        $mail->setSubject(html_entity_decode($subject, ENT_QUOTES, 'UTF-8'));
-        $mail->setText(strip_tags($message));
-        $mail->setHtml($message);
-
-        $mail->send();
+		
+		$this->load->model('tool/mail');
+		
+		$mail_data = array(
+			'subject'	=> $this->language->get('text_token_expired_subject'),
+			'text'		=> strip_tags($this->language->get('text_token_expired_message')),
+			'html'		=> $this->language->get('text_token_expired_message')
+		);
+		
+		$this->model_tool_mail->sendMail($mail_data);
     }
 
     public function tokenRevokedEmail() {
         if (!$this->mailResendPeriodExpired('token_revoked')) {
             return;
         }
-
-        $mail = new Mail();
-
-        $mail->protocol = $this->config->get('config_mail_protocol');
-        $mail->parameter = $this->config->get('config_mail_parameter');
-
-        $mail->smtp_hostname = $this->config->get('config_mail_smtp_hostname');
-        $mail->smtp_username = $this->config->get('config_mail_smtp_username');
-        $mail->smtp_password = html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8');
-        $mail->smtp_port = $this->config->get('config_mail_smtp_port');
-        $mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
-
-        $subject = $this->language->get('text_token_revoked_subject');
-        $message = $this->language->get('text_token_revoked_message');
-
-        $mail->setTo($this->config->get('config_email'));
-        $mail->setFrom($this->config->get('config_email'));
-        $mail->setSender($this->config->get('config_name'));
-        $mail->setSubject(html_entity_decode($subject, ENT_QUOTES, 'UTF-8'));
-        $mail->setText(strip_tags($message));
-        $mail->setHtml($message);
-        
-        $mail->send();
+		
+		$this->load->model('tool/mail');
+		
+		$mail_data = array(
+			'subject'	=> $this->language->get('text_token_revoked_subject'),
+			'text'		=> strip_tags($this->language->get('text_token_revoked_message')),
+			'html'		=> $this->language->get('text_token_revoked_message')
+		);
+		
+		$this->model_tool_mail->sendMail($mail_data);
     }
 
     public function cronEmail($result) {
-        $mail = new Mail();
-        
-        $mail->protocol = $this->config->get('config_mail_protocol');
-        $mail->parameter = $this->config->get('config_mail_parameter');
-
-        $mail->smtp_hostname = $this->config->get('config_mail_smtp_hostname');
-        $mail->smtp_username = $this->config->get('config_mail_smtp_username');
-        $mail->smtp_password = html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8');
-        $mail->smtp_port = $this->config->get('config_mail_smtp_port');
-        $mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
 
         $br = '<br />';
-
-        $subject = $this->language->get('text_cron_subject');
 
         $message = $this->language->get('text_cron_message') . $br . $br;
 
@@ -171,14 +133,17 @@ class ModelExtensionPaymentSquareup extends Model {
                 $message .= sprintf($this->language->get('text_cron_success_charge'), $order_recurring_id, $amount) . $br;
             }
         }
-
-        $mail->setTo($this->config->get('payment_squareup_cron_email'));
-        $mail->setFrom($this->config->get('config_email'));
-        $mail->setSender($this->config->get('config_name'));
-        $mail->setSubject(html_entity_decode($subject, ENT_QUOTES, 'UTF-8'));
-        $mail->setText(strip_tags($message));
-        $mail->setHtml($message);
-        $mail->send();
+		
+		$this->load->model('tool/mail');
+		
+		$mail_data = array(
+			'to'		=> $this->config->get('payment_squareup_cron_email'),
+			'subject'	=> $this->language->get('text_cron_subject'),
+			'text'		=> strip_tags($message),
+			'html'		=> $message
+		);
+		
+		$this->model_tool_mail->sendMail($mail_data);
     }
 
     public function recurringPayments() {

--- a/upload/catalog/model/tool/mail.php
+++ b/upload/catalog/model/tool/mail.php
@@ -1,0 +1,83 @@
+<?php
+class ModelToolMail extends Model {
+	public function sendMail($data) {
+		
+		$defaults = array(
+			'config_mail_engine'		=> $this->config->get('config_mail_engine'),
+			'config_mail_parameter'		=> $this->config->get('config_mail_parameter'),
+			'config_mail_smtp_hostname'	=> $this->config->get('config_mail_smtp_hostname'),
+			'config_mail_smtp_username'	=> $this->config->get('config_mail_smtp_username'),
+			'config_mail_smtp_password'	=> html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8'),
+			'config_mail_smtp_port'		=> $this->config->get('config_mail_smtp_port'),
+			'config_mail_smtp_timeout'	=> $this->config->get('config_mail_smtp_timeout'),
+			'to'						=> $this->config->get('config_email'),
+			'from'						=> $this->config->get('config_email'),
+			'alerts'					=> false,
+			'reply_to'					=> false,
+			'sender'					=> $this->config->get('config_name'),
+			'subject'					=> false,
+			'text'						=> false,
+			'html'						=> false,
+			'attachments'				=> array(),
+		);
+		
+		foreach($defaults as $k => $v) {
+			if (!isset($data[$k])) {
+				$data[$k] = $v;
+			}
+		}
+		
+		if (strstr($this->config->get('config_mail_smtp_hostname'),'@') && filter_var($email, FILTER_VALIDATE_EMAIL)) {
+			$data['from'] = $this->config->get('config_mail_smtp_hostname');
+			if (!$data['reply_to']) {
+				$data['reply_to'] = $data['from'];
+			}
+		}
+		
+		$mail = new Mail($data['config_mail_engine']);
+		$mail->parameter = $data['config_mail_parameter'];
+		$mail->smtp_hostname = $data['config_mail_smtp_hostname'];
+		$mail->smtp_username = $data['config_mail_smtp_username'];
+		$mail->smtp_password = html_entity_decode($data['config_mail_smtp_password'], ENT_QUOTES, 'UTF-8');
+		$mail->smtp_port = $data['config_mail_smtp_port'];
+		$mail->smtp_timeout = $data['config_mail_smtp_timeout'];
+
+		$mail->setTo($data['config_email']);
+		$mail->setFrom($data['config_email']);
+		
+		if ($data['reply_to']) {
+			$mail->setReplyTo($data['reply_to']);
+		}
+		
+		$mail->setSender(html_entity_decode($data['sender'], ENT_QUOTES, 'UTF-8'));
+		$mail->setSubject(html_entity_decode($data['subject'], ENT_QUOTES, 'UTF-8'));
+		
+		if ($data['text']) {
+			$mail->setText($data['text']);
+		}
+		
+		if ($data['html']) {
+			$mail->setHtml($data['html']);
+		}
+		
+		if ($data['attachments']) {
+			foreach($data['attachments'] as $attachment) {
+				$mail->addAttachment($attachment);
+			}
+		}
+		
+		$mail->send();
+		
+		if ($data['alerts']) {
+			// Send to additional alert emails
+			$emails = explode(',', $this->config->get('config_mail_alert_email'));
+
+			foreach ($emails as $email) {
+				if (utf8_strlen($email) > 0 && filter_var($email, FILTER_VALIDATE_EMAIL)) {
+					$mail->setTo($email);
+					$mail->send();
+				}
+			}
+		}
+	}
+}

--- a/upload/catalog/model/tool/mail.php
+++ b/upload/catalog/model/tool/mail.php
@@ -27,8 +27,8 @@ class ModelToolMail extends Model {
 			}
 		}
 		
-		if (strstr($this->config->get('config_mail_smtp_hostname'),'@') && filter_var($email, FILTER_VALIDATE_EMAIL)) {
-			$data['from'] = $this->config->get('config_mail_smtp_hostname');
+		if (strstr($this->config->get('config_mail_smtp_username'),'@') && filter_var($email, FILTER_VALIDATE_EMAIL)) {
+			$data['from'] = $this->config->get('config_mail_smtp_username');
 			if (!$data['reply_to']) {
 				$data['reply_to'] = $data['from'];
 			}

--- a/upload/system/library/mail/smtp.php
+++ b/upload/system/library/mail/smtp.php
@@ -26,22 +26,26 @@ class Smtp {
 		$header .= 'To: <' . $to . '>' . PHP_EOL;
 		$header .= 'Subject: =?UTF-8?B?' . base64_encode($this->subject) . '?=' . PHP_EOL;
 		$header .= 'Date: ' . date('D, d M Y H:i:s O') . PHP_EOL;
-		$header .= 'From: =?UTF-8?B?' . base64_encode($this->sender) . '?= <' . $this->from . '>' . PHP_EOL;
 		
+		$return_path = $this->from;
+			
+		if (strstr($this->smtp_username,'@') && filter_var($this->smtp_username, FILTER_VALIDATE_EMAIL)) {
+			// Presume username is the fully qualified email address that we are actually sending the email from
+			$from = $this->smtp_username;
+			$this->reply_to = $this->from;
+			$return_path = $from;
+		}
+			
 		if (!$this->reply_to) {
-			$header .= 'From: =?UTF-8?B?' . base64_encode($this->sender) . '?=' . ' <' . $this->from . '>' . $this->newline;
-			$header .= 'Reply-To: =?UTF-8?B?' . base64_encode($this->sender) . '?=' . ' <' . $this->from . '>' . $this->newline;
+			$header .= 'From: =?UTF-8?B?' . base64_encode($this->sender) . '?=' . ' <' . $this->from . '>' . PHP_EOL;
+			$header .= 'Reply-To: =?UTF-8?B?' . base64_encode($this->sender) . '?=' . ' <' . $this->from . '>' . PHP_EOL;
 		} else {
-			if (strstr($this->smtp_username,'@') && filter_var($this->smtp_username, FILTER_VALIDATE_EMAIL)) {
-				// Presume username is the fully qualified email address that we are actually sending the email from
-				$to = $this->smtp_username;
-			}
-			$header .= 'From: =?UTF-8?B?' . base64_encode($this->sender) . '?=' . ' <' . $to . '>' . $this->newline;
-			$header .= 'Reply-To: =?UTF-8?B?' . base64_encode($this->reply_to) . '?=' . ' <' . $this->reply_to . '>' . $this->newline;
+			$header .= 'From: =?UTF-8?B?' . base64_encode($this->sender) . '?=' . ' <' . $from . '>' . PHP_EOL;
+			$header .= 'Reply-To: =?UTF-8?B?' . base64_encode($this->reply_to) . '?=' . ' <' . $this->reply_to . '>' . PHP_EOL;
 		}
 		
 		if ($cc) {
-			$header .= 'Cc: ' . $to . $this->newline;
+			$header .= 'Cc: ' . $cc . PHP_EOL;
 		}
 		
 		$header .= 'Return-Path: ' . $this->from . PHP_EOL;

--- a/upload/system/library/mail/smtp.php
+++ b/upload/system/library/mail/smtp.php
@@ -48,7 +48,7 @@ class Smtp {
 			$header .= 'Cc: ' . $cc . PHP_EOL;
 		}
 		
-		$header .= 'Return-Path: ' . $this->from . PHP_EOL;
+		$header .= 'Return-Path: ' . $return_path . PHP_EOL;
 		$header .= 'X-Mailer: PHP/' . phpversion() . PHP_EOL;
 		$header .= 'Content-Type: multipart/mixed; boundary="' . $boundary . '"' . PHP_EOL . PHP_EOL;
 

--- a/upload/system/library/openbay.php
+++ b/upload/system/library/openbay.php
@@ -245,31 +245,16 @@ final class Openbay {
 			$text .= $order_info['comment'] . "\n\n";
 		}
 
-		$mail = new \Mail();
-		$mail->protocol = $this->config->get('config_mail_protocol');
-		$mail->parameter = $this->config->get('config_mail_parameter');
-		$mail->smtp_hostname = $this->config->get('config_mail_smtp_hostname');
-		$mail->smtp_username = $this->config->get('config_mail_smtp_username');
-		$mail->smtp_password = html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8');
-		$mail->smtp_port = $this->config->get('config_mail_smtp_port');
-		$mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
-
-		$mail->setTo($this->config->get('config_email'));
-		$mail->setFrom($this->config->get('config_email'));
-		$mail->setSender(html_entity_decode($order_info['store_name'], ENT_QUOTES, 'UTF-8'));
-		$mail->setSubject($subject);
-		$mail->setText($text);
-		$mail->send();
-
-		// Send to additional alert emails
-		$emails = explode(',', $this->config->get('config_mail_alert_email'));
-
-		foreach ($emails as $email) {
-			if ($email && filter_var($email, FILTER_VALIDATE_EMAIL)) {
-				$mail->setTo($email);
-				$mail->send();
-			}
-		}
+		$this->load->model('tool/mail');
+		
+		$mail_data = array(
+			'alerts'	=> true,
+			'sender'	=> $order_info['store_name'],
+			'subject'	=> $subject,
+			'text'		=> $text
+		);
+		
+		$this->model_tool_mail->sendMail($mail_data);
 	}
 
 	public function orderDelete($order_id) {

--- a/upload/system/library/openbay/ebay.php
+++ b/upload/system/library/openbay/ebay.php
@@ -366,21 +366,15 @@ final class Ebay {
 	public function notifyAdmin($subject, $message) {
 		$this->log('Sending email to: ' . $this->config->get('config_email') . ' - notifyAdmin()');
 
-		$mail = new \Mail();
-		$mail->protocol = $this->config->get('config_mail_protocol');
-		$mail->parameter = $this->config->get('config_mail_parameter');
-		$mail->smtp_hostname = $this->config->get('config_mail_smtp_hostname');
-		$mail->smtp_username = $this->config->get('config_mail_smtp_username');
-		$mail->smtp_password = html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES, 'UTF-8');
-		$mail->smtp_port = $this->config->get('config_mail_smtp_port');
-		$mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
 
-		$mail->setTo($this->config->get('config_email'));
-		$mail->setFrom($this->config->get('config_email'));
-		$mail->setSender(html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8'));
-		$mail->setSubject(html_entity_decode($subject, ENT_QUOTES, 'UTF-8'));
-		$mail->setText($message);
-		$mail->send();
+		$this->load->model('tool/mail');
+		
+		$mail_data = array(
+			'subject'	=> $subject,
+			'text'		=> $message
+		);
+		
+		$this->model_tool_mail->sendMail($mail_data);
 	}
 
 	public function validateJsonDecode($data) {


### PR DESCRIPTION
Creates a centralized email delivery function. This function does most of the leg work in sending the email through the mail library.

It will attempt to auto correct email headers for from, reply_to, cc, to.

Issue arises when sending SMTP email. Most providers will not allow the FROM header to be anything other than the logged in SMTP user. Thus this patch sets the FROM to be that of the SMTP username if it qualifies as a full email (as most services require). The reply_to header is automatically set to the original FROM header.