### PR TITLE
Fix Multiple Marketing Email Sending for Customers and Affiliates from Issue #8051

### DIFF
--- a/upload/admin/controller/marketing/contact.php
+++ b/upload/admin/controller/marketing/contact.php
@@ -135,11 +135,16 @@ class ControllerMarketingContact extends Controller {
 						break;
 					case 'customer':
 						if (!empty($this->request->post['customer'])) {
-							foreach ($this->request->post['customer'] as $customer_id) {
-								$customer_info = $this->model_customer_customer->getCustomer($customer_id);
+							$start = ($page - 1) * 10;
 
-								if ($customer_info) {
-									$emails[] = $customer_info['email'];
+							for ($i = 0; $i < 10; $i++) {
+								if (isset($this->request->post['customer'][($start + $i)])) {
+									$customer_id = $this->request->post['customer'][($start + $i)];
+									$customer_info = $this->model_customer_customer->getCustomer($customer_id);
+
+									if ($customer_info) {
+										$emails[] = $customer_info['email'];
+									}
 								}
 							}
 
@@ -163,11 +168,16 @@ class ControllerMarketingContact extends Controller {
 						break;
 					case 'affiliate':
 						if (!empty($this->request->post['affiliate'])) {
-							foreach ($this->request->post['affiliate'] as $affiliate_id) {
-								$affiliate_info = $this->model_customer_customer->getCustomer($affiliate_id);
+							$start = ($page - 1) * 10;
 
-								if ($affiliate_info) {
-									$emails[] = $affiliate_info['email'];
+							for ($i = 0; $i < 10; $i++) {
+								if (isset($this->request->post['affiliate'][($start + $i)])) {
+									$affiliate_id = $this->request->post['affiliate'][($start + $i)];
+									$affiliate_info = $this->model_customer_customer->getCustomer($affiliate_id);
+
+									if ($affiliate_info) {
+										$emails[] = $affiliate_info['email'];
+									}
 								}
 							}
 						}


### PR DESCRIPTION
Fix multiple marketing email sending for **Customers** and **Affiliates** on admin `marketing/contact` page, as reported in #8051 by @eka7a.

Issue caused by the absent of pagination in retrieving individual customer info by calling `$this->model_customer_customer->getCustomer()` function repetitively from ajax call in the template:

https://github.com/opencart/opencart/blob/7d156508fd2cf6b1d12313db5c7b8e8c4291cbc3/upload/admin/view/template/marketing/contact.twig#L269-L271

Therefore, the fix involves chunking the function call in pages of 10.