### PR TITLE
Update map.php - Fix for empty map

### DIFF
--- a/upload/admin/model/extension/dashboard/map.php
+++ b/upload/admin/model/extension/dashboard/map.php
@@ -10,7 +10,7 @@ class ModelExtensionDashboardMap extends Model {
 		}
 		
 		if ($implode) {
-			$query = $this->db->query("SELECT COUNT(*) AS total, SUM(o.total) AS amount, c.iso_code_2 FROM `" . DB_PREFIX . "order` o LEFT JOIN `" . DB_PREFIX . "country` c ON (o.payment_country_id = c.country_id) WHERE o.order_status_id IN('" . (int)implode(',', $implode) . "') GROUP BY o.payment_country_id");
+			$query = $this->db->query("SELECT COUNT(*) AS total, SUM(o.total) AS amount, c.iso_code_2 FROM `" . DB_PREFIX . "order` o LEFT JOIN `" . DB_PREFIX . "country` c ON (o.payment_country_id = c.country_id) WHERE o.order_status_id IN(" . implode(',', $implode) . ") GROUP BY o.payment_country_id");
 
 			return $query->rows;
 		} else {


### PR DESCRIPTION
If you have multiple complete statuses then you would get a statement like "WHERE o.order_status_id IN('5,3')" which gives 0 results because of the quotes. If you leave the int() declaration before the implode() function you get "WHERE o.order_status_id IN(5)".

Removing both the quotes and the (int) declaration before the implode() function gives a working map again.