### PR TITLE
removed date_default_timezone_set in framework.php

### DIFF
--- a/upload/system/framework.php
+++ b/upload/system/framework.php
@@ -14,8 +14,6 @@ $registry->set('config', $config);
 $log = new Log($config->get('error_filename'));
 $registry->set('log', $log);
 
-date_default_timezone_set($config->get('date_timezone'));
-
 set_error_handler(function($code, $message, $file, $line) use($log, $config) {
 	// error suppressed with @
 	if (error_reporting() === 0) {


### PR DESCRIPTION
It is no longer necessary in:
system/framework.php

Also cause conflict when:
admin/controller/startup/startup.php
date_default_timezone_set ($this->config->get('config_timezone'));
It is different from UTC.

Important: Tested at PHP 5.6 to 7.2