### PR TITLE
Removed required field validation from meta-title field in admin product edit form

### DIFF
--- a/upload/admin/controller/catalog/product.php
+++ b/upload/admin/controller/catalog/product.php
@@ -1140,7 +1140,7 @@ class ControllerCatalogProduct extends Controller {
 				$this->error['name'][$language_id] = $this->language->get('error_name');
 			}
 
-			if ((utf8_strlen($value['meta_title']) < 1) || (utf8_strlen($value['meta_title']) > 255)) {
+			if (utf8_strlen($value['meta_title']) > 255) {
 				$this->error['meta_title'][$language_id] = $this->language->get('error_meta_title');
 			}
 		}

--- a/upload/admin/view/template/catalog/product_form.twig
+++ b/upload/admin/view/template/catalog/product_form.twig
@@ -59,7 +59,7 @@
                         <textarea name="product_description[{{ language.language_id }}][description]" placeholder="{{ entry_description }}" id="input-description{{ language.language_id }}" data-toggle="ckeditor" data-lang="{{ ckeditor }}" class="form-control">{{ product_description[language.language_id] ? product_description[language.language_id].description }}</textarea>
                       </div>
                     </div>
-                    <div class="form-group row required">
+                    <div class="form-group row">
                       <label class="col-sm-2 col-form-label" for="input-meta-title{{ language.language_id }}">{{ entry_meta_title }}</label>
                       <div class="col-sm-10">
                         <input type="text" name="product_description[{{ language.language_id }}][meta_title]" value="{{ product_description[language.language_id] ? product_description[language.language_id].meta_title }}" placeholder="{{ entry_meta_title }}" id="input-meta-title{{ language.language_id }}" class="form-control"/>

--- a/upload/catalog/controller/product/product.php
+++ b/upload/catalog/controller/product/product.php
@@ -214,7 +214,11 @@ class ControllerProductProduct extends Controller {
 				'href' => $this->url->link('product/product', 'language=' . $this->config->get('config_language') . $url . '&product_id=' . $this->request->get['product_id'])
 			);
 
-			$this->document->setTitle($product_info['meta_title']);
+			if ($product_info['meta_title'] == '') {
+				$this->document->setTitle(utf8_substr($product_info['name'], 0, 255));
+			} else {
+				$this->document->setTitle($product_info['meta_title']);
+			}
 			$this->document->setDescription($product_info['meta_description']);
 			$this->document->setKeywords($product_info['meta_keyword']);
 			$this->document->addLink($this->url->link('product/product', 'language=' . $this->config->get('config_language') . '&product_id=' . $this->request->get['product_id']), 'canonical');


### PR DESCRIPTION
This will help making it easier to add products via admin form, as it will add a default fallback to product name in case a user doesn't want to add this field in admin.
Control is still with the admin user, so if they do want to add this field, that value will still be honored.

On the top of my experiences so far , this user voice also emphasized the requirement for this : https://opencart.uservoice.com/forums/52387-general/suggestions/6492535-meta-tag-title-not-required-but-auto-fill-based-o