### PR TITLE
Handle single item update with separate params in checkout/cart/edit

### DIFF
--- a/upload/catalog/controller/checkout/cart.php
+++ b/upload/catalog/controller/checkout/cart.php
@@ -342,19 +342,29 @@ class ControllerCheckoutCart extends Controller {
 
 		// Update
 		if (!empty($this->request->post['quantity'])) {
-			foreach ($this->request->post['quantity'] as $key => $value) {
-				$this->cart->update($key, $value);
+			// Handles single item update
+			if (!empty($this->request->post['key'])) {
+				$key = $this->request->post['key'];
+				$quantity = (int)$this->request->post['quantity'];
+
+				$this->cart->update($key, $quantity);
+
+				$json['success'] = $this->language->get('text_remove');
+			} else {
+				foreach ($this->request->post['quantity'] as $key => $value) {
+					$this->cart->update($key, $value);
+				}
+
+				$this->session->data['success'] = $this->language->get('text_remove');
+
+				unset($this->session->data['shipping_method']);
+				unset($this->session->data['shipping_methods']);
+				unset($this->session->data['payment_method']);
+				unset($this->session->data['payment_methods']);
+				unset($this->session->data['reward']);
+
+				$this->response->redirect($this->url->link('checkout/cart', 'language=' . $this->config->get('config_language')));
 			}
-
-			$this->session->data['success'] = $this->language->get('text_remove');
-
-			unset($this->session->data['shipping_method']);
-			unset($this->session->data['shipping_methods']);
-			unset($this->session->data['payment_method']);
-			unset($this->session->data['payment_methods']);
-			unset($this->session->data['reward']);
-
-			$this->response->redirect($this->url->link('checkout/cart', 'language=' . $this->config->get('config_language')));
 		}
 
 		$this->response->addHeader('Content-Type: application/json');


### PR DESCRIPTION
This PR changes the `edit` action from `ControllerCheckoutCart` to make it compatible with `cart.update` function from [common.js](https://github.com/opencart/opencart/blob/master/upload/catalog/view/javascript/common.js). Currently, that Javascript function is broken since the `key` param is ignored by the backend and the action responds with a redirect instead of a valid JSON response.

The changes aren't supposed to side-effect existing parts of the system that use the same route with the former behavior, i.e. expecting an array parameter named `quantity` having quantities indexed by cart keys.