### PR TITLE
Fixed extension-promotion link issue in the captcha controller

### DIFF
--- a/upload/admin/controller/extension/extension/captcha.php
+++ b/upload/admin/controller/extension/extension/captcha.php
@@ -45,7 +45,7 @@ class ControllerExtensionExtensionCaptcha extends Controller {
 
 			$this->session->data['success'] = $this->language->get('text_success');
 		}
-		
+
 		$this->getList();
 	}
 
@@ -75,7 +75,7 @@ class ControllerExtensionExtensionCaptcha extends Controller {
 		}
 
 		$data['extensions'] = array();
-		
+
 		// Compatibility code for old extension folders
 		$files = glob(DIR_APPLICATION . 'controller/extension/captcha/*.php');
 
@@ -96,7 +96,7 @@ class ControllerExtensionExtensionCaptcha extends Controller {
 			}
 		}
 
-		$data['promotion'] = $this->load->controller('extension/promotion');
+		$data['promotion'] = $this->load->controller('extension/extension/promotion');
 
 		$this->response->setOutput($this->load->view('extension/extension/captcha', $data));
 	}


### PR DESCRIPTION
There was wrong controller link in the Captcha controller 
it was like this => $this->load->controller('extension/promotion');
It must be this =>  $this->load->controller('extension/extension/promotion');