### PR TITLE
Use getLatestProducts in latest module

### DIFF
--- a/upload/catalog/controller/extension/module/latest.php
+++ b/upload/catalog/controller/extension/module/latest.php
@@ -9,14 +9,7 @@ class ControllerExtensionModuleLatest extends Controller {
 
 		$data['products'] = array();
 
-		$filter_data = array(
-			'sort'  => 'p.date_added',
-			'order' => 'DESC',
-			'start' => 0,
-			'limit' => $setting['limit']
-		);
-
-		$results = $this->model_catalog_product->getProducts($filter_data);
+		$results = $this->model_catalog_product->getLatestProducts($setting['limit']);
 
 		if ($results) {
 			foreach ($results as $result) {


### PR DESCRIPTION
https://github.com/opencart/opencart/pull/6962 for 3.0.x.x as latest module can slow down sites with lot of products.