### PR TITLE
Replace setTimeout with expire

### DIFF
--- a/upload/system/library/cache/redis.php
+++ b/upload/system/library/cache/redis.php
@@ -21,7 +21,7 @@ class Redis {
 		$status = $this->cache->set(CACHE_PREFIX . $key, json_encode($value));
 
 		if ($status) {
-			$this->cache->setTimeout(CACHE_PREFIX . $key, $this->expire);
+			$this->cache->expire(CACHE_PREFIX . $key, $this->expire);
 		}
 
 		return $status;


### PR DESCRIPTION
setTimeout is an alias for expire and will be removed in future versions of phpredis (is already deprecated when used on AWS).