### PR TITLE
Add built-in plugin for NMI Collect.js inline

### DIFF
--- a/upload/admin/controller/extension/payment/nmi_collectjs.php
+++ b/upload/admin/controller/extension/payment/nmi_collectjs.php
@@ -1,0 +1,162 @@
+<?php
+class ControllerExtensionPaymentNMICollectJS extends Controller {
+	private $error = array();
+
+	public function index() {
+		$this->load->language('extension/payment/nmi_collectjs');
+
+		$this->document->setTitle($this->language->get('heading_title'));
+
+		$this->load->model('setting/setting');
+
+		if (($this->request->server['REQUEST_METHOD'] == 'POST') && $this->validate()) {
+			$this->model_setting_setting->editSetting('payment_nmi_collectjs', $this->request->post);
+
+			$this->session->data['success'] = $this->language->get('text_success');
+
+			$this->response->redirect($this->url->link('marketplace/extension', 'user_token=' . $this->session->data['user_token'] . '&type=payment'));
+		}
+
+		if (isset($this->error['warning'])) {
+			$data['error_warning'] = $this->error['warning'];
+		} else {
+			$data['error_warning'] = '';
+		}
+
+		if (isset($this->error['username'])) {
+			$data['error_username'] = $this->error['username'];
+		} else {
+			$data['error_username'] = '';
+		}
+
+		if (isset($this->error['password'])) {
+			$data['error_password'] = $this->error['password'];
+		} else {
+			$data['error_password'] = '';
+		}
+
+		$data['breadcrumbs'] = array();
+
+		$data['breadcrumbs'][] = array(
+			'text' => $this->language->get('text_home'),
+			'href' => $this->url->link('common/dashboard', 'user_token=' . $this->session->data['user_token'])
+		);
+
+		$data['breadcrumbs'][] = array(
+			'text' => $this->language->get('text_extension'),
+			'href' => $this->url->link('marketplace/extension', 'user_token=' . $this->session->data['user_token'] . '&type=payment')
+		);
+
+		$data['breadcrumbs'][] = array(
+			'text' => $this->language->get('heading_title'),
+			'href' => $this->url->link('extension/payment/nmi_collectjs', 'user_token=' . $this->session->data['user_token'])
+		);
+
+		$data['action'] = $this->url->link('extension/payment/nmi_collectjs', 'user_token=' . $this->session->data['user_token']);
+		$data['cancel'] = $this->url->link('marketplace/extension', 'user_token=' . $this->session->data['user_token'] . '&type=payment');
+
+		if (isset($this->request->post['payment_nmi_collectjs_username'])) {
+			$data['payment_nmi_collectjs_username'] = $this->request->post['payment_nmi_collectjs_username'];
+		} else {
+			$data['payment_nmi_collectjs_username'] = $this->config->get('payment_nmi_collectjs_username');
+		}
+
+		if (isset($this->request->post['payment_nmi_collectjs_password'])) {
+			$data['payment_nmi_collectjs_password'] = $this->request->post['payment_nmi_collectjs_password'];
+		} else {
+			$data['payment_nmi_collectjs_password'] = $this->config->get('payment_nmi_collectjs_password');
+		}
+
+		if (isset($this->request->post['payment_nmi_collectjs_api_key'])) {
+			$data['payment_nmi_collectjs_api_key'] = $this->request->post['payment_nmi_collectjs_api_key'];
+		} else {
+			$data['payment_nmi_collectjs_api_key'] = $this->config->get('payment_nmi_collectjs_api_key');
+		}
+
+		if (isset($this->request->post['payment_nmi_collectjs_tokenization_key'])) {
+			$data['payment_nmi_collectjs_tokenization_key'] = $this->request->post['payment_nmi_collectjs_tokenization_key'];
+		} else {
+			$data['payment_nmi_collectjs_tokenization_key'] = $this->config->get('payment_nmi_collectjs_tokenization_key');
+		}
+
+		if (isset($this->request->post['payment_nmi_collectjs_dup_seconds'])) {
+			$data['payment_nmi_collectjs_dup_seconds'] = $this->request->post['payment_nmi_collectjs_dup_seconds'];
+		} else {
+			$data['payment_nmi_collectjs_dup_seconds'] = $this->config->get('payment_nmi_collectjs_dup_seconds');
+		}
+
+		if (isset($this->request->post['payment_nmi_collectjs_method'])) {
+			$data['payment_nmi_collectjs_method'] = $this->request->post['payment_nmi_collectjs_method'];
+		} else {
+			$data['payment_nmi_collectjs_method'] = $this->config->get('payment_nmi_collectjs_method');
+		}
+
+		if (isset($this->request->post['payment_nmi_collectjs_total'])) {
+			$data['payment_nmi_collectjs_total'] = $this->request->post['payment_nmi_collectjs_total'];
+		} else {
+			$data['payment_nmi_collectjs_total'] = $this->config->get('payment_nmi_collectjs_total');
+		}
+
+		if (isset($this->request->post['payment_nmi_collectjs_debug'])) {
+			$data['payment_nmi_collectjs_debug'] = $this->request->post['payment_nmi_collectjs_debug'];
+		} else {
+			$data['payment_nmi_collectjs_debug'] = $this->config->get('payment_nmi_collectjs_debug');
+		}
+
+		if (isset($this->request->post['payment_nmi_collectjs_order_status_id'])) {
+			$data['payment_nmi_collectjs_order_status_id'] = $this->request->post['payment_nmi_collectjs_order_status_id'];
+		} else {
+			$data['payment_nmi_collectjs_order_status_id'] = $this->config->get('payment_nmi_collectjs_order_status_id');
+		}
+
+		$this->load->model('localisation/order_status');
+
+		$data['order_statuses'] = $this->model_localisation_order_status->getOrderStatuses();
+
+		if (isset($this->request->post['payment_nmi_collectjs_geo_zone_id'])) {
+			$data['payment_nmi_collectjs_geo_zone_id'] = $this->request->post['payment_nmi_collectjs_geo_zone_id'];
+		} else {
+			$data['payment_nmi_collectjs_geo_zone_id'] = $this->config->get('payment_nmi_collectjs_geo_zone_id');
+		}
+
+		$this->load->model('localisation/geo_zone');
+
+		$data['geo_zones'] = $this->model_localisation_geo_zone->getGeoZones();
+
+		if (isset($this->request->post['payment_nmi_collectjs_status'])) {
+			$data['payment_nmi_collectjs_status'] = $this->request->post['payment_nmi_collectjs_status'];
+		} else {
+			$data['payment_nmi_collectjs_status'] = $this->config->get('payment_nmi_collectjs_status');
+		}
+
+		if (isset($this->request->post['payment_nmi_collectjs_sort_order'])) {
+			$data['payment_nmi_collectjs_sort_order'] = $this->request->post['payment_nmi_collectjs_sort_order'];
+		} else {
+			$data['payment_nmi_collectjs_sort_order'] = $this->config->get('payment_nmi_collectjs_sort_order');
+		}
+
+		$data['header'] = $this->load->controller('common/header');
+		$data['column_left'] = $this->load->controller('common/column_left');
+		$data['footer'] = $this->load->controller('common/footer');
+
+		$this->response->setOutput($this->load->view('extension/payment/nmi_collectjs', $data));
+	}
+
+	protected function validate() {
+		if (!$this->user->hasPermission('modify', 'extension/payment/nmi_collectjs')) {
+			$this->error['warning'] = $this->language->get('error_permission');
+		}
+
+		if (!$this->request->post['payment_nmi_collectjs_api_key']) {
+			if (!$this->request->post['payment_nmi_collectjs_username']) {
+				$this->error['username'] = $this->language->get('error_username');
+			}
+
+			if (!$this->request->post['payment_nmi_collectjs_password']) {
+				$this->error['password'] = $this->language->get('error_password');
+			}
+		}
+
+		return !$this->error;
+	}
+}

--- a/upload/admin/language/en-gb/extension/payment/nmi_collectjs.php
+++ b/upload/admin/language/en-gb/extension/payment/nmi_collectjs.php
@@ -1,0 +1,36 @@
+<?php
+// Heading
+$_['heading_title']         = 'NMI Collect.js';
+
+// Text
+$_['text_extension']        = 'Extensions';
+$_['text_success']          = 'Success: You have modified NMI Collect.js account details!';
+$_['text_edit']             = 'Edit NMI Collect.js';
+$_['text_authorization']    = 'Authorization';
+$_['text_capture']          = 'Capture';
+$_['text_enabled']          = 'On';
+$_['text_disabled']         = 'Off';
+
+// Entry
+$_['entry_username']        = 'Username';
+$_['entry_password']        = 'Password';
+$_['entry_api_key']         = 'API Security Key';
+$_['entry_tokenization_key'] = 'Tokenization Key';
+$_['entry_dup_seconds']     = 'Duplication checking window (seconds)';
+$_['entry_method']          = 'Transaction Method';
+$_['entry_total']           = 'Total';
+$_['entry_order_status']    = 'Order Status';
+$_['entry_geo_zone']        = 'Geo Zone';
+$_['entry_status']          = 'Status';
+$_['entry_sort_order']      = 'Sort Order';
+$_['entry_debug']           = 'Debug Mode';
+
+// Help
+$_['help_total']            = 'The checkout total the order must reach before this payment method becomes active.';
+$_['help_api_key']          = 'If specified, username and password are ignored and need not be set.  This key needs the API permission only.';
+$_['help_tokenization_key'] = 'Do not use your API key here!  Create this key in the NMI console.';
+
+// Error
+$_['error_permission']      = 'Warning: You do not have permission to modify payment NMI Collect.js!';
+$_['error_username']        = 'Username or API key required!';
+$_['error_password']        = 'Password or API key required!';

--- a/upload/admin/view/template/extension/payment/nmi_collectjs.twig
+++ b/upload/admin/view/template/extension/payment/nmi_collectjs.twig
@@ -1,0 +1,165 @@
+{{ header }}{{ column_left }}
+<div id="content">
+  <div class="page-header">
+    <div class="container-fluid">
+      <div class="float-right">
+        <button type="submit" form="form-payment" data-toggle="tooltip" title="{{ button_save }}" class="btn btn-primary"><i class="fas fa-save"></i></button>
+        <a href="{{ cancel }}" data-toggle="tooltip" title="{{ button_cancel }}" class="btn btn-light"><i class="fas fa-reply"></i></a></div>
+      <h1>{{ heading_title }}</h1>
+      <ol class="breadcrumb">
+        {% for breadcrumb in breadcrumbs %}
+          <li class="breadcrumb-item"><a href="{{ breadcrumb.href }}">{{ breadcrumb.text }}</a></li>
+        {% endfor %}
+      </ol>
+    </div>
+  </div>
+  <div class="container-fluid">
+    {% if error_warning %}
+      <div class="alert alert-danger alert-dismissible"><i class="fas fa-exclamation-circle"></i> {{ error_warning }}
+        <button type="button" class="close" data-dismiss="alert">&times;</button>
+      </div>
+    {% endif %}
+    <div class="card">
+      <div class="card-header"><i class="fas fa-pencil-alt"></i> {{ text_edit }}</div>
+      <div class="card-body">
+        <form action="{{ action }}" method="post" enctype="multipart/form-data" id="form-payment">
+          <div class="form-group row required">
+            <label class="col-sm-2 col-form-label" for="input-username">{{ entry_username }}</label>
+            <div class="col-sm-10">
+              <input type="text" name="payment_nmi_collectjs_username" value="{{ payment_nmi_collectjs_username }}" placeholder="{{ entry_username }}" id="input-username" class="form-control"/>
+              {% if error_username %}
+                <div class="invalid-tooltip">{{ error_username }}</div>
+              {% endif %}
+            </div>
+          </div>
+          <div class="form-group row required">
+            <label class="col-sm-2 col-form-label" for="input-password">{{ entry_password }}</label>
+            <div class="col-sm-10">
+              <input type="text" name="payment_nmi_collectjs_password" value="{{ payment_nmi_collectjs_password }}" placeholder="{{ entry_password }}" id="input-password" class="form-control"/>
+              {% if error_password %}
+                <div class="invalid-tooltip">{{ error_password }}</div>
+              {% endif %}
+            </div>
+          </div>
+          <div class="form-group row required">
+            <label class="col-sm-2 col-form-label" for="input-api_key">{{ entry_api_key }}</label>
+            <div class="col-sm-10">
+              <input type="text" name="payment_nmi_collectjs_api_key" value="{{ payment_nmi_collectjs_api_key }}" placeholder="{{ entry_api_key }}" id="input-api_key" class="form-control"/>
+              <small class="form-text text-muted">{{ help_api_key }}</small>
+              {% if error_api_key %}
+                <div class="invalid-tooltip">{{ error_api_key }}</div>
+              {% endif %}
+            </div>
+          </div>
+          <div class="form-group row required">
+            <label class="col-sm-2 col-form-label" for="input-tokenization_key">{{ entry_tokenization_key }}</label>
+            <div class="col-sm-10">
+              <input type="text" name="payment_nmi_collectjs_tokenization_key" value="{{ payment_nmi_collectjs_tokenization_key }}" placeholder="{{ entry_tokenization_key }}" id="input-tokenization_key" class="form-control"/>
+              <small class="form-text text-muted">{{ help_tokenization_key }}</small>
+              {% if error_tokenization_key %}
+                <div class="invalid-tooltip">{{ error_tokenization_key }}</div>
+              {% endif %}
+            </div>
+          </div>
+          <div class="form-group row required">
+            <label class="col-sm-2 col-form-label" for="input-dup_seconds">{{ entry_dup_seconds }}</label>
+            <div class="col-sm-10">
+              <input type="text" name="payment_nmi_collectjs_dup_seconds" value="{{ payment_nmi_collectjs_dup_seconds }}" placeholder="{{ entry_dup_seconds }}" id="input-dup_seconds" class="form-control"/>
+              {% if error_dup_seconds %}
+                <div class="invalid-tooltip">{{ error_dup_seconds }}</div>
+              {% endif %}
+            </div>
+          </div>
+          <div class="form-group row">
+            <label class="col-sm-2 col-form-label" for="input-method">{{ entry_method }}</label>
+            <div class="col-sm-10">
+              <select name="payment_nmi_collectjs_method" id="input-method" class="form-control">
+                {% if payment_nmi_collectjs_method == 'authorization' %}
+                  <option value="authorization" selected="selected">{{ text_authorization }}</option>
+                {% else %}
+                  <option value="authorization">{{ text_authorization }}</option>
+                {% endif %}
+                {% if payment_nmi_collectjs_method == 'capture' %}
+                  <option value="capture" selected="selected">{{ text_capture }}</option>
+                {% else %}
+                  <option value="capture">{{ text_capture }}</option>
+                {% endif %}
+              </select>
+            </div>
+          </div>
+          <div class="form-group row">
+            <label class="col-sm-2 col-form-label" for="input-total">{{ entry_total }}</label>
+            <div class="col-sm-10">
+              <input type="text" name="payment_nmi_collectjs_total" value="{{ payment_nmi_collectjs_total }}" placeholder="{{ entry_total }}" id="input-total" class="form-control"/>
+              <small class="form-text text-muted">{{ help_total }}</small>
+            </div>
+          </div>
+          <div class="form-group row">
+            <label class="col-sm-2 col-form-label" for="input-order-status">{{ entry_order_status }}</label>
+            <div class="col-sm-10">
+              <select name="payment_nmi_collectjs_order_status_id" id="input-order-status" class="form-control">
+                {% for order_status in order_statuses %}
+                  {% if order_status.order_status_id == payment_nmi_collectjs_order_status_id %}
+                    <option value="{{ order_status.order_status_id }}" selected="selected">{{ order_status.name }}</option>
+                  {% else %}
+                    <option value="{{ order_status.order_status_id }}">{{ order_status.name }}</option>
+                  {% endif %}
+                {% endfor %}
+              </select>
+            </div>
+          </div>
+          <div class="form-group row">
+            <label class="col-sm-2 col-form-label" for="input-geo-zone">{{ entry_geo_zone }}</label>
+            <div class="col-sm-10">
+              <select name="payment_nmi_collectjs_geo_zone_id" id="input-geo-zone" class="form-control">
+                <option value="0">{{ text_all_zones }}</option>
+                {% for geo_zone in geo_zones %}
+                  {% if geo_zone.geo_zone_id == payment_nmi_collectjs_geo_zone_id %}
+                    <option value="{{ geo_zone.geo_zone_id }}" selected="selected">{{ geo_zone.name }}</option>
+                  {% else %}
+                    <option value="{{ geo_zone.geo_zone_id }}">{{ geo_zone.name }}</option>
+                  {% endif %}
+                {% endfor %}
+              </select>
+            </div>
+          </div>
+          <div class="form-group row">
+            <label class="col-sm-2 col-form-label" for="input-debug">{{ entry_debug }}</label>
+            <div class="col-sm-10">
+              <select name="payment_nmi_collectjs_debug" id="input-debug" class="form-control">
+                {% if payment_nmi_collectjs_debug %}
+                  <option value="1" selected="selected">{{ text_enabled }}</option>
+                  <option value="0">{{ text_disabled }}</option>
+                {% else %}
+                  <option value="1">{{ text_enabled }}</option>
+                  <option value="0" selected="selected">{{ text_disabled }}</option>
+                {% endif %}
+              </select>
+            </div>
+          </div>
+          <div class="form-group row">
+            <label class="col-sm-2 col-form-label" for="input-status">{{ entry_status }}</label>
+            <div class="col-sm-10">
+              <select name="payment_nmi_collectjs_status" id="input-status" class="form-control">
+                {% if payment_nmi_collectjs_status %}
+                  <option value="1" selected="selected">{{ text_enabled }}</option>
+                  <option value="0">{{ text_disabled }}</option>
+                {% else %}
+                  <option value="1">{{ text_enabled }}</option>
+                  <option value="0" selected="selected">{{ text_disabled }}</option>
+                {% endif %}
+              </select>
+            </div>
+          </div>
+          <div class="form-group row">
+            <label class="col-sm-2 col-form-label" for="input-sort-order">{{ entry_sort_order }}</label>
+            <div class="col-sm-10">
+              <input type="text" name="payment_nmi_collectjs_sort_order" value="{{ payment_nmi_collectjs_sort_order }}" placeholder="{{ entry_sort_order }}" id="input-sort-order" class="form-control"/>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{{ footer }} 

--- a/upload/catalog/controller/extension/payment/nmi_collectjs.php
+++ b/upload/catalog/controller/extension/payment/nmi_collectjs.php
@@ -1,0 +1,143 @@
+<?php
+class ControllerExtensionPaymentNMICollectJs extends Controller {
+	public function index() {
+		$this->load->language('extension/payment/nmi_collectjs');
+
+		$data["payment_nmi_collectjs_tokenization_key"] = $this->config->get('payment_nmi_collectjs_tokenization_key');
+
+		return $this->load->view('extension/payment/nmi_collectjs', $data);
+	}
+
+	public function send() {
+		$url = 'https://secure.nmi.com/api/transact.php';
+
+		$this->load->model('checkout/order');
+
+		$order_info = $this->model_checkout_order->getOrder($this->session->data['order_id']);
+
+		$dup_seconds = $this->config->get('payment_nmi_collectjs_dup_seconds');
+		if (!$dup_seconds) $dup_seconds = "0";
+
+		$api_key = $this->config->get('payment_nmi_collectjs_api_key');
+
+		$taxes = 0;
+		foreach ($this->cart->getTaxes() as $key => $value) {
+			$taxes += $value;
+		}
+		$shipping = 0;
+		if ($this->cart->hasShipping() && isset($this->session->data['shipping_method']))
+			$shipping = $this->session->data['shipping_method']['cost'];
+
+		$data = array();
+
+		$data['type'] = ($this->config->get('payment_nmi_collectjs_method') == 'capture') ? 'sale' : 'auth';
+		if ($api_key) {
+			$data['security_key'] = $api_key;
+		} else {
+			$data['username'] = $this->config->get('payment_nmi_collectjs_username');
+			$data['password'] = $this->config->get('payment_nmi_collectjs_password');
+		}
+		$data['payment_token'] = $this->request->post['cc_number'];
+		$data['amount'] = sprintf("%.2f", $order_info['total']);
+		$data['currency'] = $this->session->data['currency'];
+		$data['dup_seconds'] = $dup_seconds;
+		$data['orderid'] = $this->session->data['order_id'];
+		$data['ipaddress'] = $this->request->server['REMOTE_ADDR'];
+		$data['tax'] = sprintf("%.2f", $taxes);
+		$data['shipping'] = sprintf("%.2f", $shipping);
+		$data['first_name'] = html_entity_decode($order_info['payment_firstname'], ENT_QUOTES, 'UTF-8');
+		$data['last_name'] = html_entity_decode($order_info['payment_lastname'], ENT_QUOTES, 'UTF-8');
+		$data['company'] = html_entity_decode($order_info['payment_company'], ENT_QUOTES, 'UTF-8');
+		$data['address1'] = html_entity_decode($order_info['payment_address_1'], ENT_QUOTES, 'UTF-8');
+		$data['address2'] = html_entity_decode($order_info['payment_address_2'], ENT_QUOTES, 'UTF-8');
+		$data['city'] = html_entity_decode($order_info['payment_city'], ENT_QUOTES, 'UTF-8');
+		$data['state'] = html_entity_decode($order_info['payment_zone'], ENT_QUOTES, 'UTF-8');
+		$data['zip'] = html_entity_decode($order_info['payment_postcode'], ENT_QUOTES, 'UTF-8');
+		$data['country'] = html_entity_decode($order_info['payment_country'], ENT_QUOTES, 'UTF-8');
+		$data['phone'] = $order_info['telephone'];
+		$data['email'] = $order_info['email'];
+		$data['order_description'] = html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8');
+
+		/* Customer Shipping Address Fields */
+		if ($order_info['shipping_method']) {
+			$data['shipping_firstname'] = html_entity_decode($order_info['shipping_firstname'], ENT_QUOTES, 'UTF-8');
+			$data['shipping_lastname'] = html_entity_decode($order_info['shipping_lastname'], ENT_QUOTES, 'UTF-8');
+			$data['shipping_company'] = html_entity_decode($order_info['shipping_company'], ENT_QUOTES, 'UTF-8');
+			$data['shipping_address1'] = html_entity_decode($order_info['shipping_address_1'], ENT_QUOTES, 'UTF-8');
+			$data['shipping_address2'] = html_entity_decode($order_info['shipping_address_2'], ENT_QUOTES, 'UTF-8');
+			$data['shipping_city'] = html_entity_decode($order_info['shipping_city'], ENT_QUOTES, 'UTF-8');
+			$data['shipping_state'] = html_entity_decode($order_info['shipping_zone'], ENT_QUOTES, 'UTF-8');
+			$data['shipping_zip'] = html_entity_decode($order_info['shipping_postcode'], ENT_QUOTES, 'UTF-8');
+			$data['shipping_country'] = html_entity_decode($order_info['shipping_country'], ENT_QUOTES, 'UTF-8');
+		} else {
+			$data['shipping_firstname'] = html_entity_decode($order_info['payment_firstname'], ENT_QUOTES, 'UTF-8');
+			$data['shipping_lastname'] = html_entity_decode($order_info['payment_lastname'], ENT_QUOTES, 'UTF-8');
+			$data['shipping_company'] = html_entity_decode($order_info['payment_company'], ENT_QUOTES, 'UTF-8');
+			$data['shipping_address1'] = html_entity_decode($order_info['payment_address_1'], ENT_QUOTES, 'UTF-8');
+			$data['shipping_address2'] = html_entity_decode($order_info['payment_address_2'], ENT_QUOTES, 'UTF-8');
+			$data['shipping_city'] = html_entity_decode($order_info['payment_city'], ENT_QUOTES, 'UTF-8');
+			$data['shipping_state'] = html_entity_decode($order_info['payment_zone'], ENT_QUOTES, 'UTF-8');
+			$data['shipping_zip'] = html_entity_decode($order_info['payment_postcode'], ENT_QUOTES, 'UTF-8');
+			$data['shipping_country'] = html_entity_decode($order_info['payment_country'], ENT_QUOTES, 'UTF-8');
+		}
+
+		$curl = curl_init($url);
+		$query = http_build_query($data);
+
+		curl_setopt($curl, CURLOPT_PORT, 443);
+		curl_setopt($curl, CURLOPT_HEADER, 0);
+		curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 0);
+		curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+		curl_setopt($curl, CURLOPT_FORBID_REUSE, 1);
+		curl_setopt($curl, CURLOPT_FRESH_CONNECT, 1);
+		curl_setopt($curl, CURLOPT_POST, 1);
+		curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 10);
+		curl_setopt($curl, CURLOPT_TIMEOUT, 10);
+		curl_setopt($curl, CURLOPT_POSTFIELDS, $query);
+
+		if ($this->config->get('payment_nmi_collectjs_debug')) $this->log->write('NMI COLLECTJS SEND: ' . $query);
+
+		$response = curl_exec($curl);
+		if ($this->config->get('payment_nmi_collectjs_debug')) $this->log->write('NMI COLLECTJS RECV: ' . $response);
+
+		$json = array();
+
+		if (curl_error($curl)) {
+			$json['error'] = 'CURL ERROR: ' . curl_errno($curl) . '::' . curl_error($curl);
+
+			$this->log->write('NMI COLLECTJS CURL ERROR: ' . curl_errno($curl) . '::' . curl_error($curl));
+		} elseif ($response) {
+			$response_data = array();
+			parse_str($response, $response_data);
+
+			if ($response_data['response'] == '1') { //success
+				$message = '';
+				if (isset($response_data['response_code'])) $message .= $response_data['response_code'] . ' ';
+				if (isset($response_data['responsetext'])) $message .= $response_data['responsetext'] . "\n";
+				if (isset($response_data['authcode'])) $message .= 'Authorization Code: ' . $response_data['authcode'] . "\n";
+				if (isset($response_data['transactionid'])) $message .= 'Transaction ID: ' . $response_data['transactionid'] . "\n";
+				if (isset($response_data['avsresponse'])) $message .= 'AVS Response: ' . $response_data['avsresponse'] . "\n";
+				if (isset($response_data['cvvresponse'])) $message .= 'CVV Response: ' . $response_data['cvvresponse'];
+
+				$this->model_checkout_order->addOrderHistory($this->session->data['order_id'], $this->config->get('payment_nmi_collectjs_order_status_id'), $message, false);
+				$json['redirect'] = $this->url->link('checkout/success', 'language=' . $this->config->get('config_language'));
+			}
+			elseif ($response_data['response'] == '2') { //decline
+				$json['error'] = 'Transaction declined by bank: ' . $response_data['response_code'] . ' ' . $response_data['responsetext'];
+			}
+			else { //error
+				$json['error'] = 'Internal system error';
+				$this->log->write('NMI COLLECTJS ERROR: ' . $response);
+			}
+		} else {
+			$json['error'] = 'Empty Gateway Response';
+
+			$this->log->write('NMI COLLECTJS CURL ERROR: Empty Gateway Response');
+		}
+
+		curl_close($curl);
+
+		$this->response->addHeader('Content-Type: application/json');
+		$this->response->setOutput(json_encode($json));
+	}
+}

--- a/upload/catalog/controller/extension/payment/nmi_collectjs.php
+++ b/upload/catalog/controller/extension/payment/nmi_collectjs.php
@@ -86,7 +86,7 @@ class ControllerExtensionPaymentNMICollectJs extends Controller {
 
 		curl_setopt($curl, CURLOPT_PORT, 443);
 		curl_setopt($curl, CURLOPT_HEADER, 0);
-		curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 0);
+		curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 1);
 		curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
 		curl_setopt($curl, CURLOPT_FORBID_REUSE, 1);
 		curl_setopt($curl, CURLOPT_FRESH_CONNECT, 1);

--- a/upload/catalog/language/en-gb/extension/payment/nmi_collectjs.php
+++ b/upload/catalog/language/en-gb/extension/payment/nmi_collectjs.php
@@ -1,0 +1,11 @@
+<?php
+// Text
+$_['text_title']           = 'Credit Card / Debit Card';
+$_['text_loading']         = 'Loading...';
+
+$_['text_credit_card']     = 'Credit Card Details';
+
+// Entry
+$_['entry_cc_number']      = 'Card Number';
+$_['entry_cc_expire_date'] = 'Card Expiry Date';
+$_['entry_cc_cvv2']        = 'Card Security Code (CVV2)';

--- a/upload/catalog/model/extension/payment/nmi_collectjs.php
+++ b/upload/catalog/model/extension/payment/nmi_collectjs.php
@@ -1,0 +1,31 @@
+<?php
+class ModelExtensionPaymentNMICollectJS extends Model {
+	public function getMethod($address, $total) {
+		$this->load->language('extension/payment/nmi_collectjs');
+
+		$query = $this->db->query("SELECT * FROM " . DB_PREFIX . "zone_to_geo_zone WHERE geo_zone_id = '" . (int)$this->config->get('payment_nmi_collectjs_geo_zone_id') . "' AND country_id = '" . (int)$address['country_id'] . "' AND (zone_id = '" . (int)$address['zone_id'] . "' OR zone_id = '0')");
+
+		if ($this->config->get('payment_nmi_collectjs_total') > 0 && $this->config->get('payment_nmi_collectjs_total') > $total) {
+			$status = false;
+		} elseif (!$this->config->get('payment_nmi_collectjs_geo_zone_id')) {
+			$status = true;
+		} elseif ($query->num_rows) {
+			$status = true;
+		} else {
+			$status = false;
+		}
+
+		$method_data = array();
+
+		if ($status) {
+			$method_data = array(
+				'code'       => 'nmi_collectjs',
+				'title'      => $this->language->get('text_title'),
+				'terms'      => '',
+				'sort_order' => $this->config->get('payment_nmi_collectjs_sort_order')
+			);
+		}
+
+		return $method_data;
+	}
+}

--- a/upload/catalog/view/theme/default/template/extension/payment/nmi_collectjs.twig
+++ b/upload/catalog/view/theme/default/template/extension/payment/nmi_collectjs.twig
@@ -1,0 +1,127 @@
+<form id="payment">
+  <fieldset>
+    <legend>{{ text_credit_card }}</legend>
+    <div id="nmi-collectjs-loading">
+      <div class="text-center alert alert-info"><i class="fas fa-circle-o-notch fa-spin"></i>&nbsp;{{ text_loading }}</div>
+    </div>
+    <div id="nmi-collectjs-timeout" class="text-center alert alert-warning d-none"><i class="fas fa-circle-o-notch fa-spin"></i>&nbsp;{{ text_timeout }}</div>
+    <div class="form-group row required">
+      <label class="col-sm-2 col-form-label" for="ccnumber">{{ entry_cc_number }}</label>
+      <div class="col-sm-10">
+        <div class="form-control" id="ccnumber" />
+        <div class="alert alert-danger d-none" id="error-ccnumber"></div>
+      </div>
+    </div>
+    <div class="form-group row required">
+      <label class="col-sm-2 col-form-label" for="ccexp">{{ entry_cc_expire_date }}</label>
+      <div class="col-sm-10">
+        <div class="form-control" id="ccexp" />
+        <div class="alert alert-danger d-none" id="error-ccexp"></div>
+      </div>
+    </div>
+    <div class="form-group row required">
+      <label class="col-sm-2 col-form-label" for="cvv">{{ entry_cc_cvv2 }}</label>
+      <div class="col-sm-10">
+        <div class="form-control" id="cvv" />
+        <div class="alert alert-danger d-none" id="error-cvv"></div>
+      </div>
+    </div>
+  </fieldset>
+  <input type="hidden" name="cc_number" id="token" />
+  <div class="d-inline-block pt-2 pd-2 w-100">
+    <div class="float-right">
+      <button type="button" id="button-confirm" class="btn btn-primary">{{ button_confirm }}</button>
+    </div>
+  </div>
+</form>
+<script type="text/javascript"><!--
+  function fieldsAvailableCollectJS() {
+    document.getElementById('nmi-collectjs-loading').remove();
+  };
+
+  function tokenCallbackCollectJS(resp) {
+    document.getElementById('token').value = resp.token;
+    $.ajax({
+      url: 'index.php?route=extension/payment/nmi_collectjs/send',
+      type: 'post',
+      data: $('#payment :input'),
+      dataType: 'json',
+      cache: false,
+      beforeSend: function() {
+        $('#button-confirm').button('loading');
+      },
+      complete: function() {
+        $('#button-confirm').button('reset');
+      },
+      success: function(json) {
+        if (json['error']) {
+          alert(json['error']);
+        }
+
+        if (json['redirect']) {
+          location = json['redirect'];
+        }
+      }
+    });
+  };
+
+  var CollectJSErrFd = {
+    "ccnumber": document.getElementById("error-ccnumber"),
+    "ccexp": document.getElementById("error-ccexp"),
+    "cvv": document.getElementById("error-cvv")
+  };
+
+  var CollectJSTimeoutFd = document.getElementById("nmi-collectjs-timeout");
+  var ConfirmButton = document.getElementById("button-confirm");
+
+  function validationCallbackCollectJS(field, status, message) {
+    var fd = CollectJSErrFd[field];
+    if (status) {
+      fd.classList.add("d-none");
+    }
+    else {
+      fd.innerText = message;
+      fd.classList.remove("d-none");
+    }
+  }
+
+  function timeoutCallbackCollectJS() {
+    CollectJSTimeoutFd.classList.remove("d-none");
+  }
+
+  function configureCollectJS() {
+    CollectJS.configure({
+      "variant": "inline",
+      "styleSniffer": "false",
+      "customCss": {
+        "border": "none",
+        "border-color": "transparent",
+        "outline": "none",
+        "outline-color": "transparent"
+      },
+      "fieldsAvailableCallback": fieldsAvailableCollectJS,
+      "fields": {
+        "ccnumber": {
+          "placeholder": "{{ entry_cc_number }}"
+        },
+        "ccexp": {
+          "placeholder": "{{ entry_cc_expire_date }}"
+        },
+        "cvv": {
+          "placeholder": "{{ entry_cc_cvv2 }}"
+        }
+      },
+      "callback": tokenCallbackCollectJS,
+      "validationCallback": validationCallbackCollectJS,
+      "timeoutDuration": 2000,
+      "timeoutCallback": CollectJSTimeoutFd
+    });
+    ConfirmButton.addEventListener("click", CollectJS.startPaymentRequest);
+  };
+
+  var sc = document.createElement("SCRIPT");
+  sc.src = "https://secure.nmi.com/token/Collect.js";
+  sc.setAttribute("data-tokenization-key", "{{ payment_nmi_collectjs_tokenization_key }}");
+  sc.onload = configureCollectJS;
+  document.getElementsByTagName("HEAD")[0].appendChild(sc);
+//--></script>


### PR DESCRIPTION
Add built-in support for the USA merchant account platform NMI.  Support is done using their inline collect.js option, which uses iframes to gather card data, which should reduce the PCI compliance burden to something like SAQ A-EP rather than the SAQ-D required for authorize.net emulation with them.