### PR TITLE
Added '{% include %}' not working fix

### DIFF
--- a/upload/system/library/template/twig.php
+++ b/upload/system/library/template/twig.php
@@ -40,7 +40,9 @@ final class Twig {
 				'cache'       => DIR_CACHE . 'template/'
 			);
 
-			$loader = new \Twig\Loader\ArrayLoader(array($filename . '.twig' => $code));
+			$loader1 = new \Twig\Loader\ArrayLoader(array($filename . '.twig' => $code));
+			$loader2 = new \Twig\Loader\FilesystemLoader(array(DIR_TEMPLATE));
+			$loader = new \Twig\Loader\ChainLoader(array($loader1, $loader2));
 
 			try {
 				$twig = new \Twig\Environment($loader, $config);


### PR DESCRIPTION
{% include %} function still not working. So all themes, modules with {% include %} in a twig file will not work.

https://github.com/opencart/opencart/pull/7153#issuecomment-500143157