### PR TITLE
Add placeholder image to cart item for products without images

### DIFF
--- a/upload/catalog/controller/checkout/cart.php
+++ b/upload/catalog/controller/checkout/cart.php
@@ -81,7 +81,7 @@ class ControllerCheckoutCart extends Controller {
 				if ($product['image']) {
 					$image = $this->model_tool_image->resize(html_entity_decode($product['image'], ENT_QUOTES, 'UTF-8'), $this->config->get('theme_' . $this->config->get('config_theme') . '_image_cart_width'), $this->config->get('theme_' . $this->config->get('config_theme') . '_image_cart_height'));
 				} else {
-					$image = '';
+					$image = $this->model_tool_image->resize('placeholder.png', $this->config->get('theme_' . $this->config->get('config_theme') . '_image_cart_width'), $this->config->get('theme_' . $this->config->get('config_theme') . '_image_cart_height'));
 				}
 
 				$option_data = array();

--- a/upload/catalog/controller/common/cart.php
+++ b/upload/catalog/controller/common/cart.php
@@ -51,7 +51,7 @@ class ControllerCommonCart extends Controller {
 			if ($product['image']) {
 				$image = $this->model_tool_image->resize(html_entity_decode($product['image'], ENT_QUOTES, 'UTF-8'), $this->config->get('theme_' . $this->config->get('config_theme') . '_image_cart_width'), $this->config->get('theme_' . $this->config->get('config_theme') . '_image_cart_height'));
 			} else {
-				$image = '';
+				$image = $this->model_tool_image->resize('placeholder.png', $this->config->get('theme_' . $this->config->get('config_theme') . '_image_cart_width'), $this->config->get('theme_' . $this->config->get('config_theme') . '_image_cart_height'));
 			}
 
 			$option_data = array();


### PR DESCRIPTION
It's probably better to display a placeholder image for product items in cart that doesn't have any images instead of just leaving the column empty.

<img width="1215" alt="opencart-empty-cart-image" src="https://user-images.githubusercontent.com/3436468/86482403-72592900-bd84-11ea-9d56-b6641cd6efa0.png">
