### PR TITLE
Fix HTTPS issue admin order edit. Change API URL based on request admin URL

### DIFF
--- a/upload/admin/controller/sale/order.php
+++ b/upload/admin/controller/sale/order.php
@@ -371,7 +371,7 @@ class ControllerSaleOrder extends Controller {
 		$data['order_statuses'] = $this->model_localisation_order_status->getOrderStatuses();
 
 		// API login
-		$data['catalog'] = HTTP_CATALOG;
+		$data['catalog'] = $this->request->server['HTTPS'] ? HTTPS_CATALOG : HTTP_CATALOG;
 		
 		// API login
 		$this->load->model('user/api');
@@ -679,7 +679,7 @@ class ControllerSaleOrder extends Controller {
 		$data['voucher_themes'] = $this->model_sale_voucher_theme->getVoucherThemes();
 
 		// API login
-		$data['catalog'] = HTTP_CATALOG;
+		$data['catalog'] = $this->request->server['HTTPS'] ? HTTPS_CATALOG : HTTP_CATALOG;
 		
 		// API login
 		$this->load->model('user/api');
@@ -1222,7 +1222,7 @@ class ControllerSaleOrder extends Controller {
 			}
 			
 			// The URL we send API requests to
-			$data['catalog'] = HTTP_CATALOG;
+			$data['catalog'] = $this->request->server['HTTPS'] ? HTTPS_CATALOG : HTTP_CATALOG;
 			
 			// API login
 			$this->load->model('user/api');


### PR DESCRIPTION
Fixes error:
Mixed Content: The page at 'https://www.example.com/admin/index.php?route=sale/order/add&user_token=123' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://www.example.com/index.php?route=api/currency&api_token=123&store_id=0'. This request has been blocked; the content must be served over HTTPS