### PR TITLE
Solving race condition in session file handling

### DIFF
--- a/upload/system/library/session/file.php
+++ b/upload/system/library/session/file.php
@@ -30,12 +30,12 @@ class File {
 	public function write($session_id, $data) {
 		$file = DIR_SESSION . 'sess_' . basename($session_id);
 
-		$handle = fopen($file, 'w');
+		$handle = fopen($file, 'c');
 
 		flock($handle, LOCK_EX);
 
 		fwrite($handle, serialize($data));
-
+		ftruncate($handle, ftell($handle));
 		fflush($handle);
 
 		flock($handle, LOCK_UN);


### PR DESCRIPTION
When writing the session file on disk in the system/library/session/file.php, the fopen function in mode 'w' erases the file BEFORE acquiring the lock. This creates a race condition with the fopen in the read function, resulting in an empty session.

This resulted in annoying disconnections from the admin panel, but can be easily fixed by changing the fopen access mode from 'w' to 'c' and by emptying the file AFTER acquiring the lock by calling ftruncate.