### PR TITLE
Remove data-dismiss='toast' from Modal.

### DIFF
--- a/upload/catalog/view/javascript/common.js
+++ b/upload/catalog/view/javascript/common.js
@@ -368,7 +368,7 @@ $(document).delegate('.agree', 'click', function(e) {
 			html += '    <div class="modal-content">';
 			html += '      <div class="modal-header">';
 			html += '        <h4 class="modal-title">' + $(element).text() + '</h4>';
-			html += '        <button type="button" class="close" data-dismiss="toast">&times;</button>';
+			html += '        <button type="button" class="close" data-dismiss="modal">&times;</button>';
 			html += '      </div>';
 			html += '      <div class="modal-body">' + data + '</div>';
 			html += '    </div>';


### PR DESCRIPTION
In Bootstrap CSS, Toasts notifications is closed by data-dismiss='toast' whereas Modal is closed by data-dismiss='modal'.