### PR TITLE
Fixing API session notice when the api_token is missing

### DIFF
--- a/upload/catalog/controller/startup/session.php
+++ b/upload/catalog/controller/startup/session.php
@@ -3,15 +3,17 @@ class ControllerStartupSession extends Controller {
 	public function index() {
 		if (isset($this->request->get['route']) && substr((string)$this->request->get['route'], 0, 4) == 'api/') {
 			$this->db->query("DELETE FROM `" . DB_PREFIX . "api_session` WHERE TIMESTAMPADD(HOUR, 1, date_modified) < NOW()");
+			
+			if (isset($this->request->get['api_token'])) {
+				// Make sure the IP is allowed
+				$api_query = $this->db->query("SELECT DISTINCT * FROM `" . DB_PREFIX . "api` `a` LEFT JOIN `" . DB_PREFIX . "api_session` `as` ON (a.api_id = as.api_id) LEFT JOIN " . DB_PREFIX . "api_ip `ai` ON (a.api_id = ai.api_id) WHERE a.status = '1' AND `as`.`session_id` = '" . $this->db->escape((string)$this->request->get['api_token']) . "' AND ai.ip = '" . $this->db->escape((string)$this->request->server['REMOTE_ADDR']) . "'");
+			 
+				if ($api_query->num_rows) {
+					$this->session->start($this->request->get['api_token']);
 					
-			// Make sure the IP is allowed
-			$api_query = $this->db->query("SELECT DISTINCT * FROM `" . DB_PREFIX . "api` `a` LEFT JOIN `" . DB_PREFIX . "api_session` `as` ON (a.api_id = as.api_id) LEFT JOIN " . DB_PREFIX . "api_ip `ai` ON (a.api_id = ai.api_id) WHERE a.status = '1' AND `as`.`session_id` = '" . $this->db->escape((string)$this->request->get['api_token']) . "' AND ai.ip = '" . $this->db->escape((string)$this->request->server['REMOTE_ADDR']) . "'");
-		 
-			if ($api_query->num_rows) {
-				$this->session->start($this->request->get['api_token']);
-				
-				// keep the session alive
-				$this->db->query("UPDATE `" . DB_PREFIX . "api_session` SET `date_modified` = NOW() WHERE `api_session_id` = '" . (int)$api_query->row['api_session_id'] . "'");
+					// keep the session alive
+					$this->db->query("UPDATE `" . DB_PREFIX . "api_session` SET `date_modified` = NOW() WHERE `api_session_id` = '" . (int)$api_query->row['api_session_id'] . "'");
+				}
 			}
 		} else {
 			if (isset($this->request->cookie[$this->config->get('session_name')])) {


### PR DESCRIPTION
If you paste any api link in the browser you get an error:

<b>Notice</b>: Undefined index: api_token in <b>D:\xampp\htdocs\opencart\catalog\controller\startup\session.php</b> on line <b>8</b>