### PR TITLE
Prevent terms pop up from being indexed

### DIFF
--- a/upload/catalog/controller/information/information.php
+++ b/upload/catalog/controller/information/information.php
@@ -89,6 +89,8 @@ class Information extends \System\Engine\Controller {
 			$output .= html_entity_decode($information_info['description'], ENT_QUOTES, 'UTF-8') . "\n";
 		}
 
+		$this->response->addHeader('X-Robots-Tag: noindex');
+
 		$this->response->setOutput($output);
 	}
 }


### PR DESCRIPTION
Only have to do a Google search for ```inurl:route=information/information/agree``` or a Bing search for ```instreamset:url:route=information/information/agree```, to see how many site have the terms pop up indexed.