### PR TITLE
 Fixed issue #7578 for the filter order customer with same name

### DIFF
--- a/upload/admin/controller/sale/order.php
+++ b/upload/admin/controller/sale/order.php
@@ -96,6 +96,13 @@ class ControllerSaleOrder extends Controller {
 		} else {
 			$filter_customer = '';
 		}
+		
+        // added checks for the selected customer with same name
+		if (isset($this->request->get['filter_customer_id'])) {
+			$filter_customer_id = $this->request->get['filter_customer_id'];
+		} else {
+			$filter_customer_id = 0;
+		}
 
 		if (isset($this->request->get['filter_order_status'])) {
 			$filter_order_status = $this->request->get['filter_order_status'];
@@ -209,6 +216,7 @@ class ControllerSaleOrder extends Controller {
 		$filter_data = array(
 			'filter_order_id' => $filter_order_id,
 			'filter_customer' => $filter_customer,
+			'filter_customer_id' => $filter_customer_id,
 			'filter_order_status' => $filter_order_status,
 			'filter_order_status_id' => $filter_order_status_id,
 			'filter_total' => $filter_total,
@@ -356,6 +364,7 @@ class ControllerSaleOrder extends Controller {
 
 		$data['filter_order_id'] = $filter_order_id;
 		$data['filter_customer'] = $filter_customer;
+		$data['filter_customer_id'] = $filter_customer_id;
 		$data['filter_order_status'] = $filter_order_status;
 		$data['filter_order_status_id'] = $filter_order_status_id;
 		$data['filter_total'] = $filter_total;

--- a/upload/admin/model/sale/order.php
+++ b/upload/admin/model/sale/order.php
@@ -171,8 +171,11 @@ class ModelSaleOrder extends Model {
 		if (!empty($data['filter_order_id'])) {
 			$sql .= " AND o.order_id = '" . (int)$data['filter_order_id'] . "'";
 		}
-
-		if (!empty($data['filter_customer'])) {
+		
+        // added checks for the selected customer with same name
+        if(isset($data['filter_customer_id']) && $data['filter_customer_id']){
+			$sql .= " AND o.customer_id = '" . (int)$data['filter_customer_id'] . "'";
+		} else if (!empty($data['filter_customer'])) {
 			$sql .= " AND CONCAT(o.firstname, ' ', o.lastname) LIKE '%" . $this->db->escape((string)$data['filter_customer']) . "%'";
 		}
 
@@ -220,6 +223,9 @@ class ModelSaleOrder extends Model {
 
 			$sql .= " LIMIT " . (int)$data['start'] . "," . (int)$data['limit'];
 		}
+echo '<pre>';
+print_r($sql);
+echo '</pre>';
 
 		$query = $this->db->query($sql);
 

--- a/upload/admin/model/sale/order.php
+++ b/upload/admin/model/sale/order.php
@@ -223,9 +223,6 @@ class ModelSaleOrder extends Model {
 
 			$sql .= " LIMIT " . (int)$data['start'] . "," . (int)$data['limit'];
 		}
-echo '<pre>';
-print_r($sql);
-echo '</pre>';
 
 		$query = $this->db->query($sql);
 

--- a/upload/admin/view/template/sale/order_list.twig
+++ b/upload/admin/view/template/sale/order_list.twig
@@ -36,6 +36,7 @@
             </div>
             <div class="form-group">
               <label class="col-form-label">{{ entry_customer }}</label> <input type="text" name="filter_customer" value="{{ filter_customer }}" placeholder="{{ entry_customer }}" id="input-customer" class="form-control"/>
+              <input type="hidden" name="filter_customer_id" id="input-customer-id" value="{{ filter_customer_id }}"/>
             </div>
             <div class="form-group">
               <label for="input-order-status" class="col-form-label">{{ entry_order_status }}</label> <select name="filter_order_status_id" id="input-order-status" class="form-control">
@@ -162,6 +163,12 @@ $('#button-filter').on('click', function() {
 		url += '&filter_customer=' + encodeURIComponent(filter_customer);
 	}
 
+  var filter_customer_id = $('input[name=\'filter_customer_id\']').val();
+
+	if (filter_customer_id) {
+		url += '&filter_customer_id=' + encodeURIComponent(filter_customer_id);
+	}
+
 	var filter_order_status_id = $('select[name=\'filter_order_status_id\']').val();
 
 	if (filter_order_status_id !== '') {
@@ -207,6 +214,7 @@ $('input[name=\'filter_customer\']').autocomplete({
 	},
 	'select': function(item) {
 		$('input[name=\'filter_customer\']').val(item['label']);
+    $('input[name=\'filter_customer_id\']').val(item['value']);
 	}
 });
 //--></script>


### PR DESCRIPTION
 Fixed issue #7578 for the filter order customer with the same name

This patch will not affect any current feature for the filter.
Here is the scenario of how it works
-If the customer is selected from the autocomplete then it will only display the data related to that selected customer.
- if we direct-write any name then will only filter the based on the name not on the customer id.

