### PR TITLE
Not work property_exists #7659

### DIFF
--- a/upload/system/engine/proxy.php
+++ b/upload/system/engine/proxy.php
@@ -11,19 +11,17 @@
 * Proxy class
 */
 class Proxy {
-	private $data = array();
-
     /**
      * 
      *
      * @param	string	$key
      */	
 	public function &__get($key) {
-		return $this->data[$key];
+		return $this->{$key};
 	}
 
 	public function attach($key, &$value) {
-		$this->data[$key] = $value;
+		$this->{$key} = $value;
 	}
 
     /**
@@ -33,15 +31,15 @@ class Proxy {
 	 * @param	string	$value
      */	
 	public function __set($key, $value) {
-		$this->data[$key] = $value;
+		$this->{$key} = $value;
 	}
 	
 	public function __call($method, $args) {
 		// Hack for pass-by-reference
 		foreach ($args as $key => &$value);
 
-		if (isset($this->data[$method])) {
-			return call_user_func_array($this->data[$method], $args);
+		if (isset($this->{$method})) {
+			return call_user_func_array($this->{$method}, $args);
 		} else {
 			$trace = debug_backtrace();
 


### PR DESCRIPTION
Customer transaction, coupon, vouchers and reward points confirm/unconfirm and fraud check functions does not work in order processing.

Example: The customer has a $100 store credit. The customer bought a $500 product. At the end of the order must remain a $0 store credit but customer still have a $100 store credit.

https://github.com/opencart/opencart/issues/7659