### PR TITLE
Escape XML entities in Google Sitemaps

### DIFF
--- a/upload/catalog/controller/extension/feed/google_sitemap.php
+++ b/upload/catalog/controller/extension/feed/google_sitemap.php
@@ -1,5 +1,19 @@
 <?php
 class ControllerExtensionFeedGoogleSitemap extends Controller {
+
+    private function xml_entities($string) {
+        return strtr(
+            $string, 
+            array(
+                "<" => "&lt;",
+                ">" => "&gt;",
+                '"' => "&quot;",
+                "'" => "&apos;",
+                "&" => "&amp;",
+            )
+        );
+    }
+
 	public function index() {
 		if ($this->config->get('feed_google_sitemap_status')) {
 			$output  = '<?xml version="1.0" encoding="UTF-8"?>';
@@ -12,20 +26,20 @@ class ControllerExtensionFeedGoogleSitemap extends Controller {
 
 			foreach ($products as $product) {
 				if ($product['image']) {
+                    $name  = $this->xml_entities($product['name']);
 					$output .= '<url>';
-					$output .= '  <loc>' . $this->url->link('product/product', 'language=' . $this->config->get('config_language') . '&product_id=' . $product['product_id']) . '</loc>';
-					$output .= '  <changefreq>weekly</changefreq>';
+					$output .= '  <loc>' . $this->url->link('product/product', 'product_id=' . $product['product_id']) . '</loc>';
+					$output .= ' <changefreq>weekly</changefreq>';
 					$output .= '  <lastmod>' . date('Y-m-d\TH:i:sP', strtotime($product['date_modified'])) . '</lastmod>';
 					$output .= '  <priority>1.0</priority>';
 					$output .= '  <image:image>';
 					$output .= '  <image:loc>' . $this->model_tool_image->resize($product['image'], $this->config->get('theme_' . $this->config->get('config_theme') . '_image_popup_width'), $this->config->get('theme_' . $this->config->get('config_theme') . '_image_popup_height')) . '</image:loc>';
-					$output .= '  <image:caption>' . $product['name'] . '</image:caption>';
-					$output .= '  <image:title>' . $product['name'] . '</image:title>';
+					$output .= '  <image:caption>' . $name . '</image:caption>';
+					$output .= '  <image:title>' . $name . '</image:title>';
 					$output .= '  </image:image>';
 					$output .= '</url>';
 				}
 			}
-
 			$this->load->model('catalog/category');
 
 			$output .= $this->getCategories(0);
@@ -36,7 +50,7 @@ class ControllerExtensionFeedGoogleSitemap extends Controller {
 
 			foreach ($manufacturers as $manufacturer) {
 				$output .= '<url>';
-				$output .= '  <loc>' . $this->url->link('product/manufacturer/info', 'language=' . $this->config->get('config_language') . '&manufacturer_id=' . $manufacturer['manufacturer_id']) . '</loc>';
+				$output .= '  <loc>' . $this->url->link('product/manufacturer/info', 'manufacturer_id=' . $manufacturer['manufacturer_id']) . '</loc>';
 				$output .= '  <changefreq>weekly</changefreq>';
 				$output .= '  <priority>0.7</priority>';
 				$output .= '</url>';
@@ -45,7 +59,7 @@ class ControllerExtensionFeedGoogleSitemap extends Controller {
 
 				foreach ($products as $product) {
 					$output .= '<url>';
-					$output .= '  <loc>' . $this->url->link('product/product', 'language=' . $this->config->get('config_language') . '&manufacturer_id=' . $manufacturer['manufacturer_id'] . '&product_id=' . $product['product_id']) . '</loc>';
+					$output .= '  <loc>' . $this->url->link('product/product', 'manufacturer_id=' . $manufacturer['manufacturer_id'] . '&product_id=' . $product['product_id']) . '</loc>';
 					$output .= '  <changefreq>weekly</changefreq>';
 					$output .= '  <priority>1.0</priority>';
 					$output .= '</url>';
@@ -58,7 +72,7 @@ class ControllerExtensionFeedGoogleSitemap extends Controller {
 
 			foreach ($informations as $information) {
 				$output .= '<url>';
-				$output .= '  <loc>' . $this->url->link('information/information', 'language=' . $this->config->get('config_language') . '&information_id=' . $information['information_id']) . '</loc>';
+				$output .= '  <loc>' . $this->url->link('information/information', 'information_id=' . $information['information_id']) . '</loc>';
 				$output .= '  <changefreq>weekly</changefreq>';
 				$output .= '  <priority>0.5</priority>';
 				$output .= '</url>';
@@ -84,7 +98,7 @@ class ControllerExtensionFeedGoogleSitemap extends Controller {
 			}
 
 			$output .= '<url>';
-			$output .= '  <loc>' . $this->url->link('product/category', 'language=' . $this->config->get('config_language') . '&path=' . $new_path) . '</loc>';
+			$output .= '  <loc>' . $this->url->link('product/category', 'path=' . $new_path) . '</loc>';
 			$output .= '  <changefreq>weekly</changefreq>';
 			$output .= '  <priority>0.7</priority>';
 			$output .= '</url>';
@@ -93,7 +107,7 @@ class ControllerExtensionFeedGoogleSitemap extends Controller {
 
 			foreach ($products as $product) {
 				$output .= '<url>';
-				$output .= '  <loc>' . $this->url->link('product/product', 'language=' . $this->config->get('config_language') . '&path=' . $new_path . '&product_id=' . $product['product_id']) . '</loc>';
+				$output .= '  <loc>' . $this->url->link('product/product', 'path=' . $new_path . '&product_id=' . $product['product_id']) . '</loc>';
 				$output .= '  <changefreq>weekly</changefreq>';
 				$output .= '  <priority>1.0</priority>';
 				$output .= '</url>';

--- a/upload/catalog/controller/extension/feed/google_sitemap.php
+++ b/upload/catalog/controller/extension/feed/google_sitemap.php
@@ -26,7 +26,7 @@ class ControllerExtensionFeedGoogleSitemap extends Controller {
 
 			foreach ($products as $product) {
 				if ($product['image']) {
-                    $name = $product['name'];
+                    $name = xml_entities($product['name']);
 					$output .= '<url>';
 					$output .= '  <loc>' . $this->url->link('product/product', 'language=' . $this->config->get('config_language') . '&product_id=' . $product['product_id']) . '</loc>';
 					$output .= '  <changefreq>weekly</changefreq>';

--- a/upload/catalog/controller/extension/feed/google_sitemap.php
+++ b/upload/catalog/controller/extension/feed/google_sitemap.php
@@ -26,20 +26,21 @@ class ControllerExtensionFeedGoogleSitemap extends Controller {
 
 			foreach ($products as $product) {
 				if ($product['image']) {
-                    $name  = $this->xml_entities($product['name']);
+                    $name = $product['name'];
 					$output .= '<url>';
-					$output .= '  <loc>' . $this->url->link('product/product', 'product_id=' . $product['product_id']) . '</loc>';
-					$output .= ' <changefreq>weekly</changefreq>';
+					$output .= '  <loc>' . $this->url->link('product/product', 'language=' . $this->config->get('config_language') . '&product_id=' . $product['product_id']) . '</loc>';
+					$output .= '  <changefreq>weekly</changefreq>';
 					$output .= '  <lastmod>' . date('Y-m-d\TH:i:sP', strtotime($product['date_modified'])) . '</lastmod>';
 					$output .= '  <priority>1.0</priority>';
 					$output .= '  <image:image>';
 					$output .= '  <image:loc>' . $this->model_tool_image->resize($product['image'], $this->config->get('theme_' . $this->config->get('config_theme') . '_image_popup_width'), $this->config->get('theme_' . $this->config->get('config_theme') . '_image_popup_height')) . '</image:loc>';
-					$output .= '  <image:caption>' . $name . '</image:caption>';
+					$output .= '  <image:caption>' . $name. '</image:caption>';
 					$output .= '  <image:title>' . $name . '</image:title>';
 					$output .= '  </image:image>';
 					$output .= '</url>';
 				}
 			}
+
 			$this->load->model('catalog/category');
 
 			$output .= $this->getCategories(0);
@@ -50,7 +51,7 @@ class ControllerExtensionFeedGoogleSitemap extends Controller {
 
 			foreach ($manufacturers as $manufacturer) {
 				$output .= '<url>';
-				$output .= '  <loc>' . $this->url->link('product/manufacturer/info', 'manufacturer_id=' . $manufacturer['manufacturer_id']) . '</loc>';
+				$output .= '  <loc>' . $this->url->link('product/manufacturer/info', 'language=' . $this->config->get('config_language') . '&manufacturer_id=' . $manufacturer['manufacturer_id']) . '</loc>';
 				$output .= '  <changefreq>weekly</changefreq>';
 				$output .= '  <priority>0.7</priority>';
 				$output .= '</url>';
@@ -59,7 +60,7 @@ class ControllerExtensionFeedGoogleSitemap extends Controller {
 
 				foreach ($products as $product) {
 					$output .= '<url>';
-					$output .= '  <loc>' . $this->url->link('product/product', 'manufacturer_id=' . $manufacturer['manufacturer_id'] . '&product_id=' . $product['product_id']) . '</loc>';
+					$output .= '  <loc>' . $this->url->link('product/product', 'language=' . $this->config->get('config_language') . '&manufacturer_id=' . $manufacturer['manufacturer_id'] . '&product_id=' . $product['product_id']) . '</loc>';
 					$output .= '  <changefreq>weekly</changefreq>';
 					$output .= '  <priority>1.0</priority>';
 					$output .= '</url>';
@@ -72,7 +73,7 @@ class ControllerExtensionFeedGoogleSitemap extends Controller {
 
 			foreach ($informations as $information) {
 				$output .= '<url>';
-				$output .= '  <loc>' . $this->url->link('information/information', 'information_id=' . $information['information_id']) . '</loc>';
+				$output .= '  <loc>' . $this->url->link('information/information', 'language=' . $this->config->get('config_language') . '&information_id=' . $information['information_id']) . '</loc>';
 				$output .= '  <changefreq>weekly</changefreq>';
 				$output .= '  <priority>0.5</priority>';
 				$output .= '</url>';
@@ -98,7 +99,7 @@ class ControllerExtensionFeedGoogleSitemap extends Controller {
 			}
 
 			$output .= '<url>';
-			$output .= '  <loc>' . $this->url->link('product/category', 'path=' . $new_path) . '</loc>';
+			$output .= '  <loc>' . $this->url->link('product/category', 'language=' . $this->config->get('config_language') . '&path=' . $new_path) . '</loc>';
 			$output .= '  <changefreq>weekly</changefreq>';
 			$output .= '  <priority>0.7</priority>';
 			$output .= '</url>';
@@ -107,7 +108,7 @@ class ControllerExtensionFeedGoogleSitemap extends Controller {
 
 			foreach ($products as $product) {
 				$output .= '<url>';
-				$output .= '  <loc>' . $this->url->link('product/product', 'path=' . $new_path . '&product_id=' . $product['product_id']) . '</loc>';
+				$output .= '  <loc>' . $this->url->link('product/product', 'language=' . $this->config->get('config_language') . '&path=' . $new_path . '&product_id=' . $product['product_id']) . '</loc>';
 				$output .= '  <changefreq>weekly</changefreq>';
 				$output .= '  <priority>1.0</priority>';
 				$output .= '</url>';


### PR DESCRIPTION
I have a lot of products with `&` in the name and was surprised to get an invalid Google Sitemap from the extension because it didn't escape it or many other characters. This is a quick and dirty fix to make it work.