### PR TITLE
[v3.0.3.0b - Concept] - Custom Field Required not only on customer group

### DIFF
--- a/upload/admin/model/sale/voucher.php
+++ b/upload/admin/model/sale/voucher.php
@@ -140,7 +140,7 @@ class ModelSaleVoucher extends Model {
 
 				$data['title'] = sprintf($this->language->get('text_subject'), $voucher_info['from_name']);
 
-				$data['text_greeting'] = sprintf($this->language->get('text_greeting'), $this->currency->format($voucher_info['amount'], $order_info['currency_code'], $order_info['currency_value']));
+				$data['text_greeting'] = sprintf($this->language->get('text_greeting'), $this->currency->format($voucher_info['amount'], $this->config->get('config_currency')));
 				$data['text_from'] = sprintf($this->language->get('text_from'), $voucher_info['from_name']);
 				$data['text_message'] = $this->language->get('text_message');
 				$data['text_redeem'] = sprintf($this->language->get('text_redeem'), $voucher_info['code']);

--- a/upload/catalog/view/theme/default/template/checkout/register.twig
+++ b/upload/catalog/view/theme/default/template/checkout/register.twig
@@ -502,9 +502,9 @@ $('#collapse-payment-address select[name=\'country_id\']').on('change', function
 		},
 		success: function(json) {
 			if (json['postcode_required'] == '1') {
-				$('#collapse-payment-address input[name=\'postcode\']').parent().parent().addClass('required');
+				$('#collapse-payment-address input[name=\'postcode\']').parent().addClass('required');
 			} else {
-				$('#collapse-payment-address input[name=\'postcode\']').parent().parent().removeClass('required');
+				$('#collapse-payment-address input[name=\'postcode\']').parent().removeClass('required');
 			}
 
 			html = '<option value="">{{ text_select }}</option>';


### PR DESCRIPTION
In system/helper/db_schema.php file, on the custom_field_value table, the:

`array(
				'name' => 'required',
				'type' => 'int(1)',
				'not_null' => true,
                                'default' => '0'
			),`

should be added for checkout customer information compliance.