### PR TITLE
Fix Unintended Heading Title Overwrite by Unused Module Language Load - Issue #8153

### DIFF
--- a/upload/admin/controller/design/layout.php
+++ b/upload/admin/controller/design/layout.php
@@ -365,12 +365,9 @@ class ControllerDesignLayout extends Controller {
 		// Add all the modules which have multiple settings for each module
 		foreach ($layout_modules as $layout_module) {
 			$part = explode('.', $layout_module['code']);
-		
-			$this->load->language('extension/module/' . $part[0]);
 
 			if (!isset($part[1])) {
 				$data['layout_modules'][] = array(
-					'name'       => strip_tags($this->language->get('heading_title')),
 					'code'       => $layout_module['code'],
 					'edit'       => $this->url->link('extension/module/' . $part[0], 'user_token=' . $this->session->data['user_token'], true),
 					'position'   => $layout_module['position'],
@@ -381,7 +378,6 @@ class ControllerDesignLayout extends Controller {
 				
 				if ($module_info) {
 					$data['layout_modules'][] = array(
-						'name'       => strip_tags($module_info['name']),
 						'code'       => $layout_module['code'],
 						'edit'       => $this->url->link('extension/module/' . $part[0], 'user_token=' . $this->session->data['user_token'] . '&module_id=' . $part[1], true),
 						'position'   => $layout_module['position'],


### PR DESCRIPTION
### Issue:
Refer to issue #8153 for detailed description.

### Cause:
Module language is loaded without 2nd `key` parameter, causing overwrite of certain language text, such as `'heading_title'` of the current Layout page.

### Solution:
The code is removed altogether as it was never used in its template file in `upload/admin/view/template/design/layout_form.twig`