### PR TITLE
Fixed default sorting for column Campaign Name on the Marketing page

### DIFF
--- a/upload/admin/controller/marketing/marketing.php
+++ b/upload/admin/controller/marketing/marketing.php
@@ -168,7 +168,7 @@ class ControllerMarketingMarketing extends Controller {
 		if (isset($this->request->get['sort'])) {
 			$sort = $this->request->get['sort'];
 		} else {
-			$sort = 'name';
+			$sort = 'm.name';
 		}
 
 		if (isset($this->request->get['order'])) {


### PR DESCRIPTION
The alias name is missing in the controller (marketing.php) file. It should be m.name instead of the name.

Error code:- 
               if (isset($this->request->get['sort'])) {
			$sort = $this->request->get['sort'];
		} else {
			$sort = 'name';
		}
Resolved code :-  
                if (isset($this->request->get['sort'])) {
			$sort = $this->request->get['sort'];
		} else {
			$sort = 'm.name';
		}