### PR TITLE
Update googleshopping

### DIFF
--- a/upload/system/library/googleshopping/googleshopping.php
+++ b/upload/system/library/googleshopping/googleshopping.php
@@ -351,6 +351,8 @@ class Googleshopping extends Library {
 
                 if ($parts[2] >= '1970-01-01') {
                     $special_price['end'] = $parts[2];
+                } else {
+                    unset($special_price['start']);
                 }
             }
 


### PR DESCRIPTION
There is a parametr called "sale_price_effective_date"  in google feed, which is two dates range (start and end) of the special price is active. If there won't be end or start date, so the feed won't be created.