### PR TITLE
do not hardcode decimal places in pp_express currency

### DIFF
--- a/upload/catalog/model/extension/payment/pp_express.php
+++ b/upload/catalog/model/extension/payment/pp_express.php
@@ -82,7 +82,7 @@ class ModelExtensionPaymentPPExpress extends Model {
 			$data['L_PAYMENTREQUEST_0_NUMBER' . $i] = $item['model'];
 			$data['L_PAYMENTREQUEST_0_AMT' . $i] = $item_price;
 
-			$item_total += number_format($item_price * $item['quantity'], 2, '.', '');
+			$item_total += $this->currency->format($item_price * $item['quantity'], $this->session->data['currency'], false, false);
 
 			$data['L_PAYMENTREQUEST_0_QTY' . $i] = (int)$item['quantity'];
 
@@ -179,8 +179,8 @@ class ModelExtensionPaymentPPExpress extends Model {
 			}
 		}
 
-		$data['PAYMENTREQUEST_0_ITEMAMT'] = number_format($item_total, 2, '.', '');
-		$data['PAYMENTREQUEST_0_AMT'] = number_format($item_total, 2, '.', '');
+		$data['PAYMENTREQUEST_0_ITEMAMT'] = $this->currency->format($item_total, $this->session->data['currency'], false, false);
+		$data['PAYMENTREQUEST_0_AMT'] = $this->currency->format($item_total, $this->session->data['currency'], false, false);
 
 		$z = 0;
 


### PR DESCRIPTION
The pull request eliminates cases when a currency uses more than 2 decimal places (such as XBT) which would make the calculation wrong.