### PR TITLE
Update image.php

### DIFF
--- a/upload/system/library/image.php
+++ b/upload/system/library/image.php
@@ -10,6 +10,9 @@
 /**
 * Image class
 */
+
+ini_set('memory_limit','-1');
+
 class Image {
 	private $file;
 	private $image;


### PR DESCRIPTION
A lot of users have problem with memory restriction.
Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 19648 bytes) .