### PR TITLE
Show actual PHP version for install view

### DIFF
--- a/upload/install/view/template/install/step_2.twig
+++ b/upload/install/view/template/install/step_2.twig
@@ -39,7 +39,7 @@
               <tr>
                 <td>{{ text_version }}</td>
                 <td>{{ php_version }}</td>
-                <td>5.6+</td>
+                <td>7.0+</td>
                 <td class="text-center">
                   {% if version %}
                     <span class="text-success"><i class="fa fa-check-circle"></i></span>


### PR DESCRIPTION
Updated install view in order to display correct minimum required version of PHP.

Currently it shows that Opencart requires PHP 5.6+, but in upload/system/startup.php:6 declared minimum version to be not less then 7.0.0.
![image](https://user-images.githubusercontent.com/17802186/47986302-f3aa7500-e0e4-11e8-9b92-51d0cc117b25.png)
