### PR TITLE
Fixed undefined index "master_id" bug on admin panel order edit

### DIFF
--- a/upload/catalog/controller/api/order.php
+++ b/upload/catalog/controller/api/order.php
@@ -575,6 +575,7 @@ class ControllerApiOrder extends Controller {
 
 						$order_data['products'][] = array(
 							'product_id' => $product['product_id'],
+							'master_id'  => $product['master_id'],
 							'name'       => $product['name'],
 							'model'      => $product['model'],
 							'option'     => $option_data,


### PR DESCRIPTION
I have described bug here #7644