### PR TITLE
Update ups.php

### DIFF
--- a/upload/catalog/model/extension/shipping/ups.php
+++ b/upload/catalog/model/extension/shipping/ups.php
@@ -227,7 +227,7 @@ class ModelExtensionShippingUps extends Model {
 			$xml .= '</RatingServiceSelectionRequest>';
 
 			if (!$this->config->get('shipping_ups_test')) {
-				$url = 'https://www.ups.com/ups.app/xml/Rate';
+				$url = 'https://onlinetools.ups.com/ups.app/xml/Rate';
 			} else {
 				$url = 'https://wwwcie.ups.com/ups.app/xml/Rate';
 			}


### PR DESCRIPTION
Per recent announcement from UPS, the endpoint has changed:

"Effective December 31, 2019, UPS will disable all of these outdated Developer Kit API URLs. The current URL https://onlinetools.ups.com/ API name is noted in the Developer guides and needs to be utilized for all UPS Developer Kit API transactions."