### PR TITLE
Ocmod should allow more than one install.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@
 
 # IDE Project files
 /.idea
+/.settings

--- a/upload/admin/language/en-gb/marketplace/install.php
+++ b/upload/admin/language/en-gb/marketplace/install.php
@@ -4,7 +4,16 @@ $_['text_success']     = 'Success: You have modified extensions!';
 $_['text_unzip']       = 'Extracting files!';
 $_['text_move']        = 'Copying files!';
 $_['text_xml']         = 'Applying modifications!';
+$_['text_xmls']        = 'Installing additional xmls';
 $_['text_clear']       = 'Clearing temporary files!';
+
+
+$_['column_name']      = 'Compatibility Name';
+$_['column_comments']  = 'Comments';
+$_['column_optional']  = 'Optional';
+$_['help_additional']  = 'Install all optional xmls you wish to add.';
+$_['text_additional']  = 'Additional xmls/modifications';
+$_['text_no_optional_modifications'] = 'No optional modifications to install';
 
 // Error
 $_['error_permission'] = 'Warning: You do not have permission to modify extensions!';

--- a/upload/admin/view/template/marketplace/installer.twig
+++ b/upload/admin/view/template/marketplace/installer.twig
@@ -122,7 +122,7 @@ function next(url, i) {
 		url: url,
 		dataType: 'json',
 		success: function(json) {
-			$('#progress-bar').css('width', (i * 20) + '%');
+			$('#progress-bar').css('width', (i * 16.66) + '%');
 
 			if (json['error']) {
 				$('#progress-bar').addClass('progress-bar-danger');
@@ -143,9 +143,19 @@ function next(url, i) {
 			if (json['text']) {
 				$('#progress-text').html(json['text']);
 			}
-
+			
+			if(json['xmls']){
+				$("#modal-xmls").remove();
+				$('body').append(json['xmls']);
+				$('#modal-xmls').modal('show');										
+			}
+			
 			if (json['next']) {
-				next(json['next'], i);
+				if(json['next'] == 'additional'){
+					additional(json['additional']);
+				}else{
+					next(json['next'], i);
+				}
 			}
 		},
 		error: function(xhr, ajaxOptions, thrownError) {
@@ -154,6 +164,43 @@ function next(url, i) {
 	});
 }
 
+function additional(additional){
+	$.ajax({
+		url: additional,
+		type: 'get',
+		dataType: 'html',
+		success: function(data) {
+			$("#modal-xmls").remove();
+			$('body').append(data);
+			$('#modal-xmls').modal('show');
+		}
+	});
+}
+
+function installxmls(additional){
+	$.ajax({
+		url: additional,
+        type: 'post',
+        data: $("#additional_xmls").serialize(),
+        dataType: 'json',
+		success: function(json) {
+			if (json['error']) {
+				$('#progress-bar').addClass('progress-bar-danger');
+				$('#progress-text').html('<div class="invalid-tooltip">' + json['error'] + '</div>');
+
+				$('#button-upload').button('reset');
+			}
+			if (json['text']) {
+				$('#progress-text').html(json['text']);
+			}			
+			$('#modal-xmls').modal('hide');
+			$('#modal-xmls').remove();
+			if (json['next']) {
+				next(json['next'], 6);
+			}
+		}
+	});
+}
 // Uninstall
 $('#history').on('click', '.btn-danger', function(e) {
 	e.preventDefault();

--- a/upload/admin/view/template/marketplace/xmls.twig
+++ b/upload/admin/view/template/marketplace/xmls.twig
@@ -1,0 +1,69 @@
+<div id="modal-xmls" class="modal">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">{{ text_additional }}</h5>
+      </div>
+      <div class="modal-body">
+        <div class="alert alert-info"><i class="fa fa-exclamation-circle"></i> {{ help_additional }}</div>
+        <form role="form" id="additional_xmls" autocomplete="off" method="post" novalidate enctype="multipart/form-data">        
+          <fieldset>
+            <legend>{{ text_choose }}</legend>
+            {% if modifications %}
+            	<div class="row">
+                    <div class="col-sm-12">                    	
+                    	<div class="table-responsive">
+                            <table class="table table-bordered table-hover">
+                              <thead>
+                                <tr>
+                                  <td style="width: 1px;" class="text-center"><input type="checkbox" onclick="$('input[name*=\'selected\']').trigger('click');"/></td>
+                                  
+                                  <td class="text-left">{{ column_name }}</td>
+                                  <td class="text-left">{{ column_optional }}</td>
+                                  <td class="text-left">{{ column_comments }}</td>                 
+                                </tr>
+                              </thead>
+                              <tbody>
+                                  {% for modification in modifications %}
+                                    <tr>
+                                      <td class="text-center">{% if not modification.optional %}
+                                          <input type="checkbox" name="selected[]" value="{{ modification.file }}" disabled="disabled" checked="checked"/>
+                                        {% else %}
+                                          <input type="checkbox" name="selected[]" value="{{ modification.file }}"/>
+                                        {% endif %}</td>
+                                      <td class="text-left">{{ modification.name }}</td>
+                                      <td class="text-left">{{   modification.optional? text_yes: text_no }}</td>
+                                      <td class="text-left">{{ modification.comments }}</td>
+                                     </tr>
+                                  {% endfor %}                
+                              </tbody>
+                            </table>
+                        </div>
+                	</div>
+                	<div class="buttons col-sm-12">                    	
+                		<div class="pull-left">
+                			<button onclick="$('#modal-xmls').modal('hide');$('#modal-xmls').remove();next('{{ clear }}',6);" type="button" id="button-xmls-cancel" data-loading="{{ text_loading }}" class="btn btn-info">{{ button_cancel }}</button>
+                		</div>
+                		<div class="pull-right">
+                        	<button onclick="installxmls('{{ install }}');" type="button" id="button-xmls" data-loading="{{ text_loading }}" class="btn btn-primary">{{ button_install }}</button>
+    	            	</div>
+    	            	<div class="clearfix"></div>
+                	</div>
+                </div>
+                {%  else %}
+                <div class="row">
+                <div class="col-sm-12">
+                <div class="alert alert-danger">{{ text_no_optional_modifications }}</div>
+                <div class="text-center">
+                	<button onclick="$('#modal-xmls').modal('hide');$('#modal-xmls').remove();next('{{ clear }}',6);" type="button" id="button-xmls-cancel" data-loading="{{ text_loading }}" class="btn btn-info">{{ button_close }}</button>
+                </div> 
+                <div class="clearfix"></div>              
+                </div>
+                </div>
+                {% endif %}
+            </fieldset>
+         </form>
+		</div>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
Ocmod should allow more than one install.xml files, maybe getting away from naming convention install.xml and should support any name ending with .ocmod.xml

Reasoning: Most of the modules that we create need to give compatibility for other addons. Like a checkout module which modifies many files will have their own install.xml but they may want to add a compatibility for other developers module like abandonedcart, smsshare, postcode manager, gift wraps, shippingpros etc. We can not put these changes in main install.xml because not all customers will have these running on their store. So we need to put these in zip folder along with install.xml and name them compatibility_abaondonedcart.ocmod.xml, compatibility_xshippingpro.ocmod.xml extra. The extension installer can prompt user that which files they need to install along. 

In current system this can be achieved by adding a new zip file named compatibile_addons.zip which user can install manually, but looking at how marketplace installation works online in version above 3.x, it will require us to create as many zip files for each xml. And when you have just one file in zip. The opencart system does not approve the zip file because of its very small size(thats what I have seen when I uploaded one separate zip that contains changelog, installation and licensing file).

Original discussion: https://forum.opencart.com/viewtopic.php?f=110&t=200631

One ocmod file attached for testing. [testing.ocmod.zip](https://github.com/opencart/opencart/files/1810531/testing.ocmod.zip)