### PR TITLE
Turn on TLS checking for UPS API

### DIFF
--- a/upload/catalog/model/extension/shipping/ups.php
+++ b/upload/catalog/model/extension/shipping/ups.php
@@ -227,7 +227,7 @@ class ModelExtensionShippingUps extends Model {
 			$xml .= '</RatingServiceSelectionRequest>';
 
 			if (!$this->config->get('shipping_ups_test')) {
-				$url = 'https://www.ups.com/ups.app/xml/Rate';
+				$url = 'https://onlinetools.ups.com/ups.app/xml/Rate';
 			} else {
 				$url = 'https://wwwcie.ups.com/ups.app/xml/Rate';
 			}
@@ -238,8 +238,6 @@ class ModelExtensionShippingUps extends Model {
 			curl_setopt($curl, CURLOPT_POST, 1);
 			curl_setopt($curl, CURLOPT_TIMEOUT, 60);
 			curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-			curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 0);
-			curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 0);
 			curl_setopt($curl, CURLOPT_POSTFIELDS, $xml);
 
 			$result = curl_exec($curl);


### PR DESCRIPTION
UPS sent an email today indicating that the old API endpoint for prod changed from https://www.ups.com/ups.app/xml/ to https://onlinetools.ups.com/ups.app/xml/.  They will turn off the old one on December 31 2019.

This patch updates the URL.  While I was patching, I noticed that TLS certificate checking was totally disabled, and changed it to be enabled.  I also tested to make sure it works; it does.