### PR TITLE
OC 3.0.3.2 (and up) > Fatal error: Uncaught Exception: Error: Field '…

### DIFF
--- a/upload/system/helper/db_schema.php
+++ b/upload/system/helper/db_schema.php
@@ -2076,12 +2076,14 @@ function db_schema() {
 			array(
 				'name' => 'status',
 				'type' => 'tinyint(1)',
-				'not_null' => true
+				'not_null' => true,
+				'default' => '0'
 			),
 			array(
 				'name' => 'sort_order',
 				'type' => 'int(3)',
-				'not_null' => true
+				'not_null' => true,
+				'default' => '1'
 			)
 		),
 		'primary' => array(


### PR DESCRIPTION
…sort_order' doesn't have a default value

Fatal` error: Uncaught Exception: Error: Field 'sort_order' doesn't have a default value<br />Error No: 1364<br /> INSERT INTO `oc_event` (`event_id`, `code`, `trigger`, `action`, `status`) VALUES (1, 'activity_customer_add', 'catalog/model/account/customer/addCustomer/after', 'event/activity/addCustomer', 1); 

While this error occur in OC 3.0.3.2, it will also later if the fields have no default value because if no sort_order is submitted (as it will be in most cases).