### PR TITLE
It is necessary to delete the log

### DIFF
--- a/upload/admin/controller/marketplace/modification.php
+++ b/upload/admin/controller/marketplace/modification.php
@@ -391,6 +391,8 @@ class ControllerMarketplaceModification extends Controller {
 			}
 
 			// Log
+			@unlink(DIR_LOGS . 'ocmod.log');
+			
 			$ocmod = new Log('ocmod.log');
 			$ocmod->write(implode("\n", $log));
 


### PR DESCRIPTION
A large log causes a "memory limit" error, we do not need to store as much information