### PR TITLE
Fix tax calculation for new users with no address

### DIFF
--- a/upload/catalog/controller/startup/startup.php
+++ b/upload/catalog/controller/startup/startup.php
@@ -222,13 +222,13 @@ class ControllerStartupStartup extends Controller {
 		// Tax
 		$this->registry->set('tax', new Cart\Tax($this->registry));
 
-		if (isset($this->session->data['shipping_address'])) {
+		if (!empty($this->session->data['shipping_address'])) {
 			$this->tax->setShippingAddress($this->session->data['shipping_address']['country_id'], $this->session->data['shipping_address']['zone_id']);
 		} elseif ($this->config->get('config_tax_default') == 'shipping') {
 			$this->tax->setShippingAddress($this->config->get('config_country_id'), $this->config->get('config_zone_id'));
 		}
 
-		if (isset($this->session->data['payment_address'])) {
+		if (!empty($this->session->data['payment_address'])) {
 			$this->tax->setPaymentAddress($this->session->data['payment_address']['country_id'], $this->session->data['payment_address']['zone_id']);
 		} elseif ($this->config->get('config_tax_default') == 'payment') {
 			$this->tax->setPaymentAddress($this->config->get('config_country_id'), $this->config->get('config_zone_id'));


### PR DESCRIPTION
Based on "config_tax_customer" the $this->session->data['payment_address'] or $this->session->data['shipping_address'] will be set to "false" if a new user with no address set logs in.

Replacing "isset" (which returns "true" even if the value is "false") with "!empty" allows the software to temporarily use the store locale settings.