### PR TITLE
Fixes for square payment extension

### DIFF
--- a/upload/admin/controller/extension/payment/squareup.php
+++ b/upload/admin/controller/extension/payment/squareup.php
@@ -451,7 +451,7 @@ class ControllerExtensionPaymentSquareup extends Controller {
         $this->load->model('extension/payment/squareup');
 
         if (isset($this->request->get['page'])) {
-            $page = (int)$this->request->get['page'];
+            $page = max((int)$this->request->get['page'], 1);
         } else {
             $page = 1;
         }
@@ -462,7 +462,7 @@ class ControllerExtensionPaymentSquareup extends Controller {
         );
 
         $filter_data = array(
-            'start' => max(($page - 1), 0) * (int)$this->config->get('config_limit_admin'),
+            'start' => ($page - 1) * (int)$this->config->get('config_limit_admin'),
             'limit' => $this->config->get('config_limit_admin')
         );
 

--- a/upload/admin/controller/extension/payment/squareup.php
+++ b/upload/admin/controller/extension/payment/squareup.php
@@ -935,7 +935,7 @@ class ControllerExtensionPaymentSquareup extends Controller {
                 $this->error['sandbox_client_id'] = $this->language->get('error_sandbox_client_id');
             }
 
-            if (empty($this->request->post['payment_squareup_sandbox_token']) || strlen($this->request->post['payment_squareup_sandbox_token']) > 42) {
+            if (empty($this->request->post['payment_squareup_sandbox_token']) || strlen($this->request->post['payment_squareup_sandbox_token']) > 64) {
                 $this->error['sandbox_token'] = $this->language->get('error_sandbox_token');
             }
 

--- a/upload/admin/controller/extension/payment/squareup.php
+++ b/upload/admin/controller/extension/payment/squareup.php
@@ -462,7 +462,7 @@ class ControllerExtensionPaymentSquareup extends Controller {
         );
 
         $filter_data = array(
-            'start' => ($page - 1) * (int)$this->config->get('config_limit_admin'),
+            'start' => max(($page - 1), 0) * (int)$this->config->get('config_limit_admin'),
             'limit' => $this->config->get('config_limit_admin')
         );
 
@@ -651,6 +651,7 @@ class ControllerExtensionPaymentSquareup extends Controller {
             $previous_setting['payment_squareup_merchant_name'] = ''; // only available in v1 of the API, not populated for now
             $previous_setting['payment_squareup_access_token'] = $token['access_token'];
             $previous_setting['payment_squareup_access_token_expires'] = $token['expires_at'];
+	    $previous_setting['payment_squareup_refresh_token'] = $token['refresh_token'];
 
             $this->model_setting_setting->editSetting('payment_squareup', $previous_setting);
 

--- a/upload/catalog/controller/account/transaction.php
+++ b/upload/catalog/controller/account/transaction.php
@@ -33,7 +33,7 @@ class ControllerAccountTransaction extends Controller {
 		$data['column_amount'] = sprintf($this->language->get('column_amount'), $this->config->get('config_currency'));
 
 		if (isset($this->request->get['page'])) {
-			$page = (int)$this->request->get['page'];
+			$page = max((int)$this->request->get['page'], 1);
 		} else {
 			$page = 1;
 		}
@@ -43,7 +43,7 @@ class ControllerAccountTransaction extends Controller {
 		$filter_data = array(
 			'sort'  => 'date_added',
 			'order' => 'DESC',
-			'start' => max(($page - 1), 0) * 10,
+			'start' => ($page - 1) * 10,
 			'limit' => 10
 		);
 

--- a/upload/catalog/controller/account/transaction.php
+++ b/upload/catalog/controller/account/transaction.php
@@ -43,7 +43,7 @@ class ControllerAccountTransaction extends Controller {
 		$filter_data = array(
 			'sort'  => 'date_added',
 			'order' => 'DESC',
-			'start' => ($page - 1) * 10,
+			'start' => max(($page - 1), 0) * 10,
 			'limit' => 10
 		);
 

--- a/upload/catalog/view/theme/default/template/extension/payment/squareup.twig
+++ b/upload/catalog/view/theme/default/template/extension/payment/squareup.twig
@@ -153,7 +153,7 @@ $(document).ready(function() {
 			type: $(form).attr('method'),
 			data: $(form).serialize(),
 			beforeSend: function() {
-				$('#button-confirm-order').button('loading');
+				$('#button-confirm').button('loading');
 			},
 			success: function(json) {
 				if (json.error) {
@@ -166,7 +166,7 @@ $(document).ready(function() {
 				squareupError(thrownError);
 			},
 			complete: function() {
-				$('#button-confirm-order').button('reset');
+				$('#button-confirm').button('reset');
 			}
 		});
 	}
@@ -185,7 +185,7 @@ $(document).ready(function() {
 	}
 
 	function squareupError(error) {
-		$('#button-confirm-order').button('reset');
+		$('#button-confirm').button('reset');
 
 		$('#squareup-notification').html('<div class="alert alert-danger"><button type="button" class="close" data-dismiss="alert" aria-label="X"><span aria-hidden="true">&times;</span></button><i class="fas fa-exclamation-circle"></i>&nbsp;' + error + '</div>');
 	}
@@ -208,12 +208,12 @@ $(document).ready(function() {
 		toggleAjaxSetup(init_ajax_setup);
 	}
 
-	$('#button-confirm-order').unbind().click(function(e) {
+	$('#button-confirm').unbind().click(function(e) {
 		e.preventDefault();
 		e.stopPropagation();
 
 		$('#squareup-notification').empty();
-		$('#button-confirm-order').button('loading');
+		$('#button-confirm').button('loading');
 
 		onConfirmCheckout();
 	});

--- a/upload/system/library/squareup.php
+++ b/upload/system/library/squareup.php
@@ -23,7 +23,7 @@ class Squareup {
     const ENDPOINT_TRANSACTIONS = 'locations/%s/transactions';
     const ENDPOINT_VOID_TRANSACTION = 'locations/%s/transactions/%s/void';
     const PAYMENT_FORM_URL = 'https://js.squareup.com/v2/paymentform';
-    const SCOPE = 'MERCHANT_PROFILE_READ PAYMENTS_READ SETTLEMENTS_READ CUSTOMERS_READ CUSTOMERS_WRITE';
+    const SCOPE = 'MERCHANT_PROFILE_READ PAYMENTS_READ PAYMENTS_WRITE SETTLEMENTS_READ CUSTOMERS_READ CUSTOMERS_WRITE';
     const VIEW_TRANSACTION_URL = 'https://squareup.com/dashboard/sales/transactions/%s/by-unit/%s';
     const SQUARE_INTEGRATION_ID = 'sqi_65a5ac54459940e3600a8561829fd970';
 

--- a/upload/system/library/squareup.php
+++ b/upload/system/library/squareup.php
@@ -18,7 +18,6 @@ class Squareup {
     const ENDPOINT_DELETE_CARD = 'customers/%s/cards/%s';
     const ENDPOINT_GET_TRANSACTION = 'locations/%s/transactions/%s';
     const ENDPOINT_LOCATIONS = 'locations';
-    const ENDPOINT_REFRESH_TOKEN = 'oauth2/clients/%s/access-token/renew';
     const ENDPOINT_REFUND_TRANSACTION = 'locations/%s/transactions/%s/refund';
     const ENDPOINT_TOKEN = 'oauth2/token';
     const ENDPOINT_TRANSACTIONS = 'locations/%s/transactions';
@@ -224,6 +223,7 @@ class Squareup {
             'parameters' => array(
                 'client_id' => $this->config->get('payment_squareup_client_id'),
                 'client_secret' => $this->config->get('payment_squareup_client_secret'),
+		'grant_type' => 'authorization_code',
                 'redirect_uri' => $this->session->data['payment_squareup_oauth_redirect'],
                 'code' => $code
             )
@@ -241,12 +241,13 @@ class Squareup {
     public function refreshToken() {
         $request_data = array(
             'method' => 'POST',
-            'endpoint' => sprintf(self::ENDPOINT_REFRESH_TOKEN, $this->config->get('payment_squareup_client_id')),
+            'endpoint' => self::ENDPOINT_TOKEN,
             'no_version' => true,
-            'auth_type' => 'Client',
-            'token' => $this->config->get('payment_squareup_client_secret'),
             'parameters' => array(
-                'access_token' => $this->config->get('payment_squareup_access_token')
+                'client_id' => $this->config->get('payment_squareup_client_id'),
+                'client_secret' => $this->config->get('payment_squareup_client_secret'),
+		'grant_type' => 'refresh_token',
+                'refresh_token' => $this->config->get('payment_squareup_refresh_token')
             )
         );
 


### PR DESCRIPTION
Fixes multiple issues with the Square payment extension:

1. Sandbox token length has risen to 64 characters; amend the admin form to allow this length so that sandbox mode can be configured
2. Fix the name of the submit button in the checkout process so the corresponding event applies to it, so that checkout with square works
3. Update the token acquisition and refresh process to match Square's new refresh token requirements.  This will require clicking "connect" and signing into square once for existing users; new users cannot register using the old flow and the currently-used token renewal API is deprecated.
4. Add the PAYMENTS_WRITE scope so that charges and refunds can be made outside sandbox mode