### PR TITLE
Fix missing language load in function send

### DIFF
--- a/upload/admin/controller/sale/voucher.php
+++ b/upload/admin/controller/sale/voucher.php
@@ -567,6 +567,8 @@ class ControllerSaleVoucher extends Controller {
 			}
 
 			if ($vouchers) {
+				$this->load->language('sale/voucher');
+				
 				foreach ($vouchers as $voucher_id) {
 					$voucher_info = $this->model_sale_voucher->getVoucher($voucher_id);
 			


### PR DESCRIPTION
When sending a voucher from the administration, the translation key appears:

![image](https://user-images.githubusercontent.com/408546/37208384-8f0aae7c-23a1-11e8-83d8-d57a3ac705bc.png)
