### PR TITLE
Update currency.php

### DIFF
--- a/upload/catalog/model/localisation/currency.php
+++ b/upload/catalog/model/localisation/currency.php
@@ -24,7 +24,8 @@ class ModelLocalisationCurrency extends Model {
 					'decimal_place' => $result['decimal_place'],
 					'value'         => $result['value'],
 					'status'        => $result['status'],
-					'date_modified' => $result['date_modified']
+					'date_modified' => $result['date_modified'],
+					'vanish_decimalpart_if_zeroes'	=> $result['vanish_decimal_if_zeroes']
 				);
 			}
 


### PR DESCRIPTION
get rid of decimals in case of zeroes only displayed after decimal point

"USD 1900.000" looks silly if you sell ware that needs zero decimals but in specific cases also 3 decimal places like purchasing of thousands of pieces (nails, ammunition, etc.)