### PR TITLE
Added workaround for undefined GLOB_BRACE on non GNU systems

### DIFF
--- a/upload/admin/controller/common/filemanager.php
+++ b/upload/admin/controller/common/filemanager.php
@@ -63,7 +63,18 @@ class ControllerCommonFileManager extends Controller {
 
 		$data['images'] = array();
 
-		$files = glob($directory . $filter_name . '*.{jpg,jpeg,png,gif,JPG,JPEG,PNG,GIF}', GLOB_BRACE);
+		if (defined('GLOB_BRACE')) {
+				$files = glob($directory . $filter_name . '*.{jpg,jpeg,png,gif,JPG,JPEG,PNG,GIF}', GLOB_BRACE);
+			} else {
+				$files = glob($directory . $filter_name . '*.jpg');
+				$files += glob($directory . $filter_name . '*.jpeg');
+				$files += glob($directory . $filter_name . '*.png');
+				$files += glob($directory . $filter_name . '*.gif');
+				$files += glob($directory . $filter_name . '*.JPG');
+				$files += glob($directory . $filter_name . '*.JPEG');
+				$files += glob($directory . $filter_name . '*.PNG');
+				$files += glob($directory . $filter_name . '*.GIF');
+			}
 
 		if ($files) {
 			// Split the array based on current page number and max number of items per page of 10

--- a/upload/admin/controller/design/theme.php
+++ b/upload/admin/controller/design/theme.php
@@ -119,7 +119,12 @@ class ControllerDesignTheme extends Controller {
 			$path_data = array();
 
 			// We grab the files from the default theme directory first as the custom themes drops back to the default theme if selected theme files can not be found.
-			$files = glob(rtrim(DIR_CATALOG . 'view/theme/{default,' . $theme . '}/template/' . $path, '/') . '/*', GLOB_BRACE);
+			if (defined('GLOB_BRACE')) {
+				$files = glob(rtrim(DIR_CATALOG . 'view/theme/{default,' . $theme . '}/template/' . $path, '/') . '/*', GLOB_BRACE);
+			} else {
+				$files = glob(rtrim(DIR_CATALOG . 'view/theme/default/template/' . $path, '/') . '/*');
+				$files += glob(rtrim(DIR_CATALOG . 'view/theme/' . $theme . '/template/' . $path, '/') . '/*');
+			}
 
 			if ($files) {
 				foreach($files as $file) {

--- a/upload/admin/controller/marketplace/extension.php
+++ b/upload/admin/controller/marketplace/extension.php
@@ -27,7 +27,7 @@ class ControllerMarketplaceExtension extends Controller {
 		
 		$data['categories'] = array();
 		
-		$files = glob(DIR_APPLICATION . 'controller/extension/extension/*.php', GLOB_BRACE);
+		$files = glob(DIR_APPLICATION . 'controller/extension/extension/*.php');
 		
 		foreach ($files as $file) {
 			$extension = basename($file, '.php');
@@ -37,7 +37,7 @@ class ControllerMarketplaceExtension extends Controller {
 				$this->load->language('extension/extension/' . $extension, $extension);
 
 				if ($this->user->hasPermission('access', 'extension/extension/' . $extension)) {
-					$files = glob(DIR_APPLICATION . 'controller/extension/' . $extension . '/*.php', GLOB_BRACE);
+					$files = glob(DIR_APPLICATION . 'controller/extension/' . $extension . '/*.php');
 
 					$data['categories'][] = array(
 						'code' => $extension,

--- a/upload/admin/controller/marketplace/modification.php
+++ b/upload/admin/controller/marketplace/modification.php
@@ -177,7 +177,7 @@ class ControllerMarketplaceModification extends Controller {
 						}
 
 						if ($path) {
-							$files = glob($path, GLOB_BRACE);
+							$files = glob($path);
 
 							if ($files) {
 								foreach ($files as $file) {

--- a/upload/install/model/upgrade/1001.php
+++ b/upload/install/model/upgrade/1001.php
@@ -113,7 +113,12 @@ class ModelUpgrade1001 extends Model {
 
 		// Update the config.php by adding a DIR_MODIFICATION
 		if (is_file(DIR_OPENCART . 'config.php')) {
-			$files = glob(DIR_OPENCART . '{config.php,admin/config.php}', GLOB_BRACE);
+			if (defined('GLOB_BRACE')) {
+				$files = glob(DIR_OPENCART . '{config.php,admin/config.php}', GLOB_BRACE);
+			} else {
+				$files = glob(DIR_OPENCART . 'config.php');
+				$files += glob(DIR_OPENCART . 'admin/config.php');
+			}
 
 			foreach ($files as $file) {
 				if (!is_writable($file)) {

--- a/upload/install/model/upgrade/1006.php
+++ b/upload/install/model/upgrade/1006.php
@@ -16,7 +16,12 @@ class ModelUpgrade1006 extends Model {
 
 		// Update the config.php by adding a DB_PORT
 		if (is_file(DIR_OPENCART . 'config.php')) {
-			$files = glob(DIR_OPENCART . '{config.php,admin/config.php}', GLOB_BRACE);
+			if (defined('GLOB_BRACE')) {
+				$files = glob(DIR_OPENCART . '{config.php,admin/config.php}', GLOB_BRACE);
+			} else {
+				$files = glob(DIR_OPENCART . 'config.php');
+				$files += glob(DIR_OPENCART . 'admin/config.php');
+			}
 
 			foreach ($files as $file) {
 				$upgrade = true;

--- a/upload/install/model/upgrade/1009.php
+++ b/upload/install/model/upgrade/1009.php
@@ -120,7 +120,12 @@ class ModelUpgrade1009 extends Model {
 			fclose($handle);
 		}
 	
-		$files = glob(DIR_OPENCART . '{config.php,admin/config.php}', GLOB_BRACE);
+		if (defined('GLOB_BRACE')) {
+			$files = glob(DIR_OPENCART . '{config.php,admin/config.php}', GLOB_BRACE);
+		} else {
+			$files = glob(DIR_OPENCART . 'config.php');
+			$files += glob(DIR_OPENCART . 'admin/config.php');
+		}
 
 		foreach ($files as $file) {
 			$lines = file($file);


### PR DESCRIPTION
The GLOB_BRACE flag is not available on all systems, see: https://www.php.net/manual/en/function.glob.php -> Notes
I removed the flag where possible or split the glob command in multiple parts where needed.
Behavior on systems with GLOB_BRACE available is unchanged. Systems missing GLOB_BRACE functionality have to execute more glob commands, one for each pattern in braces, and the results have to be merged into a single result array.
Tested on systems with and without GLOB_BRACE functionality, working as expected.
Needed for a few webhosters which are running Solaris (e.g. Strato).