### PR TITLE
Change url to https to eliminate Document moved error

### DIFF
--- a/upload/install/model/upgrade/1009.php
+++ b/upload/install/model/upgrade/1009.php
@@ -107,7 +107,7 @@ class ModelUpgrade1009 extends Model {
 	   		foreach ($lines as $line_id => $line) {
 				if (strpos($line, 'DB_PREFIX') !== false) {
 					$output .= $line . "\n\n";
-					$output .= 'define(\'OPENCART_SERVER\', \'http://www.opencart.com/\');' . "\n";
+					$output .= 'define(\'OPENCART_SERVER\', \'https://www.opencart.com/\');' . "\n";
 				} else {
 					$output .= $line;
 				}


### PR DESCRIPTION
Was getting these "Moved Permanently" Errors on all of the extension pages in the admin section, see below:
![image](https://user-images.githubusercontent.com/16450422/54331665-2eaf3e80-45d8-11e9-8984-b833e27a04ad.png)


Fix: Change url to HTTPS in admin config.php