### PR TITLE
Uninstall all extension files

### DIFF
--- a/upload/admin/controller/marketplace/install.php
+++ b/upload/admin/controller/marketplace/install.php
@@ -451,8 +451,8 @@ class ControllerMarketplaceInstall extends Controller {
 					$source = DIR_IMAGE . substr($result['path'], 6);
 				}
 				
-				if (substr($result['path'], 0, 14) == 'system/library') {
-					$source = DIR_SYSTEM . 'library/' . substr($result['path'], 15);
+				if (substr($result['path'], 0, 6) == 'system') {
+					$source = DIR_SYSTEM . substr($result['path'], 7);
 				}
 
 				if (is_file($source)) {


### PR DESCRIPTION
When you delete an extension, files may remain in the folder system/config/ .