### PR TITLE
Fix CORS OPTIONS issue

### DIFF
--- a/upload/system/library/response.php
+++ b/upload/system/library/response.php
@@ -13,7 +13,7 @@
 class Response {
 	private $headers = array();
 	private $level = 0;
-	private $output;
+	private $output = false;
 
 	/**
 	 * Constructor
@@ -106,7 +106,7 @@ class Response {
 	 * 
  	*/
 	public function output() {
-		if ($this->output) {
+		if ($this->output !== false) {
 			$output = $this->level ? $this->compress($this->output, $this->level) : $this->output;
 			
 			if (!headers_sent()) {


### PR DESCRIPTION
Fixes issues when dealing with Custom API creations and handling CORS correctly. Issue is that headers will never be sent on an OPTIONS request as the output SHOULD be '' thus the headers portion is never fired and thus no CORS headers are sent.