### PR TITLE
Fix PayPal Standard when session has SameSite=Lax

### DIFF
--- a/upload/catalog/view/theme/default/template/extension/payment/pp_standard.twig
+++ b/upload/catalog/view/theme/default/template/extension/payment/pp_standard.twig
@@ -35,7 +35,7 @@
   <input type="hidden" name="email" value="{{ email }}" />
   <input type="hidden" name="invoice" value="{{ invoice }}" />
   <input type="hidden" name="lc" value="{{ lc }}" />
-  <input type="hidden" name="rm" value="2" />
+  <input type="hidden" name="rm" value="1" />
   <input type="hidden" name="no_note" value="1" />
   <input type="hidden" name="no_shipping" value="1" />
   <input type="hidden" name="charset" value="utf-8" />


### PR DESCRIPTION
When new web browsers start to change the default of SameSite to Lax for cookies (https://www.chromium.org/updates/same-site). PayPal needs to return to the store with a GET and not a POST or the session will be lost.

Changing 'rm' to 1 will force PayPal to return using a GET. https://www.paypal.com/ee/smarthelp/article/how-do-i-use-the-rm-variable-for-website-payments-ts1011