### PR TITLE
add post_max_size directive

### DIFF
--- a/upload/php.ini
+++ b/upload/php.ini
@@ -3,6 +3,7 @@ register_globals = Off
 default_charset = UTF-8
 memory_limit = 64M
 max_execution_time = 36000
+post_max_size = 1000M
 upload_max_filesize = 999M
 safe_mode = Off
 mysql.connect_timeout = 20


### PR DESCRIPTION
post_max_size is related with upload_max_size, always suggest bigger than upload. When you make and upload with post you send the file/s and text fields for that reason post_max_size must be bigger