### PR TITLE
[Issue Fix #7048 : Product's Options are not showing in Order Email Notification.]

### DIFF
--- a/upload/admin/controller/mail/return.php
+++ b/upload/admin/controller/mail/return.php
@@ -6,39 +6,41 @@ class ControllerMailReturn extends Controller {
 		} else {
 			$return_id = '';
 		}
-		
+
 		if (isset($args[1])) {
 			$return_status_id = $args[1];
 		} else {
 			$return_status_id = '';
-		}		
-		
+		}
+
 		if (isset($args[2])) {
 			$comment = $args[2];
 		} else {
 			$comment = '';
 		}
-		
+
 		if (isset($args[3])) {
 			$notify = $args[3];
 		} else {
 			$notify = '';
-		}		
-		
+		}
+
 		if ($notify) {
 			$this->load->model('sale/return');
-			
+
 			$return_info = $this->model_sale_return->getReturn($return_id);
-			
-			if ($return_info) {                
+
+			if ($return_info) {
+				$this->load->model('localisation/language');
+				
 				$language_info = $this->model_localisation_language->getLanguage($return_info['language_id']);
-                
+
 				if ($language_info) {
 					$language_code = $language_info['code'];
 				} else {
 					$language_code = $this->config->get('config_language');
 				}
-                
+
 				$language = new Language($language_code);
 				$language->load($language_code);
 				$language->load('mail/return');
@@ -65,4 +67,4 @@ class ControllerMailReturn extends Controller {
 			}
 		}
 	}
-}	
+}

--- a/upload/catalog/view/theme/default/template/mail/order_alert.twig
+++ b/upload/catalog/view/theme/default/template/mail/order_alert.twig
@@ -8,27 +8,26 @@
 
 {% for product in products %}
 {{ product.quantity }}x {{ product.name }} ({{ product.model }}) {{ product.total }}
-{% if option %}
+{% if product.option %}
 {% for option in product.option %}
 	- {{ option.name }} {{ option.value }}
 {% endfor %}
 {% endif %}
-{% endfor %} 
+{% endfor %}
 {% if vouchers %}
 
 {% for voucher in vouchers %}
 1x {{ voucher.description }} {{ voucher.amount }}
-{% endfor %} 
+{% endfor %}
 {% endif %}
 {{ text_total }}
 
 {% for total in totals %}
 {{ total.title }}: {{ total.value }}
-{% endfor %} 
-  
+{% endfor %}
+
 {% if comment %}
 {{ text_comment }}
 
 {{ comment }}
 {% endif %}
-


### PR DESCRIPTION
[Issue Fix #7048 : Product's Options are not showing in Order Email Notification.]

**1) Issue Fix : **  Ordered Product's Options are not showing in email Notification. **Status- Resolved.**
![email_product_option](https://user-images.githubusercontent.com/28401696/48883033-c4656900-ee43-11e8-82e2-3d77410eb12c.png)

**2) Issue Fix :**  Ordered Product Return History update at admin end. **Status- Resolved.**

**Error : ** <b>Error</b>: Call to a member function getLanguage() on null in <b>/home/users/viveksh047/www/html/official_oc/admin/controller/mail/return.php</b> on line <b>36</b>

**Reason : ** The issue was due to Language Model wasn't Load before calling the getLanguage() Method.
![product returns](https://user-images.githubusercontent.com/28401696/48883106-2faf3b00-ee44-11e8-8fdf-a5e4d41ccd13.jpg)
