### PR TITLE
repair for custom_field db table

### DIFF
--- a/upload/install/model/upgrade/1012.php
+++ b/upload/install/model/upgrade/1012.php
@@ -1,0 +1,9 @@
+<?php
+class ModelUpgrade1012 extends Model {
+	public function upgrade() {
+
+		// repair custom_field (issue from upgrade 1004 line 26)
+		$this->db->query("ALTER TABLE `" . DB_PREFIX . "custom_field` CHANGE `location` `location` varchar(9) NOT NULL");
+		$this->db->query("UPDATE `" . DB_PREFIX . "custom_field` SET `location` = 'affiliate' WHERE `location` = 'affilia'");
+	}
+}


### PR DESCRIPTION
Repair for "Custom field" page. 
Set DB column size to fit values (from 7 to 9 chars). Fix existing "cuted" values.