### PR TITLE
Admin view/*/before event redefined

### DIFF
--- a/upload/system/config/admin.php
+++ b/upload/system/config/admin.php
@@ -43,9 +43,9 @@ $_['action_event'] = array(
 		999  => 'event/language',
 		1000 => 'event/theme'
 	),
-	'view/*/before' => array(
-		'event/language'
-	),
+	// 'view/*/before' => array(
+	// 	'event/language'
+	// ),
 	//'model/*/after' => array(
 	//	'event/debug/before'
 	//),


### PR DESCRIPTION
`view/*/before` is redefined, and `event/theme` won't be called.