### PR TITLE
[Issue Fixed: Reward Point was not working at cart page.]

### DIFF
--- a/upload/catalog/view/theme/default/template/extension/total/reward.twig
+++ b/upload/catalog/view/theme/default/template/extension/total/reward.twig
@@ -6,7 +6,7 @@
         <label class="col-md-2 col-form-label" for="input-reward">{{ entry_reward }}</label>
         <div class="col-md-10">
           <div class="input-group">
-            <input type="text" name="coupon" value="{{ coupon }}" placeholder="{{ entry_reward }}" id="input-coupon" class="form-control"/>
+            <input type="text" name="reward" value="{{ reward }}" placeholder="{{ entry_reward }}" id="input-coupon" class="form-control"/>
             <div class="input-group-append">
               <input type="submit" value="{{ button_reward }}" id="button-reward" data-loading-text="{{ text_loading }}" class="btn btn-primary"/>
             </div>


### PR DESCRIPTION
There was an issue on checkout/cart page:
index.php?route=checkout/cart&language=en-gb#collapse-reward

Customer can't add their reward points for the cart products.
![product_review_point](https://user-images.githubusercontent.com/28401696/44946029-b0e0ce00-ae11-11e8-9324-45745c46bee3.jpg)
![shopping_cart_issue](https://user-images.githubusercontent.com/28401696/44946030-b0e0ce00-ae11-11e8-99c7-90700dfd7b45.jpg)

Issue fixed now customer can add the reward point at cart page.
![applied_reward](https://user-images.githubusercontent.com/28401696/44946044-d53caa80-ae11-11e8-8298-494d1c026fd1.png)
