### PR TITLE
issue fixed for unchecked box for recaptcha v2

### DIFF
--- a/upload/catalog/controller/extension/captcha/google.php
+++ b/upload/catalog/controller/extension/captcha/google.php
@@ -17,7 +17,7 @@ class ControllerExtensionCaptchaGoogle extends Controller {
     }
 
     public function validate() {
-		if (empty($this->session->data['gcaptcha'])) {
+		if ($this->session->data['gcaptcha']) {
 			$this->load->language('extension/captcha/google');
 
 			if (!isset($this->request->post['g-recaptcha-response'])) {


### PR DESCRIPTION
Forms are being sent even if the recaptcha v2 box is not checked, solved when the unnecessary "empty" function is deleted from the condition here.