### PR TITLE
Config Iterator & ArrayAccess interface.

### DIFF
--- a/upload/system/library/config.php
+++ b/upload/system/library/config.php
@@ -5,63 +5,142 @@
  * @copyright	Copyright (c) 2005 - 2017, OpenCart, Ltd. (https://www.opencart.com/)
  * @license		https://opensource.org/licenses/GPL-3.0
  * @link		https://www.opencart.com
-*/
+ */
 
 /**
-* Config class
-*/
-class Config {
-	private $data = array();
-    
-	/**
-     * 
-     *
-     * @param	string	$key
-	 * 
-	 * @return	mixed
-     */
-	public function get($key) {
-		return (isset($this->data[$key]) ? $this->data[$key] : null);
-	}
-	
-    /**
-     * 
-     *
-     * @param	string	$key
-	 * @param	string	$value
-     */
-	public function set($key, $value) {
-		$this->data[$key] = $value;
-	}
+ * Config class
+ */
+class Config implements ArrayAccess, Iterator {
+    private $data = array();
 
     /**
-     * 
+     *
      *
      * @param	string	$key
-	 *
-	 * @return	mixed
+     *
+     * @return	mixed
      */
-	public function has($key) {
-		return isset($this->data[$key]);
-	}
-	
+    public function get($key) {
+        return (isset($this->data[$key]) ? $this->data[$key] : null);
+    }
+
     /**
-     * 
+     *
+     *
+     * @param	string	$key
+     * @param	string	$value
+     */
+    public function set($key, $value) {
+        $this->data[$key] = $value;
+    }
+
+    /**
+     *
+     *
+     * @param	string	$key
+     *
+     * @return	mixed
+     */
+    public function has($key) {
+        return isset($this->data[$key]);
+    }
+
+    /**
+     *
      *
      * @param	string	$filename
      */
-	public function load($filename) {
-		$file = DIR_CONFIG . $filename . '.php';
+    public function load($filename) {
+        $file = DIR_CONFIG . $filename . '.php';
 
-		if (file_exists($file)) {
-			$_ = array();
+        if (file_exists($file)) {
+            $_ = array();
 
-			require($file);
+            require($file);
 
-			$this->data = array_merge($this->data, $_);
-		} else {
-			trigger_error('Error: Could not load config ' . $filename . '!');
-			exit();
-		}
-	}
+            $this->data = array_merge($this->data, $_);
+        } else {
+            trigger_error('Error: Could not load config ' . $filename . '!');
+            exit();
+        }
+    }
+
+    /**
+     * @return mixed
+     */
+    public function current()
+    {
+        return current($this->data);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function next()
+    {
+        return next($this->data);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function key()
+    {
+        return key($this->data);
+    }
+
+    /**
+     * @return bool
+     */
+    public function valid()
+    {
+        return $this->key() !== null;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function rewind()
+    {
+        return reset($this->data);
+    }
+
+    /**
+     * @param  string $key
+     * @return bool
+     */
+    public function offsetExists($key)
+    {
+        return array_key_exists($key, $this->data);
+    }
+
+    /**
+     * @param  string $key
+     * @return mixed
+     */
+    public function offsetGet($key)
+    {
+        return $this->data[$key];
+    }
+
+    /**
+     * @param  string $key
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function offsetSet($key, $value)
+    {
+        $this->data[$key] = $value;
+        return $this;
+    }
+
+    /**
+     * @param  string $key
+     * @return $this
+     */
+    public function offsetUnset($key)
+    {
+        unset($this->data[$key]);
+        return $this;
+    }
 }


### PR DESCRIPTION
With implemented [Iterator interface](http://php.net/manual/en/class.iterator.php) developers will have ability to iterate over config items (key -> val) and that will ease development very much, primarily data variable population:

**Before:**
```php
    $data['fraud_fraudlabspro_status'] = $this->config->get('fraud_fraudlabspro_status');
    $data['fraud_fraudlabspro_simulate_ip'] = $this->config->get('fraud_fraudlabspro_simulate_ip');
    $data['fraud_fraudlabspro_reject_status_id'] = $this->config->get('fraud_fraudlabspro_reject_status_id');
```

**After:**
```php
    foreach ($this->config as $key => $value) {
        if (strpos($key, 'fraud_fraudlabspro') !== false) {
            $data[$key] = $value;    
        }
    }
```

Also with implemented [ArrayAccess ](http://php.net/manual/en/class.arrayaccess.php)interface developers will have ability to access object in context of array.

**Before:**
```php
    $data['fraud_fraudlabspro_status'] = $this->config->get('fraud_fraudlabspro_status');
    $data['fraud_fraudlabspro_simulate_ip'] = $this->config->get('fraud_fraudlabspro_simulate_ip');
    $data['fraud_fraudlabspro_reject_status_id'] = $this->config->get('fraud_fraudlabspro_reject_status_id');
```

**After:**
```php
    $data['fraud_fraudlabspro_status'] = $this->config->fraud_fraudlabspro_status;
    $data['fraud_fraudlabspro_simulate_ip'] = $this->config->fraud_fraudlabspro_simulate_ip;
    $data['fraud_fraudlabspro_reject_status_id'] = $this->config->fraud_fraudlabspro_reject_status_id;
```

**No BC breaks & interfaces are presented with PHP 5 so there will be no problem with older versions of OC.**