### PR TITLE
Fixing typo

### DIFF
--- a/upload/catalog/controller/extension/captcha/google.php
+++ b/upload/catalog/controller/extension/captcha/google.php
@@ -17,7 +17,7 @@ class ControllerExtensionCaptchaGoogle extends Controller {
     }
 
     public function validate() {
-		if (empty($this->session->data['gcapcha'])) {
+		if (empty($this->session->data['gcaptcha'])) {
 			$this->load->language('extension/captcha/google');
 
 			if (!isset($this->request->post['g-recaptcha-response'])) {


### PR DESCRIPTION
There is a typo in the Google validate function allowing users to bypass the Google Captcha