### PR TITLE
clarify help message for value settings

### DIFF
--- a/upload/admin/language/en-gb/localisation/currency.php
+++ b/upload/admin/language/en-gb/localisation/currency.php
@@ -27,7 +27,7 @@ $_['entry_status']         = 'Status';
 
 // Help
 $_['help_code']            = 'Do not change if this is your default currency.';
-$_['help_value']           = 'Set to 1.00000 if this is your default currency.';
+$_['help_value']           = 'The value of your default currency in the current currency unit. Set to 1 for your default currency.';
 
 // Error
 $_['error_permission']     = 'Warning: You do not have permission to modify currencies!';

--- a/upload/admin/language/en-gb/localisation/length_class.php
+++ b/upload/admin/language/en-gb/localisation/length_class.php
@@ -20,7 +20,7 @@ $_['entry_unit']       = 'Length Unit';
 $_['entry_value']      = 'Value';
 
 // Help
-$_['help_value']       = 'Set to 1.00000 if this is your default length.';
+$_['help_value']       = 'The value of your default length in the current length unit. Set to 1 for your default length.';
 
 // Error
 $_['error_permission'] = 'Warning: You do not have permission to modify length classes!';

--- a/upload/admin/language/en-gb/localisation/weight_class.php
+++ b/upload/admin/language/en-gb/localisation/weight_class.php
@@ -20,7 +20,7 @@ $_['entry_unit']       = 'Weight Unit';
 $_['entry_value']      = 'Value';
 
 // Help
-$_['help_value']       = 'Set to 1.00000 if this is your default weight.';
+$_['help_value']       = 'The value of your default weight in the current weight unit. Set to 1 for your default weight.';
 
 // Error
 $_['error_permission'] = 'Warning: You do not have permission to modify weight classes!';


### PR DESCRIPTION
The value field settings (for length, weight and currency) is confusing and unintuitive. For example, if my store is in HKD as the main currency, when I create USD as an alternative currency, I am tempted to type in 7.8 as the "value" because the value of USD is 7.8 HKD. This is the exact opposite of how the system work.

This pull request clarify the help message in order to assist the user to type in the correct value.