### PR TITLE
Fix bugs preventing square payment from working

### DIFF
--- a/upload/catalog/controller/account/transaction.php
+++ b/upload/catalog/controller/account/transaction.php
@@ -43,7 +43,7 @@ class ControllerAccountTransaction extends Controller {
 		$filter_data = array(
 			'sort'  => 'date_added',
 			'order' => 'DESC',
-			'start' => ($page - 1) * 10,
+			'start' => max(($page - 1), 0) * 10,
 			'limit' => 10
 		);
 

--- a/upload/catalog/view/theme/default/template/extension/payment/squareup.twig
+++ b/upload/catalog/view/theme/default/template/extension/payment/squareup.twig
@@ -153,7 +153,7 @@ $(document).ready(function() {
 			type: $(form).attr('method'),
 			data: $(form).serialize(),
 			beforeSend: function() {
-				$('#button-confirm-order').button('loading');
+				$('#button-confirm').button('loading');
 			},
 			success: function(json) {
 				if (json.error) {
@@ -166,7 +166,7 @@ $(document).ready(function() {
 				squareupError(thrownError);
 			},
 			complete: function() {
-				$('#button-confirm-order').button('reset');
+				$('#button-confirm').button('reset');
 			}
 		});
 	}
@@ -185,7 +185,7 @@ $(document).ready(function() {
 	}
 
 	function squareupError(error) {
-		$('#button-confirm-order').button('reset');
+		$('#button-confirm').button('reset');
 
 		$('#squareup-notification').html('<div class="alert alert-danger"><button type="button" class="close" data-dismiss="alert" aria-label="X"><span aria-hidden="true">&times;</span></button><i class="fas fa-exclamation-circle"></i>&nbsp;' + error + '</div>');
 	}
@@ -208,12 +208,12 @@ $(document).ready(function() {
 		toggleAjaxSetup(init_ajax_setup);
 	}
 
-	$('#button-confirm-order').unbind().click(function(e) {
+	$('#button-confirm').unbind().click(function(e) {
 		e.preventDefault();
 		e.stopPropagation();
 
 		$('#squareup-notification').empty();
-		$('#button-confirm-order').button('loading');
+		$('#button-confirm').button('loading');
 
 		onConfirmCheckout();
 	});


### PR DESCRIPTION
Fixes a SQL error in the square plugin that caused it to try to pull transactions starting at negative numbers in some cases, and a Javascript error whereby the confirm transaction buttons were bound to an element with the wrong ID.