### PR TITLE
Bug fixes on Amazon Pay and Login with Amazon

### DIFF
--- a/upload/admin/model/extension/payment/amazon_login_pay.php
+++ b/upload/admin/model/extension/payment/amazon_login_pay.php
@@ -247,7 +247,7 @@ class ModelExtensionPaymentAmazonLoginPay extends Model {
 	}
 
 	public function updateAuthorizationStatus($amazon_authorization_id, $status) {
-		$this->db->query("UPDATE `" . DB_PREFIX . "amazon_login_pay_order_transaction` SET `status` = '" . $this->db->escape($status) . "' WHERE `amazon_authorization_id`='" . $this->db->escape($status) . "' AND `type`='authorization'");
+		$this->db->query("UPDATE `" . DB_PREFIX . "amazon_login_pay_order_transaction` SET `status` = '" . $this->db->escape($status) . "' WHERE `amazon_authorization_id`='" . $this->db->escape($amazon_authorization_id) . "' AND `type`='authorization'");
 	}
 
 	public function isOrderInState($order_reference_id, $states = array()) {

--- a/upload/catalog/model/extension/payment/amazon_login_pay.php
+++ b/upload/catalog/model/extension/payment/amazon_login_pay.php
@@ -682,7 +682,8 @@ class ModelExtensionPaymentAmazonLoginPay extends Model {
             'postcode' => (string)$amazon_address->PostalCode,
             'country' => $country_info['country'],
             'country_id' => $country_info['country_id'],
-            'zone' => $zone_info['zone'],
+            'zone' => $zone_info['name'],
+            'zone_code' => $zone_info['code'],
             'zone_id' => $zone_info['zone_id'],
             'address_1' => (string)$address_line_1,
             'address_2' => (string)$address_line_2,
@@ -755,14 +756,16 @@ class ModelExtensionPaymentAmazonLoginPay extends Model {
             if ($result->num_rows > 0) {
                 return array(
                     'zone_id' => (int)$result->row['zone_id'],
-                    'zone' => $result->row['code']
+                    'name' => $result->row['name'],
+                    'code' => $result->row['code']
                 );
             }
         }
 
         return array(
             'zone_id' => 0,
-            'zone' => ''
+            'name' => '',
+            'code' => ''
         );
     }
 


### PR DESCRIPTION
- Fix an issue where the Amazon authorization is not changed to the Closed state after a successful capture.
- Add the missing `zone_code` address key.
- Change the meaning of the `zone` address key to contain the name instead of the code.