### PR TITLE
 Fixing API login notice when the username and key are missing

### DIFF
--- a/upload/catalog/controller/api/login.php
+++ b/upload/catalog/controller/api/login.php
@@ -7,37 +7,43 @@ class ControllerApiLogin extends Controller {
 
 		$this->load->model('account/api');
 
-		// Login with API Key
-		$api_info = $this->model_account_api->login($this->request->post['username'], $this->request->post['key']);
+		if (!isset($this->request->post['username']) || !isset($this->request->post['key'])) {
+			$json['error']['credentials'] = $this->language->get('error_credentials');
+		}
 
-		if ($api_info) {
-			// Check if IP is allowed
-			$ip_data = array();
-	
-			$results = $this->model_account_api->getApiIps($api_info['api_id']);
-	
-			foreach ($results as $result) {
-				$ip_data[] = trim($result['ip']);
-			}
-	
-			if (!in_array($this->request->server['REMOTE_ADDR'], $ip_data)) {
-				$json['error']['ip'] = sprintf($this->language->get('error_ip'), $this->request->server['REMOTE_ADDR']);
-			}				
-				
-			if (!$json) {
-				$json['success'] = $this->language->get('text_success');
+		if (!$json) {
+			// Login with API Key
+			$api_info = $this->model_account_api->login($this->request->post['username'], $this->request->post['key']);
 
-				$session = new Session($this->config->get('session_engine'), $this->registry);
-				$session->start();
-				
-				$this->model_account_api->addApiSession($api_info['api_id'], $session->getId(), $this->request->server['REMOTE_ADDR']);
-				
-				$session->data['api_id'] = $api_info['api_id'];
-				
-				// Create Token
-				$json['api_token'] = $session->getId();
-			} else {
-				$json['error']['key'] = $this->language->get('error_key');
+			if ($api_info) {
+				// Check if IP is allowed
+				$ip_data = array();
+		
+				$results = $this->model_account_api->getApiIps($api_info['api_id']);
+		
+				foreach ($results as $result) {
+					$ip_data[] = trim($result['ip']);
+				}
+		
+				if (!in_array($this->request->server['REMOTE_ADDR'], $ip_data)) {
+					$json['error']['ip'] = sprintf($this->language->get('error_ip'), $this->request->server['REMOTE_ADDR']);
+				}				
+					
+				if (!$json) {
+					$json['success'] = $this->language->get('text_success');
+
+					$session = new Session($this->config->get('session_engine'), $this->registry);
+					$session->start();
+					
+					$this->model_account_api->addApiSession($api_info['api_id'], $session->getId(), $this->request->server['REMOTE_ADDR']);
+					
+					$session->data['api_id'] = $api_info['api_id'];
+					
+					// Create Token
+					$json['api_token'] = $session->getId();
+				} else {
+					$json['error']['key'] = $this->language->get('error_key');
+				}
 			}
 		}
 		

--- a/upload/catalog/language/en-gb/api/login.php
+++ b/upload/catalog/language/en-gb/api/login.php
@@ -3,5 +3,6 @@
 $_['text_success'] = 'Success: API session successfully started!';
 
 // Error
-$_['error_key']    = 'Warning: Incorrect API Key!';
-$_['error_ip']     = 'Warning: Your IP %s is not allowed to access this API!';
+$_['error_key']         = 'Warning: Incorrect API Key!';
+$_['error_credentials'] = 'Warning: No credentials were provided!';
+$_['error_ip']          = 'Warning: Your IP %s is not allowed to access this API!';


### PR DESCRIPTION
If you paste the login api link in the browser you get 2 errors:

<b>Notice</b>: Undefined index: username in <b>D:\xampp\htdocs\opencart\catalog\controller\api\login.php</b> on line <b>11</b>
and
<b>Notice</b>: Undefined index: key in <b>D:\xampp\htdocs\opencart\catalog\controller\api\login.php</b> on line <b>11</b>

that triggers 1 MySQL error:

<b>Fatal error</b>:  Uncaught Exception: Error: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '`key` = '' AND status = '1'' at line;<br />Error No: 1064<br />SELECT * FROM `oc_api` WHERE `username` = '' `key` = '' AND status = '1'