### PR TITLE
Removing the oc_setcookie function

### DIFF
--- a/upload/admin/controller/startup/startup.php
+++ b/upload/admin/controller/startup/startup.php
@@ -2,8 +2,8 @@
 class ControllerStartupStartup extends Controller {
 	public function index() {
 		// Settings
-		$query = $this->db->query("SELECT * FROM " . DB_PREFIX . "setting WHERE store_id = '0'"); 
-		
+		$query = $this->db->query("SELECT * FROM " . DB_PREFIX . "setting WHERE store_id = '0'");
+
 		foreach ($query->rows as $setting) {
 			if (!$setting['serialized']) {
 				$this->config->set($setting['key'], $setting['value']);
@@ -31,7 +31,7 @@ class ControllerStartupStartup extends Controller {
 
 		// Require higher security for session cookies
 		$option = array(
-			'max-age'  => time() + $this->config->get('session_expire'),
+			'expires'  => time() + $this->config->get('session_expire'),
 			'path'     => !empty($_SERVER['PHP_SELF']) ? dirname($_SERVER['PHP_SELF']) . '/' : '',
 			'domain'   => $this->request->server['HTTP_HOST'],
 			'secure'   => $this->request->server['HTTPS'],
@@ -39,7 +39,7 @@ class ControllerStartupStartup extends Controller {
 			'SameSite' => 'strict'
 		);
 
-		oc_setcookie($this->config->get('session_name'), $this->session->getId(), $option);
+		setcookie($this->config->get('session_name'), $this->session->getId(), $option);
 
 		// Response output compression level
 		if ($this->config->get('config_compression')) {
@@ -48,25 +48,25 @@ class ControllerStartupStartup extends Controller {
 
 		// Language
 		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "language` WHERE code = '" . $this->db->escape($this->config->get('config_admin_language')) . "'");
-		
+
 		if ($query->num_rows) {
 			$this->config->set('config_language_id', $query->row['language_id']);
 		}
-		
+
 		// Language
 		$language = new Language($this->config->get('config_admin_language'));
 		$language->load($this->config->get('config_admin_language'));
 		$this->registry->set('language', $language);
-		
+
 		// Customer
 		$this->registry->set('customer', new Cart\Customer($this->registry));
 
 		// Currency
 		$this->registry->set('currency', new Cart\Currency($this->registry));
-	
+
 		// Tax
 		$this->registry->set('tax', new Cart\Tax($this->registry));
-		
+
 		if ($this->config->get('config_tax_default') == 'shipping') {
 			$this->tax->setShippingAddress($this->config->get('config_country_id'), $this->config->get('config_zone_id'));
 		}
@@ -79,13 +79,13 @@ class ControllerStartupStartup extends Controller {
 
 		// Weight
 		$this->registry->set('weight', new Cart\Weight($this->registry));
-		
+
 		// Length
 		$this->registry->set('length', new Cart\Length($this->registry));
-		
+
 		// Cart
 		$this->registry->set('cart', new Cart\Cart($this->registry));
-		
+
 		// Encryption
 		$this->registry->set('encryption', new Encryption());
 	}

--- a/upload/catalog/controller/common/cookie.php
+++ b/upload/catalog/controller/common/cookie.php
@@ -17,13 +17,13 @@ class ControllerCommonCookie extends Controller {
 
 		if (!isset($this->cookie['policy'])) {
 			$option = array(
-				'max-age'  => strtotime('+10 years'),
+				'expires'  => strtotime('+10 years'),
 				'path'     => '/',
 				'SameSite' => 'lax'
 			);
 
 			// Using time as the policy value allows you to see when te policy was agreed.
-			oc_setcookie('policy', time(), $option);
+			setcookie('policy', time(), $option);
 
 			$json['success'] = $this->language->get('text_success');
 		}

--- a/upload/catalog/controller/common/language.php
+++ b/upload/catalog/controller/common/language.php
@@ -54,12 +54,12 @@ class ControllerCommonLanguage extends Controller {
 		}
 
 		$option = array(
-			'max-age'  => time() + 60 * 60 * 24 * 30,
+			'expires'  => time() + 60 * 60 * 24 * 30,
 			'path'     => '/',
 			'SameSite' => 'lax'
 		);
 
-		oc_setcookie('language', $code, $option);
+		setcookie('language', $code, $option);
 
 		if ($redirect && substr($redirect, 0, strlen($this->config->get('config_url'))) == $this->config->get('config_url')) {
 			$this->response->redirect($redirect);

--- a/upload/catalog/controller/startup/marketing.php
+++ b/upload/catalog/controller/startup/marketing.php
@@ -4,12 +4,12 @@ class ControllerStartupMarketing extends Controller {
 		// Tracking Code
 		if (isset($this->request->get['tracking'])) {
 			$option = array(
-				'max-age'  => time() + 3600 * 24 * 1000,
+				'expires'  => time() + 3600 * 24 * 1000,
 				'path'     => '/',
 				'SameSite' => 'lax'
 			);
 
-			oc_setcookie('tracking', $this->request->get['tracking'], $option);
+			setcookie('tracking', $this->request->get['tracking'], $option);
 
 			$this->load->model('marketing/marketing');
 

--- a/upload/catalog/controller/startup/startup.php
+++ b/upload/catalog/controller/startup/startup.php
@@ -67,7 +67,7 @@ class ControllerStartupStartup extends Controller {
 				'SameSite' => 'strict'
 			);
 
-			oc_setcookie($this->config->get('session_name'), $this->session->getId(), $option);
+			setcookie($this->config->get('session_name'), $this->session->getId(), $option);
 		}
 
 		// Response output compression level
@@ -176,7 +176,7 @@ class ControllerStartupStartup extends Controller {
 				'SameSite' => 'lax'
 			);
 
-			oc_setcookie('language', $code, $option);
+			setcookie('language', $code, $option);
 		}
 
 		// Replace the default language object
@@ -229,12 +229,12 @@ class ControllerStartupStartup extends Controller {
 		// Set a new currency cookie if the code does not match the current one
 		if (!isset($this->request->cookie['currency']) || $this->request->cookie['currency'] != $code) {
 			$option = array(
-				'max-age'  => time() + 60 * 60 * 24 * 30,
+				'expires'  => time() + 60 * 60 * 24 * 30,
 				'path'     => '/',
 				'SameSite' => 'lax'
 			);
 
-			oc_setcookie('currency', $code, $option);
+			setcookie('currency', $code, $option);
 		}
 
 		$this->registry->set('currency', new Cart\Currency($this->registry));

--- a/upload/system/framework.php
+++ b/upload/system/framework.php
@@ -126,7 +126,7 @@ if ($config->get('session_autostart')) {
 
 	// Require higher security for session cookies
 	$option = array(
-		'max-age'  => time() + $config->get('session_expire'),
+		'expires'  => time() + $config->get('session_expire'),
 		'path'     => !empty($_SERVER['PHP_SELF']) ? dirname($_SERVER['PHP_SELF']) . '/' : '',
 		'domain'   => $_SERVER['HTTP_HOST'],
 		'secure'   => $_SERVER['HTTPS'],
@@ -134,7 +134,7 @@ if ($config->get('session_autostart')) {
 		'SameSite' => 'strict'
 	);
 
-	oc_setcookie($config->get('session_name'), $session->getId(), $option);
+	setcookie($config->get('session_name'), $session->getId(), $option);
 }
 
 // Cache

--- a/upload/system/helper/general.php
+++ b/upload/system/helper/general.php
@@ -1,48 +1,4 @@
 <?php
-/* Compatibility function Due to PHP 7.3 only being the PHP version to be able to use samesite attribute */
-function oc_setcookie(string $key, string $value, $option = array()) {
-	if (version_compare(phpversion(), '7.3.0', '>=')) {
-		// PHP need to update their setcookie function.
-		if (isset($option['max-age'])) {
-			$option['expires'] = $option['max-age'];
-
-			unset($option['max-age']);
-		}
-
-		setcookie($key, $value, $option);
-	} else {
-		$string = '';
-
-		if (isset($option['max-age'])) {
-			$string .= '; max-age=' . $option['max-age'];
-		} else {
-			$string .= '; max-age=0';
-		}
-
-		if (!empty($option['path'])) {
-			$string .= '; path=' . $option['path'];
-		}
-
-		if (!empty($option['domain'])) {
-			$string .= '; domain=' . $option['domain'];
-		}
-
-		if (!empty($option['HttpOnly'])) {
-			$string .= '; HttpOnly';
-		}
-
-		if (!empty($option['Secure'])) {
-			$string .= '; Secure';
-		}
-
-		if (isset($option['SameSite'])) {
-			$string .= '; SameSite=' . $option['SameSite'];
-		}
-
-		header('Set-Cookie: ' . rawurlencode($key) . '=' . rawurlencode($value) . $string);
-	}
-}
-
 function token($length = 32) {
 	if (!isset($length) || intval($length) <= 8) {
 		$length = 32;


### PR DESCRIPTION
The file "upload/system/startup.php" already has a php version check. In this case we can remove the oc_setcookie function.

    if (version_compare(phpversion(), '7.3.0', '<')) {
        exit('PHP7+ Required');
    }