### PR TITLE
Include an ad blocker error in Extensions > Advertising

### DIFF
--- a/upload/admin/language/en-gb/extension/extension/advertise.php
+++ b/upload/admin/language/en-gb/extension/extension/advertise.php
@@ -12,3 +12,6 @@ $_['column_action'] = "Action";
 
 // Text
 $_['text_success']   = "<strong>Success:</strong> You have modified advertising!";
+
+// Error
+$_['error_adblock'] = "It looks like you are using an ad blocker. In order to use this Advertising section, please disable your ad blocker for your OpenCart admin panel.";

--- a/upload/admin/view/template/extension/extension/advertise.twig
+++ b/upload/admin/view/template/extension/extension/advertise.twig
@@ -1,5 +1,8 @@
 <fieldset>
   <legend>{{ heading_title }}</legend>
+  <div id="blockerError" style="display: none;" class="alert alert-danger">
+    <i class="fa fa-exclamation-circle"></i> {{ error_adblock }}
+  </div>
   {% if error_warning %}
   <div class="alert alert-danger alert-dismissible"><i class="fa fa-exclamation-circle"></i> {{ error_warning }}
     <button type="button" class="close" data-dismiss="alert">&times;</button>
@@ -49,3 +52,21 @@
     </table>
   </div>
 </fieldset>
+<style type="text/css">
+  .adBanner {
+      background-color: transparent;
+      height: 1px;
+      width: 1px;
+  }
+</style>
+<div id="wrapTest">
+    <div class="adBanner">
+    </div>
+</div>
+<script type="text/javascript">
+  (function($) {
+    $(document).ready(function() {
+      $('#blockerError').toggle($("#wrapTest").height() == 0);
+    });
+  })(jQuery);
+</script>


### PR DESCRIPTION
This helps solve the issue where merchants are not able to install extensions under Extensions > Advertising.