### PR TITLE
Fix File & Directories Permission Checks in Install Script step_2.php

### DIFF
--- a/upload/install/controller/install/step_2.php
+++ b/upload/install/controller/install/step_2.php
@@ -57,24 +57,16 @@ class ControllerInstallStep2 extends Controller {
 		// catalog config
 		if (!is_file(DIR_OPENCART . 'config.php')) {
 			$data['error_catalog_config'] = $this->language->get('error_missing');
+		} elseif (!is_writable(DIR_OPENCART . 'config.php')) {
+			$data['error_catalog_config'] = $this->language->get('error_unwritable');
 		} else {
 			$data['error_catalog_config'] = '';
-		}
-		
-		if (!is_writable(DIR_OPENCART . 'config.php')) {
-			$data['error_catalog'] = $this->language->get('error_unwritable');
-		} else {
-			$data['error_catalog'] = '';
 		}
 
 		// admin configs
 		if (!is_file(DIR_OPENCART . 'admin/config.php')) {
 			$data['error_admin_config'] = $this->language->get('error_missing');
-		} else {
-			$data['error_admin_config_admin'] = '';
-		}
-		
-		if (!is_writable(DIR_OPENCART . 'admin/config.php')) {
+		} elseif (!is_writable(DIR_OPENCART . 'admin/config.php')) {
 			$data['error_admin_config'] = $this->language->get('error_unwritable');
 		} else {
 			$data['error_admin_config'] = '';
@@ -97,11 +89,17 @@ class ControllerInstallStep2 extends Controller {
 		} else {
 			$data['error_image_catalog'] = '';
 		}	
-		
-		if (!is_writable(DIR_SYSTEM . 'storage/logs/')) {
-			$data['error_log'] = $this->language->get('error_unwritable');
+
+		if (!is_writable(DIR_SYSTEM . 'storage/cache/')) {
+			$data['error_cache'] = $this->language->get('error_unwritable');
 		} else {
-			$data['error_log'] = '';
+			$data['error_cache'] = '';
+		}
+
+		if (!is_writable(DIR_SYSTEM . 'storage/logs/')) {
+			$data['error_logs'] = $this->language->get('error_unwritable');
+		} else {
+			$data['error_logs'] = '';
 		}		
 			
 		if (!is_writable(DIR_SYSTEM . 'storage/download/')) {


### PR DESCRIPTION
### Issue:
During Installation in **Step 2**:

1. `/config.php` check will show '_Writable_' even if it doesn't have writable permission.
2. `/admin/config.php` check will show '_Unwritable_' even if it's missing. Supposed to show '_Missing_'.
3. `~/upload/system/storage/cache/` check will always show '_Writable_' even if it doesn't have writable permission.
4. `~/upload/system/storage/logs/` check will always show '_Writable_' even if it doesn't have writable permission.

### Cause:
Various typos in variable names and missing checks.