### PR TITLE
updation of deprecat function del

### DIFF
--- a/upload/system/library/cache/redis.php
+++ b/upload/system/library/cache/redis.php
@@ -28,6 +28,6 @@ class Redis {
 	}
 
 	public function delete($key) {
-		$this->cache->delete(CACHE_PREFIX . $key);
+		$this->cache->del(CACHE_PREFIX . $key);
 	}
 }


### PR DESCRIPTION
Removing deprecated function delete(), which will be removed in a future version of phpredis

Please refer.
https://github.com/phpredis/phpredis#del-delete-unlink