### PR TITLE
Create authorize.net accept hosted payment extension

### DIFF
--- a/upload/admin/controller/extension/payment/authorizenet_accept_hosted.php
+++ b/upload/admin/controller/extension/payment/authorizenet_accept_hosted.php
@@ -1,0 +1,157 @@
+<?php
+class ControllerExtensionPaymentAuthorizeNetAcceptHosted extends Controller {
+	private $error = array();
+
+	public function index() {
+		$this->load->language('extension/payment/authorizenet_accept_hosted');
+
+		$this->document->setTitle($this->language->get('heading_title'));
+
+		$this->load->model('setting/setting');
+
+		if (($this->request->server['REQUEST_METHOD'] == 'POST') && $this->validate()) {
+			$this->model_setting_setting->editSetting('payment_authorizenet_accept_hosted', $this->request->post);
+
+			$this->session->data['success'] = $this->language->get('text_success');
+
+			$this->response->redirect($this->url->link('marketplace/extension', 'user_token=' . $this->session->data['user_token'] . '&type=payment'));
+		}
+
+		if (isset($this->error['warning'])) {
+			$data['error_warning'] = $this->error['warning'];
+		} else {
+			$data['error_warning'] = '';
+		}
+
+		if (isset($this->error['name'])) {
+			$data['error_name'] = $this->error['name'];
+		} else {
+			$data['error_name'] = '';
+		}
+
+		if (isset($this->error['key'])) {
+			$data['error_key'] = $this->error['key'];
+		} else {
+			$data['error_key'] = '';
+		}
+
+		$data['breadcrumbs'] = array();
+
+		$data['breadcrumbs'][] = array(
+			'text' => $this->language->get('text_home'),
+			'href' => $this->url->link('common/dashboard', 'user_token=' . $this->session->data['user_token'])
+		);
+
+		$data['breadcrumbs'][] = array(
+			'text' => $this->language->get('text_extension'),
+			'href' => $this->url->link('marketplace/extension', 'user_token=' . $this->session->data['user_token'] . '&type=payment')
+		);
+
+		$data['breadcrumbs'][] = array(
+			'text' => $this->language->get('heading_title'),
+			'href' => $this->url->link('extension/payment/authorizenet_accept_hosted', 'user_token=' . $this->session->data['user_token'])
+		);
+
+		$data['action'] = $this->url->link('extension/payment/authorizenet_accept_hosted', 'user_token=' . $this->session->data['user_token']);
+
+		$data['cancel'] = $this->url->link('marketplace/extension', 'user_token=' . $this->session->data['user_token'] . '&type=payment');
+
+		if (isset($this->request->post['payment_authorizenet_accept_hosted_name'])) {
+			$data['payment_authorizenet_accept_hosted_name'] = $this->request->post['payment_authorizenet_accept_hosted_name'];
+		} else {
+			$data['payment_authorizenet_accept_hosted_name'] = $this->config->get('payment_authorizenet_accept_hosted_name');
+		}
+
+		if (isset($this->request->post['payment_authorizenet_accept_hosted_transaction_key'])) {
+			$data['payment_authorizenet_accept_hosted_transaction_key'] = $this->request->post['payment_authorizenet_accept_hosted_transaction_key'];
+		} else {
+			$data['payment_authorizenet_accept_hosted_transaction_key'] = $this->config->get('payment_authorizenet_accept_hosted_transaction_key');
+		}
+
+		if (isset($this->request->post['payment_authorizenet_accept_hosted_credit_enabled'])) {
+			$data['payment_authorizenet_accept_hosted_credit_enabled'] = $this->request->post['payment_authorizenet_accept_hosted_credit_enabled'];
+		} else {
+			$data['payment_authorizenet_accept_hosted_credit_enabled'] = $this->config->get('payment_authorizenet_accept_hosted_credit_enabled');
+		}
+
+		if (isset($this->request->post['payment_authorizenet_accept_hosted_ach_enabled'])) {
+			$data['payment_authorizenet_accept_hosted_ach_enabled'] = $this->request->post['payment_authorizenet_accept_hosted_ach_enabled'];
+		} else {
+			$data['payment_authorizenet_accept_hosted_ach_enabled'] = $this->config->get('payment_authorizenet_accept_hosted_ach_enabled');
+		}
+
+		if (isset($this->request->post['payment_authorizenet_accept_hosted_testmode'])) {
+			$data['payment_authorizenet_accept_hosted_testmode'] = $this->request->post['payment_authorizenet_accept_hosted_testmode'];
+		} else {
+			$data['payment_authorizenet_accept_hosted_testmode'] = $this->config->get('payment_authorizenet_accept_hosted_testmode');
+		}
+
+		if (isset($this->request->post['payment_authorizenet_accept_hosted_debug'])) {
+			$data['payment_authorizenet_accept_hosted_debug'] = $this->request->post['payment_authorizenet_accept_hosted_debug'];
+		} else {
+			$data['payment_authorizenet_accept_hosted_debug'] = $this->config->get('payment_authorizenet_accept_hosted_debug');
+		}
+
+		$data['callback'] = HTTP_CATALOG . 'index.php?route=extension/payment/authorizenet_accept_hosted/callback';
+
+		if (isset($this->request->post['payment_authorizenet_accept_hosted_total'])) {
+			$data['payment_authorizenet_accept_hosted_total'] = $this->request->post['payment_authorizenet_accept_hosted_total'];
+		} else {
+			$data['payment_authorizenet_accept_hosted_total'] = $this->config->get('payment_authorizenet_accept_hosted_total');
+		}
+
+		if (isset($this->request->post['payment_authorizenet_accept_hosted_order_status_id'])) {
+			$data['payment_authorizenet_accept_hosted_order_status_id'] = $this->request->post['payment_authorizenet_accept_hosted_order_status_id'];
+		} else {
+			$data['payment_authorizenet_accept_hosted_order_status_id'] = $this->config->get('payment_authorizenet_accept_hosted_order_status_id');
+		}
+
+		$this->load->model('localisation/order_status');
+
+		$data['order_statuses'] = $this->model_localisation_order_status->getOrderStatuses();
+
+		if (isset($this->request->post['payment_authorizenet_accept_hosted_geo_zone_id'])) {
+			$data['payment_authorizenet_accept_hosted_geo_zone_id'] = $this->request->post['payment_authorizenet_accept_hosted_geo_zone_id'];
+		} else {
+			$data['payment_authorizenet_accept_hosted_geo_zone_id'] = $this->config->get('payment_authorizenet_accept_hosted_geo_zone_id');
+		}
+
+		$this->load->model('localisation/geo_zone');
+
+		$data['geo_zones'] = $this->model_localisation_geo_zone->getGeoZones();
+
+		if (isset($this->request->post['payment_authorizenet_accept_hosted_status'])) {
+			$data['payment_authorizenet_accept_hosted_status'] = $this->request->post['payment_authorizenet_accept_hosted_status'];
+		} else {
+			$data['payment_authorizenet_accept_hosted_status'] = $this->config->get('payment_authorizenet_accept_hosted_status');
+		}
+
+		if (isset($this->request->post['payment_authorizenet_accept_hosted_sort_order'])) {
+			$data['payment_authorizenet_accept_hosted_sort_order'] = $this->request->post['payment_authorizenet_accept_hosted_sort_order'];
+		} else {
+			$data['payment_authorizenet_accept_hosted_sort_order'] = $this->config->get('payment_authorizenet_accept_hosted_sort_order');
+		}
+
+		$data['header'] = $this->load->controller('common/header');
+		$data['column_left'] = $this->load->controller('common/column_left');
+		$data['footer'] = $this->load->controller('common/footer');
+
+		$this->response->setOutput($this->load->view('extension/payment/authorizenet_accept_hosted', $data));
+	}
+
+	protected function validate() {
+		if (!$this->user->hasPermission('modify', 'extension/payment/authorizenet_accept_hosted')) {
+			$this->error['warning'] = $this->language->get('error_permission');
+		}
+
+		if (!$this->request->post['payment_authorizenet_accept_hosted_name']) {
+			$this->error['name'] = $this->language->get('error_name');
+		}
+
+		if (!$this->request->post['payment_authorizenet_accept_hosted_transaction_key']) {
+			$this->error['key'] = $this->language->get('error_key');
+		}
+
+		return !$this->error;
+	}
+}

--- a/upload/admin/language/en-gb/extension/payment/authorizenet_accept_hosted.php
+++ b/upload/admin/language/en-gb/extension/payment/authorizenet_accept_hosted.php
@@ -1,0 +1,31 @@
+<?php
+// Heading
+$_['heading_title']			= 'Authorize.Net (Accept Hosted)';
+
+// Text
+$_['text_extension']			= 'Extensions';
+$_['text_success']			= 'Success: You have modified Authorize.Net (Accept Hosted) account details!';
+$_['text_edit']             		= 'Edit Authorize.Net (Accept Hosted)';
+
+// Entry
+$_['entry_merchant_name']		= 'API Login ID';
+$_['entry_transaction_key']		= 'Transaction Key';
+$_['entry_callback']			= 'Relay Response URL';
+$_['entry_credit_enabled']		= 'Credit Payment';
+$_['entry_ach_enabled']			= 'ACH Payment (requires ECheck.net)';
+$_['entry_testmode']			= 'Use Sandbox Endpoint';
+$_['entry_debug']			= 'Debug';
+$_['entry_total']			= 'Total';
+$_['entry_order_status']		= 'Order Status';
+$_['entry_geo_zone']			= 'Geo Zone';
+$_['entry_status']			= 'Status';
+$_['entry_sort_order']			= 'Sort Order';
+
+// Help
+$_['help_callback']			= 'Please login and set this at <a href="https://secure.authorize.net" target="_blank" class="txtLink">https://secure.authorize.net</a>.';
+$_['help_total']			= 'The checkout total the order must reach before this payment method becomes active.';
+
+// Error
+$_['error_permission']			= 'Warning: You do not have permission to modify payment Authorize.Net (Accept Hosted)!';
+$_['error_name']			= 'API login ID required!';
+$_['error_key']				= 'Transaction Key Required!';

--- a/upload/admin/view/template/extension/payment/authorizenet_accept_hosted.twig
+++ b/upload/admin/view/template/extension/payment/authorizenet_accept_hosted.twig
@@ -1,0 +1,168 @@
+{{ header }}{{ column_left }}
+<div id="content">
+  <div class="page-header">
+    <div class="container-fluid">
+      <div class="float-right">
+        <button type="submit" form="form-payment" data-toggle="tooltip" title="{{ button_save }}" class="btn btn-primary"><i class="fas fa-save"></i></button>
+        <a href="{{ cancel }}" data-toggle="tooltip" title="{{ button_cancel }}" class="btn btn-light"><i class="fas fa-reply"></i></a></div>
+      <h1>{{ heading_title }}</h1>
+      <ol class="breadcrumb">
+        {% for breadcrumb in breadcrumbs %}
+          <li class="breadcrumb-item"><a href="{{ breadcrumb.href }}">{{ breadcrumb.text }}</a></li>
+        {% endfor %}
+      </ol>
+    </div>
+  </div>
+  <div class="container-fluid">
+    {% if error_warning %}
+      <div class="alert alert-danger alert-dismissible"><i class="fas fa-exclamation-circle"></i> {{ error_warning }}
+        <button type="button" class="close" data-dismiss="alert">&times;</button>
+      </div>
+    {% endif %}
+    <div class="card">
+      <div class="card-header"><i class="fas fa-pencil-alt"></i> {{ text_edit }}</div>
+      <div class="card-body">
+        <form action="{{ action }}" method="post" enctype="multipart/form-data" id="form-payment">
+          <div class="form-group row required">
+            <label class="col-sm-2 col-form-label" for="input-name">{{ entry_merchant_name }}</label>
+            <div class="col-sm-10">
+              <input type="text" name="payment_authorizenet_accept_hosted_name" value="{{ payment_authorizenet_accept_hosted_name }}" placeholder="{{ entry_merchant_name }}" id="input-name" class="form-control"/>
+              {% if error_name %}
+                <div class="invalid-tooltip">{{ error_name }}</div>
+              {% endif %}
+            </div>
+          </div>
+          <div class="form-group row required">
+            <label class="col-sm-2 col-form-label" for="input-key">{{ entry_transaction_key }}</label>
+            <div class="col-sm-10">
+              <input type="text" name="payment_authorizenet_accept_hosted_transaction_key" value="{{ payment_authorizenet_accept_hosted_transaction_key }}" placeholder="{{ entry_transaction_key }}" id="input-key" class="form-control"/>
+              {% if error_transaction_key %}
+                <div class="invalid-tooltip">{{ error_key }}</div>
+              {% endif %}
+            </div>
+          </div>
+          <div class="form-group row">
+            <label class="col-sm-2 col-form-label" for="input-callback">{{ entry_callback }}</label>
+            <div class="col-sm-10">
+              <textarea rows="5" readonly id="input-callback" class="form-control">{{ callback }}</textarea>
+              <small class="form-text text-muted">{{ help_callback }}</small>
+            </div>
+          </div>
+          <div class="form-group row">
+            <label class="col-sm-2 col-form-label">{{ entry_credit_enabled }}</label>
+            <div class="col-sm-10">
+              <div class="btn-group btn-group-toggle" data-toggle="buttons">
+                {% if payment_authorizenet_accept_hosted_credit_enabled %}
+                  <label class="btn btn-outline-secondary active"><input type="radio" name="payment_authorizenet_accept_hosted_credit_enabled" value="1" checked="checked"/> {{ text_yes }}</label>
+                  <label class="btn btn-outline-secondary"><input type="radio" name="payment_authorizenet_accept_hosted_credit_enabled" value="0"/> {{ text_no }}</label>
+                {% else %}
+                  <label class="btn btn-outline-secondary"><input type="radio" name="payment_authorizenet_accept_hosted_credit_enabled" value="1"/> {{ text_yes }}</label>
+                  <label class="btn btn-outline-secondary active"><input type="radio" name="payment_authorizenet_accept_hosted_credit_enabled" value="0" checked="checked"/> {{ text_no }}</label>
+                {% endif %}
+              </div>
+            </div>
+          </div>
+          <div class="form-group row">
+            <label class="col-sm-2 col-form-label">{{ entry_ach_enabled }}</label>
+            <div class="col-sm-10">
+              <div class="btn-group btn-group-toggle" data-toggle="buttons">
+                {% if payment_authorizenet_accept_hosted_ach_enabled %}
+                  <label class="btn btn-outline-secondary active"><input type="radio" name="payment_authorizenet_accept_hosted_ach_enabled" value="1" checked="checked"/> {{ text_yes }}</label>
+                  <label class="btn btn-outline-secondary"><input type="radio" name="payment_authorizenet_accept_hosted_ach_enabled" value="0"/> {{ text_no }}</label>
+                {% else %}
+                  <label class="btn btn-outline-secondary"><input type="radio" name="payment_authorizenet_accept_hosted_ach_enabled" value="1"/> {{ text_yes }}</label>
+                  <label class="btn btn-outline-secondary active"><input type="radio" name="payment_authorizenet_accept_hosted_ach_enabled" value="0" checked="checked"/> {{ text_no }}</label>
+                {% endif %}
+              </div>
+            </div>
+          </div>
+          <div class="form-group row">
+            <label class="col-sm-2 col-form-label">{{ entry_testmode }}</label>
+            <div class="col-sm-10">
+              <div class="btn-group btn-group-toggle" data-toggle="buttons">
+                {% if payment_authorizenet_accept_hosted_testmode %}
+                  <label class="btn btn-outline-secondary active"><input type="radio" name="payment_authorizenet_accept_hosted_testmode" value="1" checked="checked"/> {{ text_yes }}</label>
+                  <label class="btn btn-outline-secondary"><input type="radio" name="payment_authorizenet_accept_hosted_testmode" value="0"/> {{ text_no }}</label>
+                {% else %}
+                  <label class="btn btn-outline-secondary"><input type="radio" name="payment_authorizenet_accept_hosted_testmode" value="1"/> {{ text_yes }}</label>
+                  <label class="btn btn-outline-secondary active"><input type="radio" name="payment_authorizenet_accept_hosted_testmode" value="0" checked="checked"/> {{ text_no }}</label>
+                {% endif %}
+              </div>
+            </div>
+          </div>
+          <div class="form-group row">
+            <label class="col-sm-2 col-form-label">{{ entry_debug }}</label>
+            <div class="col-sm-10">
+              <div class="btn-group btn-group-toggle" data-toggle="buttons">
+                {% if payment_authorizenet_accept_hosted_debug %}
+                  <label class="btn btn-outline-secondary active"><input type="radio" name="payment_authorizenet_accept_hosted_debug" value="1" checked="checked"/> {{ text_yes }}</label>
+                  <label class="btn btn-outline-secondary"><input type="radio" name="payment_authorizenet_accept_hosted_debug" value="0"/> {{ text_no }}</label>
+                {% else %}
+                  <label class="btn btn-outline-secondary"><input type="radio" name="payment_authorizenet_accept_hosted_debug" value="1"/> {{ text_yes }}</label>
+                  <label class="btn btn-outline-secondary active"><input type="radio" name="payment_authorizenet_accept_hosted_debug" value="0" checked="checked"/> {{ text_no }}</label>
+                {% endif %}
+              </div>
+            </div>
+          </div>
+          <div class="form-group row">
+            <label class="col-sm-2 col-form-label" for="input-total">{{ entry_total }}</label>
+            <div class="col-sm-10">
+              <input type="text" name="payment_authorizenet_accept_hosted_total" value="{{ payment_authorizenet_accept_hosted_total }}" placeholder="{{ entry_total }}" id="input-total" class="form-control"/>
+              <small class="form-text text-muted">{{ help_total }}</small>
+            </div>
+          </div>
+          <div class="form-group row">
+            <label class="col-sm-2 col-form-label" for="input-order-status">{{ entry_order_status }}</label>
+            <div class="col-sm-10">
+              <select name="payment_authorizenet_accept_hosted_order_status_id" id="input-order-status" class="form-control">
+                {% for order_status in order_statuses %}
+                  {% if order_status.order_status_id == payment_authorizenet_accept_hosted_order_status_id %}
+                    <option value="{{ order_status.order_status_id }}" selected="selected">{{ order_status.name }}</option>
+                  {% else %}
+                    <option value="{{ order_status.order_status_id }}">{{ order_status.name }}</option>
+                  {% endif %}
+                {% endfor %}
+              </select>
+            </div>
+          </div>
+          <div class="form-group row">
+            <label class="col-sm-2 col-form-label" for="input-geo-zone">{{ entry_geo_zone }}</label>
+            <div class="col-sm-10">
+              <select name="payment_authorizenet_accept_hosted_geo_zone_id" id="input-geo-zone" class="form-control">
+                <option value="0">{{ text_all_zones }}</option>
+                {% for geo_zone in geo_zones %}
+                  {% if geo_zone.geo_zone_id == payment_authorizenet_accept_hosted_geo_zone_id %}
+                    <option value="{{ geo_zone.geo_zone_id }}" selected="selected">{{ geo_zone.name }}</option>
+                  {% else %}
+                    <option value="{{ geo_zone.geo_zone_id }}">{{ geo_zone.name }}</option>
+                  {% endif %}
+                {% endfor %}
+              </select>
+            </div>
+          </div>
+          <div class="form-group row">
+            <label class="col-sm-2 col-form-label" for="input-status">{{ entry_status }}</label>
+            <div class="col-sm-10">
+              <select name="payment_authorizenet_accept_hosted_status" id="input-status" class="form-control">
+                {% if payment_authorizenet_accept_hosted_status %}
+                  <option value="1" selected="selected">{{ text_enabled }}</option>
+                  <option value="0">{{ text_disabled }}</option>
+                {% else %}
+                  <option value="1">{{ text_enabled }}</option>
+                  <option value="0" selected="selected">{{ text_disabled }}</option>
+                {% endif %}
+              </select>
+            </div>
+          </div>
+          <div class="form-group row">
+            <label class="col-sm-2 col-form-label" for="input-sort-order">{{ entry_sort_order }}</label>
+            <div class="col-sm-10">
+              <input type="text" name="payment_authorizenet_accept_hosted_sort_order" value="{{ payment_authorizenet_accept_hosted_sort_order }}" placeholder="{{ entry_sort_order }}" id="input-sort-order" class="form-control"/>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{{ footer }}

--- a/upload/catalog/controller/extension/payment/authorizenet_accept_hosted.php
+++ b/upload/catalog/controller/extension/payment/authorizenet_accept_hosted.php
@@ -122,8 +122,9 @@ class ControllerExtensionPaymentAuthorizeNetAcceptHosted extends Controller {
 		} elseif (!$response_raw) {
 			$this->log->write('AUTHORIZE.NET ACCEPT HOSTED CURL ERROR: No response');
 		} else {
-			if (substr($response_raw, 0, 3) === "\xef\xbb\xbf")
+			if (substr($response_raw, 0, 3) === "\xef\xbb\xbf") {
 				$response_raw = substr($response_raw, 3); //result of RFC-violating inclusion of BOM by authorize.net; remove if they fix their bug
+			}
 
 			$response = json_decode($response_raw);
 			if ($response === null) $data['error'] = $this->language->get('error_no_form');
@@ -133,8 +134,9 @@ class ControllerExtensionPaymentAuthorizeNetAcceptHosted extends Controller {
 					$this->log->write('Authorize.net accept hosted returned error while getting payment form: ' .
 						$response->messages->resultCode . ': ' . $response->messages->message[0]->code . ' ' . $response->messages->message[0]->text);
 				}
-				else
+				else {
 					$data['token'] = $response->token;
+				}
 			}
 		}
 		$data['token_responder'] = 'https://accept.authorize.net/payment/payment';
@@ -212,8 +214,9 @@ class ControllerExtensionPaymentAuthorizeNetAcceptHosted extends Controller {
 			$this->response->redirect($this->url->link('checkout/failure', 'language=' . $this->config->get('config_language')));
 			return;
 		} else {
-			if (substr($tx_resp_raw, 0, 3) === "\xef\xbb\xbf")
+			if (substr($tx_resp_raw, 0, 3) === "\xef\xbb\xbf") {
 				$tx_resp_raw = substr($tx_resp_raw, 3); //result of RFC-violating inclusion of BOM by authorize.net; remove if they fix their bug
+			}
 
 			$tx_resp = json_decode($tx_resp_raw);
 			if ($tx_resp === null || !property_exists($tx_resp, 'transaction') || $tx_resp->transaction === null) {
@@ -238,8 +241,8 @@ class ControllerExtensionPaymentAuthorizeNetAcceptHosted extends Controller {
 			if (property_exists($txn, 'cardCodeResponse')) $message .= 'CVV Response Code: ' . $txn->cardCodeResponse . "\n";
 			if (property_exists($txn, 'CAVVResponse')) $message .= 'CAVV Response Code: ' . $txn->CAVVResponse . "\n";
 			if (property_exists($txn->payment, 'creditCard')) {
-				$message .= 'Masked Account Number: ' . $txn->payment->creditCard->cardNumber . "\n";
-				$message .= 'Account Type: ' . $txn->payment->creditCard->cardType;
+				$message .= 'Masked Card Number: ' . $txn->payment->creditCard->cardNumber . "\n";
+				$message .= 'Card Account Type: ' . $txn->payment->creditCard->cardType;
 			}
 			if (property_exists($txn->payment, 'bankAccount')) {
 				$message .= 'Masked Routing Number: ' . $txn->payment->bankAccount->routingNumber . "\n";

--- a/upload/catalog/controller/extension/payment/authorizenet_accept_hosted.php
+++ b/upload/catalog/controller/extension/payment/authorizenet_accept_hosted.php
@@ -1,0 +1,256 @@
+<?php
+class ControllerExtensionPaymentAuthorizeNetAcceptHosted extends Controller {
+	public function index() {
+		$this->load->language('extension/payment/authorizenet_accept_hosted');
+
+		$data['button_confirm'] = $this->language->get('button_confirm');
+
+		$this->load->model('checkout/order');
+
+		$order_info = $this->model_checkout_order->getOrder($this->session->data['order_id']);
+
+		//Warning!  Authorize.net's parser does not comply with the JSON spec, and is sensitive to element order!
+		$request = json_encode(array(
+			'getHostedPaymentPageRequest' => array(
+				'merchantAuthentication' => array(
+					'name' => $this->config->get('payment_authorizenet_accept_hosted_name'),
+					'transactionKey' => $this->config->get('payment_authorizenet_accept_hosted_transaction_key')
+				),
+				'transactionRequest' => array(
+					'transactionType' => 'authCaptureTransaction',
+					'amount' => $this->currency->format($order_info['total'], $order_info['currency_code'], $order_info['currency_value'], false),
+					'order' => array(
+						'invoiceNumber' => $this->session->data['order_id'],
+						'description' => html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8')
+					),
+					'customer' => array(
+						'email' =>  $order_info['email']
+					),
+					'billTo' => array(
+						'firstName' => html_entity_decode($order_info['payment_firstname'], ENT_QUOTES, 'UTF-8'),
+						'lastName' => html_entity_decode($order_info['payment_lastname'], ENT_QUOTES, 'UTF-8'),
+						'company' => html_entity_decode($order_info['payment_company'], ENT_QUOTES, 'UTF-8'),
+						'address' => html_entity_decode($order_info['payment_address_1'], ENT_QUOTES, 'UTF-8') . ' ' . html_entity_decode($order_info['payment_address_2'], ENT_QUOTES, 'UTF-8'),
+						'city' => html_entity_decode($order_info['payment_city'], ENT_QUOTES, 'UTF-8'),
+						'state' => html_entity_decode($order_info['payment_zone'], ENT_QUOTES, 'UTF-8'),
+						'zip' => html_entity_decode($order_info['payment_postcode'], ENT_QUOTES, 'UTF-8'),
+						'country' => html_entity_decode($order_info['payment_country'], ENT_QUOTES, 'UTF-8'),
+						'phoneNumber' => $order_info['telephone']
+					),
+					'shipTo' => array(
+						'firstName' => html_entity_decode($order_info['shipping_firstname'], ENT_QUOTES, 'UTF-8'),
+						'lastName' => html_entity_decode($order_info['shipping_lastname'], ENT_QUOTES, 'UTF-8'),
+						'company' => html_entity_decode($order_info['shipping_company'], ENT_QUOTES, 'UTF-8'),
+						'address' => html_entity_decode($order_info['shipping_address_1'], ENT_QUOTES, 'UTF-8') . ' ' . html_entity_decode($order_info['payment_address_2'], ENT_QUOTES, 'UTF-8'),
+						'city' => html_entity_decode($order_info['shipping_city'], ENT_QUOTES, 'UTF-8'),
+						'state' => html_entity_decode($order_info['shipping_zone'], ENT_QUOTES, 'UTF-8'),
+						'zip' => html_entity_decode($order_info['shipping_postcode'], ENT_QUOTES, 'UTF-8'),
+						'country' => html_entity_decode($order_info['shipping_country'], ENT_QUOTES, 'UTF-8')
+					),
+					'customerIP' => $this->request->server['REMOTE_ADDR']
+				),
+				'hostedPaymentSettings' => array(
+					'setting' => array(
+						array(
+							'settingName' => 'hostedPaymentReturnOptions',
+							'settingValue' => json_encode(array(
+								'showReceipt' => false
+							))
+						),
+						array(
+							'settingName' => 'hostedPaymentButtonOptions',
+							'settingValue' => json_encode(array(
+								'text' => 'Pay'
+							))
+						),
+						array(
+							'settingName' => 'hostedPaymentPaymentOptions',
+							'settingValue' => json_encode(array(
+								'cardCodeRequired' => true,
+								'showCreditCard' => $this->config->get('payment_authorizenet_accept_hosted_credit_enabled')? true: false,
+								'showBankAccount' => $this->config->get('payment_authorizenet_accept_hosted_ach_enabled')? true: false
+							))
+						),
+						array(
+							'settingName' => 'hostedPaymentShippingAddressOptions',
+							'settingValue' => json_encode(array(
+								'show' => false,
+								'required' => false
+							))
+						),
+						array(
+							'settingName' => 'hostedPaymentBillingAddressOptions',
+							'settingValue' => json_encode(array(
+								'show' => false,
+								'required' => false
+							))
+						),
+						array(
+							'settingName' => 'hostedPaymentIFrameCommunicatorUrl',
+							'settingValue' => json_encode(array(
+								'url' => $this->url->link('extension/payment/authorizenet_accept_hosted/callback')
+							))
+						)
+					)
+				)
+			)
+		));
+
+		$api_url = 'https://api.authorize.net/xml/v1/request.api';
+		if ($this->config->get('payment_authorizenet_accept_hosted_testmode')) $api_url = 'https://apitest.authorize.net/xml/v1/request.api';
+
+		$curl = curl_init($api_url);
+		curl_setopt($curl, CURLOPT_PORT, 443);
+		curl_setopt($curl, CURLOPT_HEADER, 0);
+		curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 1);
+		curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+		curl_setopt($curl, CURLOPT_FORBID_REUSE, 1);
+		curl_setopt($curl, CURLOPT_FRESH_CONNECT, 1);
+		curl_setopt($curl, CURLOPT_POST, 1);
+		curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 10);
+		curl_setopt($curl, CURLOPT_TIMEOUT, 10);
+		curl_setopt($curl, CURLOPT_POSTFIELDS, $request);
+
+		if ($this->config->get('payment_authorizenet_accept_hosted_debug')) $this->log->write('AUTHORIZE.NET ACCEPT HOSTED SEND: ' . $request);
+
+		$response_raw = curl_exec($curl);
+		if ($this->config->get('payment_authorizenet_accept_hosted_debug')) $this->log->write('AUTHORIZE.NET ACCEPT HOSTED RECV: ' . $response_raw);
+
+		if (curl_error($curl)) {
+			$data['error'] = $this->language->get('error_no_form');
+			$this->log->write('AUTHORIZE.NET ACCEPT HOSTED CURL ERROR: ' . curl_errno($curl) . '::' . curl_error($curl));
+		} elseif (!$response_raw) {
+			$this->log->write('AUTHORIZE.NET ACCEPT HOSTED CURL ERROR: No response');
+		} else {
+			if (substr($response_raw, 0, 3) === "\xef\xbb\xbf")
+				$response_raw = substr($response_raw, 3); //result of RFC-violating inclusion of BOM by authorize.net; remove if they fix their bug
+
+			$response = json_decode($response_raw);
+			if ($response === null) $data['error'] = $this->language->get('error_no_form');
+			else {
+				if ($response->messages->resultCode != 'Ok') {
+					$data['error'] = $this->language->get('error_no_form');
+					$this->log->write('Authorize.net accept hosted returned error while getting payment form: ' .
+						$response->messages->resultCode . ': ' . $response->messages->message[0]->code . ' ' . $response->messages->message[0]->text);
+				}
+				else
+					$data['token'] = $response->token;
+			}
+		}
+		$data['token_responder'] = 'https://accept.authorize.net/payment/payment';
+		if ($this->config->get('payment_authorizenet_accept_hosted_testmode')) $data['token_responder'] = 'https://test.authorize.net/payment/payment';
+
+		return $this->load->view('extension/payment/authorizenet_accept_hosted', $data);
+	}
+
+	public function callback() {
+		$data = array();
+		$this->response->setOutput($this->load->view('extension/payment/authorizenet_accept_hosted_callback', $data));
+	}
+
+	public function complete() {
+		$this->load->model('checkout/order');
+		$resp_raw = html_entity_decode($this->request->post['resp']);
+		if ($this->config->get('payment_authorizenet_accept_hosted_debug')) $this->log->write('AUTHORIZE.NET ACCEPT HOSTED COMPLETION RESP: ' . $resp_raw);
+		$resp = json_decode($resp_raw);
+		if ($resp === null) {
+			$this->log->write('Authorize.NET Accept Hosted completion: invalid response; JSON parsing error ' . json_last_error_msg());
+			$this->response->redirect($this->url->link('checkout/failure', 'language=' . $this->config->get('config_language')));
+			return;
+		}
+
+		if (!property_exists($resp, "transId")) {
+			$this->log->write('Authorize.NET Accept Hosted completion: response did not include transaction ID');
+			$this->response->redirect($this->url->link('checkout/failure', 'language=' . $this->config->get('config_language')));
+			return;
+		}
+
+		if (!in_array($resp->responseCode, ["1", "4"])) { //i.e. if transaction was not approved or held
+			$this->response->redirect($this->url->link('checkout/failure', 'language=' . $this->config->get('config_language')));
+			return;
+		}
+
+		//Because authorize.net provides no way to authenticate the transaction we have to verify it by looking it up using the transaction ID the user provided.
+		//We can match it with the order ID to prevent replay attacks.
+		$request = json_encode(array(
+			'getTransactionDetailsRequest' => array(
+				'merchantAuthentication' => array(
+					'name' => $this->config->get('payment_authorizenet_accept_hosted_name'),
+					'transactionKey' => $this->config->get('payment_authorizenet_accept_hosted_transaction_key')
+				),
+				'transId' => $resp->transId
+			)
+		));
+
+		$api_url = 'https://api.authorize.net/xml/v1/request.api';
+		if ($this->config->get('payment_authorizenet_accept_hosted_testmode')) $api_url = 'https://apitest.authorize.net/xml/v1/request.api';
+
+		$curl = curl_init($api_url);
+		curl_setopt($curl, CURLOPT_PORT, 443);
+		curl_setopt($curl, CURLOPT_HEADER, 0);
+		curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 1);
+		curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+		curl_setopt($curl, CURLOPT_FORBID_REUSE, 1);
+		curl_setopt($curl, CURLOPT_FRESH_CONNECT, 1);
+		curl_setopt($curl, CURLOPT_POST, 1);
+		curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 10);
+		curl_setopt($curl, CURLOPT_TIMEOUT, 10);
+		curl_setopt($curl, CURLOPT_POSTFIELDS, $request);
+
+		if ($this->config->get('payment_authorizenet_accept_hosted_debug')) $this->log->write('AUTHORIZE.NET ACCEPT HOSTED COMPLETION SEND: ' . $request);
+
+		$tx_resp_raw = curl_exec($curl);
+		$tx_resp = array();
+		if ($this->config->get('payment_authorizenet_accept_hosted_debug')) $this->log->write('AUTHORIZE.NET ACCEPT HOSTED COMPLETION RECV: ' . $tx_resp_raw);
+
+		if (curl_error($curl)) {
+			$this->log->write('AUTHORIZE.NET ACCEPT HOSTED COMPLETION CURL ERROR: ' . curl_errno($curl) . '::' . curl_error($curl));
+			$this->response->redirect($this->url->link('checkout/failure', 'language=' . $this->config->get('config_language')));
+			return;
+		} elseif (!$tx_resp_raw) {
+			$this->log->write('AUTHORIZE.NET ACCEPT HOSTED COMPLETION CURL ERROR: No response');
+			$this->response->redirect($this->url->link('checkout/failure', 'language=' . $this->config->get('config_language')));
+			return;
+		} else {
+			if (substr($tx_resp_raw, 0, 3) === "\xef\xbb\xbf")
+				$tx_resp_raw = substr($tx_resp_raw, 3); //result of RFC-violating inclusion of BOM by authorize.net; remove if they fix their bug
+
+			$tx_resp = json_decode($tx_resp_raw);
+			if ($tx_resp === null || !property_exists($tx_resp, 'transaction') || $tx_resp->transaction === null) {
+				$this->log->write('AUTHORIZE.NET ACCEPT HOSTED COMPLETION: Got invalid response when looking transaction up in authorize.net');
+				$this->response->redirect($this->url->link('checkout/failure', 'language=' . $this->config->get('config_language')));
+				return;
+			} else if ($tx_resp->transaction->order->invoiceNumber != $this->session->data['order_id']) {
+				$this->log->write('AUTHORIZE.NET ACCEPT HOSTED COMPLETION: Attempted fraud on order ' . $this->session->data['order_id'] . ': incorrect transaction number from user: ' . $resp->transId);
+				$this->response->redirect($this->url->link('checkout/failure', 'language=' . $this->config->get('config_language')));
+				return;
+			}
+		}
+
+		$txn = $tx_resp->transaction;
+		if (in_array($txn->responseCode, ["1", "4"])) {
+			$message = 'Transaction Status: ' . $txn->transactionStatus . "\n";
+			$message = 'Response Code: ' . $txn->responseCode . "\n";
+			$message .= 'Response Reason: ' . $txn->responseReasonCode . ': ' . $txn->responseReasonDescription . "\n";
+			if (property_exists($txn, 'authCode')) $message .= 'Auth Code: ' . $txn->authCode . "\n";
+			$message .= 'Transaction ID: ' . $txn->transId . "\n";
+			$message .= 'AVS Response Code: ' . $txn->AVSResponse . "\n";
+			if (property_exists($txn, 'cardCodeResponse')) $message .= 'CVV Response Code: ' . $txn->cardCodeResponse . "\n";
+			if (property_exists($txn, 'CAVVResponse')) $message .= 'CAVV Response Code: ' . $txn->CAVVResponse . "\n";
+			if (property_exists($txn->payment, 'creditCard')) {
+				$message .= 'Masked Account Number: ' . $txn->payment->creditCard->cardNumber . "\n";
+				$message .= 'Account Type: ' . $txn->payment->creditCard->cardType;
+			}
+			if (property_exists($txn->payment, 'bankAccount')) {
+				$message .= 'Masked Routing Number: ' . $txn->payment->bankAccount->routingNumber . "\n";
+				$message .= 'Masked Account Number: ' . $txn->payment->bankAccount->accountNumber;
+			}
+
+			$this->model_checkout_order->addOrderHistory($this->session->data['order_id'], $this->config->get('payment_authorizenet_accept_hosted_order_status_id'), $message, true);
+
+			$this->response->redirect($this->url->link('checkout/success', 'language=' . $this->config->get('config_language')));
+		} else {
+			$this->response->redirect($this->url->link('checkout/failure', 'language=' . $this->config->get('config_language')));
+		}
+	}
+}

--- a/upload/catalog/language/en-gb/extension/payment/authorizenet_accept_hosted.php
+++ b/upload/catalog/language/en-gb/extension/payment/authorizenet_accept_hosted.php
@@ -1,0 +1,4 @@
+<?php
+// Text
+$_['text_title']	= 'Credit Card / Debit Card (Authorize.Net)';
+$_['error_no_form']	= 'Payment gateway error.  Please choose a different payment method above.';

--- a/upload/catalog/model/extension/payment/authorizenet_accept_hosted.php
+++ b/upload/catalog/model/extension/payment/authorizenet_accept_hosted.php
@@ -1,0 +1,31 @@
+<?php
+class ModelExtensionPaymentAuthorizeNetAcceptHosted extends Model {
+	public function getMethod($address, $total) {
+		$this->load->language('extension/payment/authorizenet_accept_hosted');
+
+		$query = $this->db->query("SELECT * FROM " . DB_PREFIX . "zone_to_geo_zone WHERE geo_zone_id = '" . (int)$this->config->get('payment_authorizenet_accept_hosted_geo_zone_id') . "' AND country_id = '" . (int)$address['country_id'] . "' AND (zone_id = '" . (int)$address['zone_id'] . "' OR zone_id = '0')");
+
+		if ($this->config->get('payment_authorizenet_accept_hosted_total') > 0 && $this->config->get('payment_authorizenet_accept_hosted_total') > $total) {
+			$status = false;
+		} elseif (!$this->config->get('payment_authorizenet_accept_hosted_geo_zone_id')) {
+			$status = true;
+		} elseif ($query->num_rows) {
+			$status = true;
+		} else {
+			$status = false;
+		}
+
+		$method_data = array();
+
+		if ($status) {
+			$method_data = array(
+				'code'       => 'authorizenet_accept_hosted',
+				'title'      => $this->language->get('text_title'),
+				'terms'      => '',
+				'sort_order' => $this->config->get('payment_authorizenet_accept_hosted_sort_order')
+			);
+		}
+
+		return $method_data;
+	}
+}

--- a/upload/catalog/view/theme/default/template/extension/payment/authorizenet_accept_hosted.twig
+++ b/upload/catalog/view/theme/default/template/extension/payment/authorizenet_accept_hosted.twig
@@ -1,0 +1,86 @@
+{% if error %}
+<div class="alert alert-danger" id="error-modal">{{ error }}</div>
+{% else %}
+<div class="alert alert-danger d-none" id="error-modal"></div>
+<div id="iframe_holder" class="center-block" style="width:90%;max-width: 1000px">
+	<iframe id="add_payment" class="embed-responsive-item panel" name="add_payment" width="100%" frameborder="0" scrolling="no">
+	</iframe>
+</div>
+<form id="send_token" action="{{ token_responder }}" method="post" target="add_payment">
+	<input type="hidden" name="token" value="{{ token }}" />
+</form>
+<form id="finalize" action="index.php?route=extension/payment/authorizenet_accept_hosted/complete" method="post">
+	<input type="hidden" name="resp" id="finalize-resp" />
+</form>
+{% endif %}
+
+<script type="text/javascript"><!--
+function handleError(err) {
+	var errbox = document.getElementById("error-modal");
+	errbox.innerText = err;
+	errbox.classList.remove("d-none");
+}
+
+function validResp(r) {
+	return (r.hasOwnProperty("responseCode") &&
+		r.hasOwnProperty("transId"))
+}
+
+function anResize(params) {
+	var w = parseInt(params.width);
+	var h = parseInt(params.height);
+	var ifrm = document.getElementById("add_payment");
+	ifrm.style.width = w.toString() + "px";
+	ifrm.style.height = h.toString() + "px";
+}
+
+function anRespond(params) {
+	var successCodes = ["1", "4"];
+	var ifrm = document.getElementById("add_payment");
+	ifrm.style.display = "none";
+	var resp = JSON.parse(params.response);
+	if (!validResp(resp)) {
+		handleError("Invalid response");
+		return;
+	}
+	if (!(successCodes.includes(resp.responseCode))) {
+		handleError("Transaction declined");
+		return;
+	}
+	document.getElementById("finalize-resp").value = JSON.stringify(resp);
+	document.getElementById("finalize").submit();
+}
+
+function parseQueryString(str) {
+	var vars = [];
+	var arr = str.split('&');
+	var pair;
+	for (var i = 0; i < arr.length; i++) {
+		pair = arr[i].split('=');
+		vars.push(pair[0]);
+		vars[pair[0]] = unescape(pair[1]);
+	}
+	return vars;
+}
+
+document.getElementById("send_token").submit();
+
+if (!window.AuthorizeNetIFrame) window.AuthorizeNetIFrame = {};
+
+AuthorizeNetIFrame.onReceiveCommunication = function (querystr) {
+	var params = parseQueryString(querystr);
+	switch (params.action) {
+		case "successfulSave":
+			break;
+		case "cancel":
+			window.location.href = "/";
+			break;
+		case "resizeWindow":
+			anResize(params);
+			break;
+		case "transactResponse":
+			anRespond(params);
+			break;
+	}
+};
+--></script>

--- a/upload/catalog/view/theme/default/template/extension/payment/authorizenet_accept_hosted_callback.twig
+++ b/upload/catalog/view/theme/default/template/extension/payment/authorizenet_accept_hosted_callback.twig
@@ -1,0 +1,28 @@
+<script type="text/javascript"><!--
+	function callParentFunction(str) {
+		if (str && str.length > 0 
+			&& window.parent 
+			&& window.parent.parent
+			&& window.parent.parent.AuthorizeNetIFrame 
+			&& window.parent.parent.AuthorizeNetIFrame.onReceiveCommunication) {
+// Errors indicate a mismatch in domain between the page containing the iframe and this page.
+				window.parent.parent.AuthorizeNetIFrame.onReceiveCommunication(str);
+		}
+	}
+
+	function receiveMessage(event) {
+		if (event && event.data) {
+			callParentFunction(event.data);
+		}
+	}
+
+	if (window.addEventListener) {
+		window.addEventListener("message", receiveMessage, false);
+	} else if (window.attachEvent) {
+		window.attachEvent("onmessage", receiveMessage);
+	}
+
+	if (window.location.hash && window.location.hash.length > 1) {
+		callParentFunction(window.location.hash.substring(1));
+	}
+--></script>


### PR DESCRIPTION
It's an extension that enables the authorize.net accept suite hosted iframe method, which NMI asserts should be SAQ A (might be SAQ A-EP in the future, who knows?).  This provides a migration path from AIM and SIM, which are both deprecated.