### PR TITLE
Fix setcookie() Fail due to invalid Path '//'

### DIFF
--- a/upload/catalog/controller/startup/startup.php
+++ b/upload/catalog/controller/startup/startup.php
@@ -60,7 +60,7 @@ class ControllerStartupStartup extends Controller {
 
 			$option = array(
 				'max-age'  => time() + $this->config->get('session_expire'),
-				'path'     => !empty($_SERVER['PHP_SELF']) ? dirname($_SERVER['PHP_SELF']) . '/' : '',
+				'path'     => !empty($_SERVER['PHP_SELF']) ? dirname($_SERVER['PHP_SELF']) : '',
 				'domain'   => $this->request->server['HTTP_HOST'],
 				'secure'   => $this->request->server['HTTPS'],
 				'httponly' => false,

--- a/upload/system/framework.php
+++ b/upload/system/framework.php
@@ -127,7 +127,7 @@ if ($config->get('session_autostart')) {
 	// Require higher security for session cookies
 	$option = array(
 		'max-age'  => time() + $config->get('session_expire'),
-		'path'     => !empty($_SERVER['PHP_SELF']) ? dirname($_SERVER['PHP_SELF']) . '/' : '',
+		'path'     => !empty($_SERVER['PHP_SELF']) ? dirname($_SERVER['PHP_SELF']) : '',
 		'domain'   => $_SERVER['HTTP_HOST'],
 		'secure'   => $_SERVER['HTTPS'],
 		'httponly' => false,


### PR DESCRIPTION
### Issue:
When a store is hosted on root directory(meaning, the webserver `DocumentRoot` points to `/oc3100b/upload/` directory), the `'path'` value will return `'//'`, where the `OCSESSID` will fail to be created by `setcookie()` due to the invalid path.

### Cause:
In `upload/catalog/controller/startup/startup.php:63` & `upload/system/framework.php:130`,  the following code will return `/` when the domain directory is root, e.g. _http://mystore.com_:
```php
dirname($_SERVER['PHP_SELF'])
```
and the additional trailing slash ` . '/'` causes it to become `'//'`, which is invalid as a Set-Cookie Path.

### Solution:
Removing the extra trailing slash will work in both root domain directory and subdirectory store access.