### PR TITLE
issue required class added to <fieldset>

### DIFF
--- a/upload/catalog/view/theme/default/template/checkout/guest.twig
+++ b/upload/catalog/view/theme/default/template/checkout/guest.twig
@@ -479,9 +479,9 @@ $('#collapse-payment-address select[name=\'country_id\']').on('change', function
 		},
 		success: function(json) {
 			if (json['postcode_required'] == '1') {
-				$('#collapse-payment-address input[name=\'postcode\']').parent().parent().addClass('required');
+				$('#collapse-payment-address input[name=\'postcode\']').parent().addClass('required');
 			} else {
-				$('#collapse-payment-address input[name=\'postcode\']').parent().parent().removeClass('required');
+				$('#collapse-payment-address input[name=\'postcode\']').parent().removeClass('required');
 			}
 
 			html = '<option value="">{{ text_select }}</option>';


### PR DESCRIPTION
.parent().parent() adds ".required" class to wrong container <fieldset id="address"> instead of <div class="form-group">