### PR TITLE
Prevent double submit on save button

### DIFF
--- a/upload/admin/view/javascript/common.js
+++ b/upload/admin/view/javascript/common.js
@@ -25,8 +25,10 @@ function getURLVar(key) {
 $(document).ready(function() {
 	//Form Submit for IE Browser
 	$('button[type=\'submit\']').on('click', function(e) {
-		e.preventDefault(); // prevent the native submit behavior of the browser which results in double submits
-		$('form[id*=\'form-\']').submit();
+              if($(this).attr('form') == 'form-product') { 
+                    e.preventDefault();
+              }
+              $("form[id*='form-']").submit();
 	});
 
 	// Highlight any found errors

--- a/upload/admin/view/javascript/common.js
+++ b/upload/admin/view/javascript/common.js
@@ -24,7 +24,8 @@ function getURLVar(key) {
 
 $(document).ready(function() {
 	//Form Submit for IE Browser
-	$('button[type=\'submit\']').on('click', function() {
+	$('button[type=\'submit\']').on('click', function(e) {
+		e.preventDefault(); // prevent the native submit behavior of the browser which results in double submits
 		$('form[id*=\'form-\']').submit();
 	});
 


### PR DESCRIPTION
We got SQL duplicate key errors. After some examination, we found out that the dit form got submit twice. This fixes block the default HTML behavior and only uses the javascript submit().