### PR TITLE
OC 3.1.0.0-b: Twig fixes for issues #7152, #7151, #7149

### DIFF
--- a/upload/catalog/controller/event/theme.php
+++ b/upload/catalog/controller/event/theme.php
@@ -1,6 +1,5 @@
 <?php
 class ControllerEventTheme extends Controller {
-	public $lambda;
 
 	public function index(&$route, &$args, &$template) {
 		if (!$this->config->get('theme_' . $this->config->get('config_theme') . '_status')) {
@@ -14,33 +13,27 @@ class ControllerEventTheme extends Controller {
 			$directory = $this->config->get('config_theme');
 		}
 
-		if (is_file(DIR_TEMPLATE . $directory . '/template/' . $route . '.twig')) {
+		$this->load->model('design/theme');
+		$theme_info = $this->model_design_theme->getTheme($route, $directory);
+		if ($theme_info) {
+			$template = html_entity_decode($theme_info['code'], ENT_QUOTES, 'UTF-8');
 			$this->config->set('template_directory', $directory . '/template/');
+			$this->config->set('template_engine','twig');
+		} else if (is_file(DIR_TEMPLATE . $directory . '/template/' . $route . '.twig')) {
+			$this->config->set('template_directory', $directory . '/template/');
+			$this->config->set('template_engine','twig');
+		} else if (is_file(DIR_TEMPLATE . $directory . '/template/' . $route . '.tpl')) {
+			$this->config->set('template_directory', $directory . '/template/');
+			$this->config->set('template_engine','template');
 		} elseif (is_file(DIR_TEMPLATE . 'default/template/' . $route . '.twig')) {
 			$this->config->set('template_directory', 'default/template/');
+			$this->config->set('template_engine','twig');
+		} elseif (is_file(DIR_TEMPLATE . 'default/template/' . $route . '.tpl')) {
+			$this->config->set('template_directory', 'default/template/');
+			$this->config->set('template_engine','template');
+		} else {
+			exit("Error: Unable to find template for '$route'!");
 		}
-
-		// Attach to the template
-		$template->addFilter('theme-override-' . $this->config->get('config_store_id'), $this);
-
-		// If you want to modify the output of the template we add a
-		$this->lambda = function (&$code) use (&$route, &$args, &$directory) {
-			// If there is a theme override we should get it
-			$this->load->model('design/theme');
-
-			$theme_info = $this->model_design_theme->getTheme($route, $directory);
-
-			if ($theme_info) {
-				$code = html_entity_decode($theme_info['code'], ENT_QUOTES, 'UTF-8');
-			}
-		};
 	}
 
-	// Ridiculous we have to use these work around's because magic methods can not pass by reference!
-	public function callback(&$code) {
-		// Genius
-		$lambda = $this->lambda;
-
-		$lambda($code);
-	}
 }

--- a/upload/system/engine/loader.php
+++ b/upload/system/engine/loader.php
@@ -110,20 +110,23 @@ final class Loader {
 		// Keep the original trigger
 		$trigger = $route;
 
-		$template = new Template($this->registry->get('config')->get('template_engine'));
+		// Modified template contents. Not the output!
+		$template_code = null;
 
 		// Trigger the pre events
-		$result = $this->registry->get('event')->trigger('view/' . $trigger . '/before', array(&$route, &$data, &$template));
+		$result = $this->registry->get('event')->trigger('view/' . $trigger . '/before', array(&$route, &$data, &$template_code));
 
 		// Make sure its only the last event that returns an output if required.
 		if ($result && !$result instanceof Exception) {
 			$output = $result;
 		} else {
+			$template = new Template($this->registry->get('config')->get('template_engine'));
+
 			foreach ($data as $key => $value) {
 				$template->set($key, $value);
 			}
 
-			$output = $template->render($this->registry->get('config')->get('template_directory') . $route, $this->registry->get('config')->get('template_cache'));
+			$output = $template->render($this->registry->get('config')->get('template_directory') . $route, $this->registry->get('config')->get('template_cache'), $template_code);
 		}
 
 		// Trigger the post events

--- a/upload/system/library/template.php
+++ b/upload/system/library/template.php
@@ -32,15 +32,6 @@ class Template {
 	/**
 	 *
 	 *
-	 * @param    mixed $value
-	 */
-	public function addFilter($key, $value) {
-		$this->adaptor->addFilter($key, $value);
-	}
-
-	/**
-	 *
-	 *
 	 * @param    string $key
 	 * @param    mixed $value
 	 */
@@ -53,10 +44,11 @@ class Template {
 	 *
 	 * @param    string $template
 	 * @param    bool $cache
+	 * @param    string &$template_code (optional modified template code from pre-events)
 	 *
 	 * @return    string
 	 */
-	public function render($template, $cache = false) {
-		return $this->adaptor->render($template, $cache);
+	public function render($template, $cache = false, &$template_code=null) {
+		return $this->adaptor->render($template, $cache, $template_code);
 	}
 }

--- a/upload/system/library/template/template.php
+++ b/upload/system/library/template/template.php
@@ -1,68 +1,61 @@
 <?php
 namespace Template;
 final class Template {
-	protected $code;
-	protected $filters = array();
 	protected $data = array();
-
-	public function addFilter($key, $value) {
-		$this->filters[$key] = $value;
-	}
 
 	public function set($key, $value) {
 		$this->data[$key] = $value;
 	}
 
-	public function render($filename, $cache = true) {
-		$file = DIR_TEMPLATE . $filename . '.tpl';
-
-		if (is_file($file)) {
-			$this->code = file_get_contents($file);
-
-			foreach ($this->filters as $filter) {
-				$filter->callback($this->code);
-			}
-
-			ob_start();
-
-			if (!$cache && function_exists('eval')) {
-				extract($this->data);
-
-				echo eval('?>' . $this->code);
+	public function render($filename, $cache = true, $template_code=null) {
+		// render from modified template code if there
+		if ($template_code) {
+			$file = DIR_CACHE.'tpl/'.$filename.'.tpl';
+			if (is_file($file)) {
+				if ($template_code != file_get_contents($file)) {
+					file_put_contents($file,$template_code,LOCK_EX);
+				}
 			} else {
-				extract($this->data);
-
-				include($this->compile($file, $this->code));
+				$this->file_force_contents($file,$template_code,LOCK_EX);
 			}
-
-			return ob_get_clean();
-		} else {
-			throw new \Exception('Error: Could not load template ' . $file . '!');
-			exit();
+			ob_start();
+			extract($this->data);
+			include( $file );
+			$output = ob_get_clean();
+			return $output;
 		}
+
+		// remove old cache file if still there
+		$file = DIR_CACHE.'tpl/'.$filename.'.tpl';
+		if (is_file( $file )) {
+			unlink( $file );
+		}
+
+		// render from PHP template file
+		$file = DIR_TEMPLATE . $filename . '.tpl';
+		if (is_file($file)) {
+			extract($this->data);
+			ob_start();
+			include($file);
+			$output = ob_get_clean();
+			return $output;
+		}
+
+		throw new \Exception('Error: Could not load template ' . $file . '!');
+		exit();
 	}
 
-	public function compile($file, $code) {
-		$hash = hash('sha256', $file . __CLASS__ . preg_replace('/[^0-9a-zA-Z_]/', '_', implode('_', array_keys($this->filters))));
-
-		$file = DIR_CACHE . substr($hash, 0, 2) . '/' . $hash . '.php';
-
-		if (!is_file($file)) {
-			$directory = dirname($file);
-
-			if (!is_dir($directory)) {
-				if (!mkdir($directory, 0777, true)) {
-					clearstatcache(true, $directory);
-				}
+	// helper function, see http://php.net/manual/en/function.file-put-contents.php#84180
+	protected function file_force_contents($dir, $contents, $flags) {
+		$parts = explode('/', substr($dir,1));
+		$file = array_pop($parts);
+		$dir = '';
+		foreach ($parts as $part) {
+			$dir .= "/$part";
+			if (!is_dir($dir)) { 
+				mkdir($dir);
 			}
-
-			$handle = fopen($file, 'w+');
-
-			fwrite($handle, $code);
-
-			fclose($handle);
 		}
-
-		return $file;
+		file_put_contents( "$dir/$file", $contents, $flags );
 	}
 }

--- a/upload/system/library/template/twig.php
+++ b/upload/system/library/template/twig.php
@@ -1,22 +1,19 @@
 <?php
 namespace Template;
 final class Twig {
-	private $filters = array();
 	private $data = array();
-
-	public function addFilter($key, $value) {
-		$this->filters[$key] = $value;
-	}
 
 	public function set($key, $value) {
 		$this->data[$key] = $value;
 	}
 
-	public function render($template, $cache = true) {
+	public function render($template, $cache = true, $template_code=null) {
 		// Initialize Twig environment
 		$config = array(
-			'autoescape' => false,
-			'debug'      => false
+			'autoescape'  => false,
+			'debug'       => false,
+			'auto_reload' => true,
+			'cache'       => ($cache) ? DIR_CACHE.'twig/' : false
 		);
 
 		/*
@@ -28,67 +25,16 @@ final class Twig {
 		 *
 		 * The fact that this system cache is just compiling php into more php code instead of html is a disgrace!
 		 */
-
-		// 1. Generate namespace for filters used to product the output
-		$namespace = preg_replace('/[^0-9a-zA-Z_]/', '_', implode('_', array_keys($this->filters)));
-
-		$loader = new \Twig_Loader_Filesystem(DIR_TEMPLATE);
-
-		// 2. Initiate Twig Environment
-		$twig = new \Twig_Environment($loader, $config);
-
-		// 3. Create an anonymous cache class as twig will not all us to generate a key based on custom keys
-		if ($cache) {
-			$cache = new class(DIR_CACHE, $options = 0, $namespace) extends \Twig_Cache_Filesystem {
-				private $directory;
-				private $options;
-
-				public function __construct($directory, $options = 0, $namespace) {
-					$this->directory = rtrim($directory, '\/') . '/';
-					$this->options = $options;
-					$this->namespace = $namespace;
-				}
-
-				public function generateKey($name, $className) {
-					$hash = hash('sha256', $name . $className . $this->namespace);
-
-					return $this->directory . $hash[0] . $hash[1] . '/' . $hash . '.php';
-				}
-			};
-
-			$twig->setCache($cache);
+		if ($template_code) {
+			// render from modified template code
+			$loader = new \Twig_Loader_Array( array($template.'.twig' => $template_code) );
+		} else {
+			// render from template file
+			$loader = new \Twig_Loader_Filesystem( DIR_TEMPLATE );
 		}
-
-		// 4. Get template class name
-		$template_class_name = $twig->getTemplateClass($template . '.twig');
-
-		// 5. Get cache file path
-		$cache_file = $twig->getCache(false)->generateKey(DIR_TEMPLATE . $template . '.twig', $template_class_name);
-
 		try {
-			// 6. Check if cached file exists with modifications if not we create one
-			if (!is_file($cache_file)) {
-				// 7. Get the source code using the source
-				$source = $twig->getLoader()->getSourceContext($template . '.twig');
-
-				$code = $source->getCode();
-
-				// 8. Run the code through the filters
-				foreach ($this->filters as $key => $filter) {
-					$filter->callback($code);
-				}
-
-				// 9. Compile the source
-				$output = $twig->compileSource(new \Twig_Source($code, $source->getName(), $source->getPath()));
-
-				// 10. Write the output to a cache file
-				$twig->getCache(false)->write($cache_file, $output);
-			}
-
-			// 11. Load the cached file into array of loaded templates
-			$twig->getCache(false)->load($cache_file);
-
-			return $twig->render($template . '.twig', $this->data);
+			$twig = new \Twig_Environment( $loader, $config );
+			return $twig->render( $template.'.twig', $this->data );
 		} catch (Twig_Error_Syntax $e) {
 			trigger_error('Error: Could not load template ' . $template . '!');
 			exit();


### PR DESCRIPTION
Hi Daniel,

Please find attached pull request for issues #7152, #7151, #7149

It basically makes OC 3.1.0.0 backward compatible for view/*/before events.
And it solves the problems with Twig caching, including auto-refresh, cooperates nicely with the theme editor changes. There is no more need for cumbersome lambda functions. And last not least, it can now automatically detect whether a template is twig or php before rendering. Finally, the rendering time, therefore the overall page load time, is now faster, too.
