### PR TITLE
Update modification.php

### DIFF
--- a/upload/admin/controller/marketplace/modification.php
+++ b/upload/admin/controller/marketplace/modification.php
@@ -327,7 +327,11 @@ class ControllerMarketplaceModification extends Controller {
 										} else {
 											$search = trim($operation->getElementsByTagName('search')->item(0)->textContent);
 											$limit = $operation->getElementsByTagName('search')->item(0)->getAttribute('limit');
-											$replace = trim($operation->getElementsByTagName('add')->item(0)->textContent);
+											$trim = $operation->getElementsByTagName('add')->item(0)->getAttribute('trim');
+											$replace = $operation->getElementsByTagName('add')->item(0)->textContent;
+											if ($trim == 'true') {
+												$replace = trim($replace);
+											}
 
 											// Limit
 											if (!$limit) {


### PR DESCRIPTION
Enable trim attribute for regex replacement.  It makes sense to ignore this for the regex itself, but it's not a problem to leave replacement content untrimmed.