### PR TITLE
Fix instances of CWE-113 HTTP response splitting

### DIFF
--- a/upload/admin/controller/common/login.php
+++ b/upload/admin/controller/common/login.php
@@ -67,7 +67,7 @@ class ControllerCommonLogin extends Controller {
 				$url .= http_build_query($this->request->get);
 			}
 
-			$data['redirect'] = $this->url->link($route, $url);
+			$data['redirect'] = str_replace(array("\r", "\n"), "", $this->url->link($route, $url));
 		} else {
 			$data['redirect'] = '';
 		}

--- a/upload/catalog/controller/common/currency.php
+++ b/upload/catalog/controller/common/currency.php
@@ -41,7 +41,7 @@ class ControllerCommonCurrency extends Controller {
 			$url = '&' . urldecode(http_build_query($url_data, '', '&'));
 		}
 
-		$data['redirect'] = $this->url->link($route, $url);
+		$data['redirect'] = str_replace(array("\r", "\n"), "", $this->url->link($route, $url));
 
 		return $this->load->view('common/currency', $data);
 	}


### PR DESCRIPTION
This issue fixes a vulnerability where in some cases it is possible to split HTTP responses, which proxies and clients will tend to interpret in such a way as to allow the attacker to set arbitrary headers or cause the server to appear to send arbitrary resources based on the request URI.  The fix here is to strip CR and LF out of the redirect value in the two instances where it's based on the query string used to invoke the controller.