### PR TITLE
Added missing escape character in .htaccess.txt

### DIFF
--- a/upload/.htaccess.txt
+++ b/upload/.htaccess.txt
@@ -6,11 +6,11 @@
 
 Options +FollowSymlinks
 
-# Prevent Directoy listing
+# Prevent Directory listing
 Options -Indexes
 
 # Prevent Direct Access to files
-<FilesMatch "(?i)((\.tpl|.twig|\.ini|\.log|(?<!robots)\.txt))">
+<FilesMatch "(?i)((\.tpl|\.twig|\.ini|\.log|(?<!robots)\.txt))">
  Require all denied
 ## For apache 2.2 and older, replace "Require all denied" with these two lines :
 # Order deny,allow


### PR DESCRIPTION
Added missing escape character for .twig extension in .htaccess.txt and fixed a typo.