### PR TITLE
Fixes for square breaking changes to oauth2 requirements

### DIFF
--- a/upload/admin/controller/extension/payment/squareup.php
+++ b/upload/admin/controller/extension/payment/squareup.php
@@ -462,7 +462,7 @@ class ControllerExtensionPaymentSquareup extends Controller {
         );
 
         $filter_data = array(
-            'start' => ($page - 1) * (int)$this->config->get('config_limit_admin'),
+            'start' => max(($page - 1), 0) * (int)$this->config->get('config_limit_admin'),
             'limit' => $this->config->get('config_limit_admin')
         );
 
@@ -651,6 +651,7 @@ class ControllerExtensionPaymentSquareup extends Controller {
             $previous_setting['payment_squareup_merchant_name'] = ''; // only available in v1 of the API, not populated for now
             $previous_setting['payment_squareup_access_token'] = $token['access_token'];
             $previous_setting['payment_squareup_access_token_expires'] = $token['expires_at'];
+	    $previous_setting['payment_squareup_refresh_token'] = $token['refresh_token'];
 
             $this->model_setting_setting->editSetting('payment_squareup', $previous_setting);
 

--- a/upload/system/library/squareup.php
+++ b/upload/system/library/squareup.php
@@ -18,7 +18,6 @@ class Squareup {
     const ENDPOINT_DELETE_CARD = 'customers/%s/cards/%s';
     const ENDPOINT_GET_TRANSACTION = 'locations/%s/transactions/%s';
     const ENDPOINT_LOCATIONS = 'locations';
-    const ENDPOINT_REFRESH_TOKEN = 'oauth2/clients/%s/access-token/renew';
     const ENDPOINT_REFUND_TRANSACTION = 'locations/%s/transactions/%s/refund';
     const ENDPOINT_TOKEN = 'oauth2/token';
     const ENDPOINT_TRANSACTIONS = 'locations/%s/transactions';
@@ -224,6 +223,7 @@ class Squareup {
             'parameters' => array(
                 'client_id' => $this->config->get('payment_squareup_client_id'),
                 'client_secret' => $this->config->get('payment_squareup_client_secret'),
+		'grant_type' => 'authorization_code',
                 'redirect_uri' => $this->session->data['payment_squareup_oauth_redirect'],
                 'code' => $code
             )
@@ -241,12 +241,13 @@ class Squareup {
     public function refreshToken() {
         $request_data = array(
             'method' => 'POST',
-            'endpoint' => sprintf(self::ENDPOINT_REFRESH_TOKEN, $this->config->get('payment_squareup_client_id')),
+            'endpoint' => self::ENDPOINT_TOKEN,
             'no_version' => true,
-            'auth_type' => 'Client',
-            'token' => $this->config->get('payment_squareup_client_secret'),
             'parameters' => array(
-                'access_token' => $this->config->get('payment_squareup_access_token')
+                'client_id' => $this->config->get('payment_squareup_client_id'),
+                'client_secret' => $this->config->get('payment_squareup_client_secret'),
+		'grant_type' => 'refresh_token',
+                'refresh_token' => $this->config->get('payment_squareup_refresh_token')
             )
         );
 


### PR DESCRIPTION
Migrate square to use refresh tokens, as the old deprecated APIs to refresh without refresh tokens no longer work.  Add required grant type parameters for oauth2.  Fix SQL error that was preventing updating locations from square on fresh installs.

Without this patch, it's not possible to connect the square plugin to a square account right now, and locations won't update correctly even if it's currently connected.