### PR TITLE
gracefully hide the carousel if need

### DIFF
--- a/upload/catalog/view/theme/default/template/extension/module/carousel.twig
+++ b/upload/catalog/view/theme/default/template/extension/module/carousel.twig
@@ -1,24 +1,26 @@
-<div class="swiper-viewport">
-  <div id="carousel{{ module }}" class="swiper-container">
-    <div class="swiper-wrapper">{% for banner in banners %}
-      <div class="swiper-slide text-center">{% if banner.link %}<a href="{{ banner.link }}"><img src="{{ banner.image }}" alt="{{ banner.title }}" class="img-fluid" /></a>{% else %}<img src="{{ banner.image }}" alt="{{ banner.title }}" class="img-fluid" />{% endif %}</div>
-      {% endfor %}</div>
-  </div>
-  <div class="swiper-pagination carousel{{ module }}"></div>
-  <div class="swiper-pager">
-    <div class="swiper-button-next"></div>
-    <div class="swiper-button-prev"></div>
-  </div>
-</div>
-<script type="text/javascript"><!--
-$('#carousel{{ module }}').swiper({
-	mode: 'horizontal',
-	slidesPerView: 5,
-	pagination: '.carousel{{ module }}',
-	paginationClickable: true,
-	nextButton: '.swiper-button-next',
-    prevButton: '.swiper-button-prev',
-	autoplay: 2500,
-	loop: true
-});
---></script>
+{% if banners is defined and banners is not empty %}
+	<div class="swiper-viewport">
+	  <div id="carousel{{ module }}" class="swiper-container">
+	    <div class="swiper-wrapper">{% for banner in banners %}
+	      <div class="swiper-slide text-center">{% if banner.link %}<a href="{{ banner.link }}"><img src="{{ banner.image }}" alt="{{ banner.title }}" class="img-fluid" /></a>{% else %}<img src="{{ banner.image }}" alt="{{ banner.title }}" class="img-fluid" />{% endif %}</div>
+	      {% endfor %}</div>
+	  </div>
+	  <div class="swiper-pagination carousel{{ module }}"></div>
+	  <div class="swiper-pager">
+	    <div class="swiper-button-next"></div>
+	    <div class="swiper-button-prev"></div>
+	  </div>
+	</div>
+	<script type="text/javascript"><!--
+	$('#carousel{{ module }}').swiper({
+		mode: 'horizontal',
+		slidesPerView: 5,
+		pagination: '.carousel{{ module }}',
+		paginationClickable: true,
+		nextButton: '.swiper-button-next',
+	    prevButton: '.swiper-button-prev',
+		autoplay: 2500,
+		loop: true
+	});
+	--></script>
+{% endif %}


### PR DESCRIPTION
add twig statement to hide the carousel if the banners passed from the controller is empty. This prevent a white carousel from appearing on pages where the carousel module are loaded and prevent unprofessional look of the site.
The change is as follow {% if banners is defined and banners is not empty %} at the begin of the line with {% endif %} at the end