### PR TITLE
Important. Fix method editCategory

### DIFF
--- a/upload/admin/model/catalog/category.php
+++ b/upload/admin/model/catalog/category.php
@@ -157,7 +157,7 @@ class ModelCatalogCategory extends Model {
 		}
 
 		// Update all the previous paths to the new one
-		$this->db->query("UPDATE `" . DB_PREFIX . "seo_url` SET `value` = REPLACE(`value`, '" . $this->db->escape($path_old) . "', '" . $this->db->escape($path) . "') WHERE `key` = 'path' AND `value` LIKE '" . $this->db->escape($path_old) . "_%'");
+		$this->db->query("UPDATE `" . DB_PREFIX . "seo_url` SET `value` = REPLACE(`value`, '" . $this->db->escape($path_old) . "', '" . $this->db->escape($path) . "') WHERE `key` = 'path' AND `value` LIKE '" . $this->db->escape($path_old) . "\_%'");
 
 		// Layouts
 		$this->db->query("DELETE FROM `" . DB_PREFIX . "category_to_layout` WHERE `category_id` = '" . (int)$category_id . "'");


### PR DESCRIPTION
In mysql, when using the LIKE operator, '_' means any one character, so the path for categories is not working correctly. For example

    UPDATE `oc_seo_url` SET `query` = REPLACE(query, 'path=1', 'path=10_1') WHERE `query` LIKE 'path=1_%'
The code above will replace the path 10_1 in the database with 10_10_1