### PR TITLE
Featured module - rename variables

### DIFF
--- a/upload/catalog/controller/extension/module/featured.php
+++ b/upload/catalog/controller/extension/module/featured.php
@@ -24,44 +24,44 @@ class ControllerExtensionModuleFeatured extends Controller {
 				}
 			}
 
-			$products = array_slice($product_data, 0, (int)$setting['limit']);
+			$results = array_slice($product_data, 0, (int)$setting['limit']);
 
-			foreach ($products as $product) {
-				if ($product['image']) {
-					$image = $this->model_tool_image->resize(html_entity_decode($product['image'], ENT_QUOTES, 'UTF-8'), $setting['width'], $setting['height']);
+			foreach ($results as $result) {
+				if ($result['image']) {
+					$image = $this->model_tool_image->resize(html_entity_decode($result['image'], ENT_QUOTES, 'UTF-8'), $setting['width'], $setting['height']);
 				} else {
 					$image = $this->model_tool_image->resize('placeholder.png', $setting['width'], $setting['height']);
 				}
 
 				if ($this->customer->isLogged() || !$this->config->get('config_customer_price')) {
-					$price = $this->currency->format($this->tax->calculate($product['price'], $product['tax_class_id'], $this->config->get('config_tax')), $this->session->data['currency']);
+					$price = $this->currency->format($this->tax->calculate($result['price'], $result['tax_class_id'], $this->config->get('config_tax')), $this->session->data['currency']);
 				} else {
 					$price = false;
 				}
 
-				if ((float)$product['special']) {
-					$special = $this->currency->format($this->tax->calculate($product['special'], $product['tax_class_id'], $this->config->get('config_tax')), $this->session->data['currency']);
+				if ((float)$result['special']) {
+					$special = $this->currency->format($this->tax->calculate($result['special'], $result['tax_class_id'], $this->config->get('config_tax')), $this->session->data['currency']);
 				} else {
 					$special = false;
 				}
 
 				if ($this->config->get('config_tax')) {
-					$tax = $this->currency->format((float)$product['special'] ? $product['special'] : $product['price'], $this->session->data['currency']);
+					$tax = $this->currency->format((float)$result['special'] ? $result['special'] : $result['price'], $this->session->data['currency']);
 				} else {
 					$tax = false;
 				}
 
 				$product_data = array(
-					'product_id'  => $product['product_id'],
+					'product_id'  => $result['product_id'],
 					'thumb'       => $image,
-					'name'        => $product['name'],
-					'description' => utf8_substr(strip_tags(html_entity_decode($product['description'], ENT_QUOTES, 'UTF-8')), 0, $this->config->get('theme_' . $this->config->get('config_theme') . '_product_description_length')) . '..',
+					'name'        => $result['name'],
+					'description' => utf8_substr(strip_tags(html_entity_decode($result['description'], ENT_QUOTES, 'UTF-8')), 0, $this->config->get('theme_' . $this->config->get('config_theme') . '_product_description_length')) . '..',
 					'price'       => $price,
 					'special'     => $special,
 					'tax'         => $tax,
-					'minimum'     => $product['minimum'] > 0 ? $product['minimum'] : 1,
-					'rating'      => $product['rating'],
-					'href'        => $this->url->link('product/product', 'language=' . $this->config->get('config_language') . '&product_id=' . $product['product_id'])
+					'minimum'     => $result['minimum'] > 0 ? $result['minimum'] : 1,
+					'rating'      => $result['rating'],
+					'href'        => $this->url->link('product/product', 'language=' . $this->config->get('config_language') . '&product_id=' . $result['product_id'])
 				);
 
 				$data['products'][] = $this->load->controller('product/thumb', $product_data);


### PR DESCRIPTION
Make product variable names same as in other product modules (bestseller, special, latest, etc).
This may be important for OCMODs.

Actually, all code, assigning $product_data = array(), could be moved to controller 'product/thumb'.
So all product lists in (category, search, manufacturer, special, bestsellers, etc.) should look like:
```
foreach ($results as $result) {
    $data['products'][] = $this->load->controller('product/thumb', $result);
}
```