### PR TITLE
store new address in session if new user

### DIFF
--- a/upload/catalog/controller/account/address.php
+++ b/upload/catalog/controller/account/address.php
@@ -37,7 +37,23 @@ class ControllerAccountAddress extends Controller {
 		$this->load->model('account/address');
 
 		if (($this->request->server['REQUEST_METHOD'] == 'POST') && $this->validateForm()) {
-			$this->model_account_address->addAddress($this->customer->getId(), $this->request->post);
+			$address_id = $this->model_account_address->addAddress($this->customer->getId(), $this->request->post);
+            
+			// Default Shipping Address
+			if (empty($this->session->data['shipping_address']['address_id'])) {
+				$this->session->data['shipping_address'] = $this->model_account_address->getAddress($address_id);
+
+				unset($this->session->data['shipping_method']);
+				unset($this->session->data['shipping_methods']);
+			}
+
+			// Default Payment Address
+			if (empty($this->session->data['payment_address']['address_id'])) {
+				$this->session->data['payment_address'] = $this->model_account_address->getAddress($address_id);
+
+				unset($this->session->data['payment_method']);
+				unset($this->session->data['payment_methods']);
+			}
 			
 			$this->session->data['success'] = $this->language->get('text_add');
 


### PR DESCRIPTION
If a new user with no address adds a new address using the account panel it will not be stored in session and the tax calculation doesn't consider the new and only address that the user has.

This fix stores the new address if no "address_id" is stored.