### PR TITLE
Fix support for session lifetimes other than 0, secure flag, and httponly flag

### DIFF
--- a/upload/admin/controller/startup/startup.php
+++ b/upload/admin/controller/startup/startup.php
@@ -29,7 +29,7 @@ class ControllerStartupStartup extends Controller {
 
 		$this->session->start($session_id);
 
-		setcookie($this->config->get('session_name'), $this->session->getId(), ini_get('session.cookie_lifetime'), ini_get('session.cookie_path'), ini_get('session.cookie_domain'));
+		setcookie($this->config->get('session_name'), $this->session->getId(), (ini_get('session.cookie_lifetime') ? (time() + ini_get('session.cookie_lifetime')) : 0), ini_get('session.cookie_path'), ini_get('session.cookie_domain'), ini_get('session.cookie_secure'), ini_get('session.cookie_httponly'));
 
 		// Response output compression level
 		if ($this->config->get('config_compression')) {

--- a/upload/catalog/controller/startup/startup.php
+++ b/upload/catalog/controller/startup/startup.php
@@ -58,7 +58,7 @@ class ControllerStartupStartup extends Controller {
 
 			$this->session->start($session_id);
 
-			setcookie($this->config->get('session_name'), $this->session->getId(), ini_get('session.cookie_lifetime'), ini_get('session.cookie_path'), ini_get('session.cookie_domain'));
+			setcookie($this->config->get('session_name'), $this->session->getId(), (ini_get('session.cookie_lifetime') ? (time() + ini_get('session.cookie_lifetime')) : 0), ini_get('session.cookie_path'), ini_get('session.cookie_domain'), ini_get('session.cookie_secure'), ini_get('session.cookie_httponly'));
 		}
 
 		// Response output compression level


### PR DESCRIPTION
Fix support for session lifetimes other than 0 for sessions set via admin and catalog (mirroring fix from daaa9b6113d51fcaf53fd2c11ede32abb51021b0).  Add support for secure and httponly flags to session cookie.

This corrects the same issue as the noted commit, where set_cookie got passed the raw value of session.cookie_lifetime, so admin and user session cookies were expiring at whatever that time was after the unix epoch instead of present (works fine for 0, not for other values).