### PR TITLE
Added missing Sass compiler in config/catalog.php

### DIFF
--- a/upload/system/config/catalog.php
+++ b/upload/system/config/catalog.php
@@ -34,6 +34,7 @@ $_['action_pre_action']  = array(
 	'startup/startup',
 	'startup/error',
 	'startup/event',
+	'startup/sass',
 	'startup/maintenance',
 	'startup/seo_url'
 );


### PR DESCRIPTION
### Issue:
`.scss` files in theme stylesheets `upload/catalog/view/theme/*/stylesheet/` does not compile into `.css` during startup process.

### Solution:
Added missing startup pre_action Sass compiler `'startup/sass'` in config/catalog.php