### PR TITLE
Fix missing 'grant_type' parameter. Fixes #7916

### DIFF
--- a/upload/system/library/squareup.php
+++ b/upload/system/library/squareup.php
@@ -223,9 +223,9 @@ class Squareup {
             'no_version' => true,
             'parameters' => array(
                 'client_id' => $this->config->get('payment_squareup_client_id'),
-                'client_secret' => $this->config->get('payment_squareup_client_secret'),
+                'code' => $code,
                 'redirect_uri' => $this->session->data['payment_squareup_oauth_redirect'],
-                'code' => $code
+                'grant_type' => 'authorization_code'
             )
         );
 


### PR DESCRIPTION
Added missing 'grant_type' => 'authorization_code' parameter to OAuth request in Squareup::exchangeCodeForAccessToken(). Resolves #7916