### PR TITLE
Added validateController into the loader engine - system/engine/loader.php file.

### DIFF
--- a/upload/system/engine/loader.php
+++ b/upload/system/engine/loader.php
@@ -86,7 +86,7 @@ final class Loader {
 	 * validateController
 	 *
 	 * @param    string $route
-	 * @param	 string $method_name
+	 * @param    string $method_name
 	 */
 	public function validateController($route, $method_name) {
 		// Sanitize the call
@@ -98,7 +98,7 @@ final class Loader {
 		if (class_exists($class)) {
 			// Lookup into controller methods is a little harder so we have to use PHP's magic methods.
 			foreach (get_class_methods($class) as $method) {
-				if ($method == trim(strtolower($method_name))) {
+				if (trim(strtolower($method)) == trim(strtolower($method_name))) {
 					return true;
 					break;
 				} else {

--- a/upload/system/engine/loader.php
+++ b/upload/system/engine/loader.php
@@ -81,6 +81,37 @@ final class Loader {
 			return $output;
 		}
 	}
+	
+	/**
+	 * validateController
+	 *
+	 * @param    string $route
+	 * @param	 string $method_name
+	 */
+	public function validateController($route, $method_name) {
+		// Sanitize the call
+		$route = preg_replace('/[^a-zA-Z0-9_\/]/', '', (string)$route);
+
+		// Converting a route path to a class name
+		$class = 'Opencart\Application\Controller\\' . str_replace(['_', '/'], ['', '\\'], ucwords($route, '_/'));
+
+		if (class_exists($class)) {
+			// Lookup into controller methods is a little harder so we have to use PHP's magic methods.
+			foreach (get_class_methods($class) as $method) {
+				if ($method == trim(strtolower($method_name))) {
+					return true;
+					break;
+				} else {
+					if ($this->registry->has('config') && $this->registry->get('config')->get('config_error_log') && $this->registry->has('log')) {
+						$this->registry->get('log')->write($route . '/' . $method_name);						
+					} else {
+						trigger_error('Error: Could not load controller route ' . $route . '/' . $method_name . '!');
+					}
+					break;
+				}
+			}
+		}		
+	}
 
 	/**
 	 * Model


### PR DESCRIPTION
The reason why we need to add this is due to the fact that the extension folder is now located outside of the admin and catalog folder. Prior to this change, Github users were suggesting similar solutions while it was not really necessary since the extension folder was still inside each core folders.

The system/engine/action.php file only validates the string of the method with | being entered but has no server functions to validate the controllers' method names being parametered into the ```$this->url->link``` method. While it is not necessary to edit the system/library/url.php file in this scenario, the system/engine/loader.php file does need to ensure that each extension lookups are loading with valid method names where only one method name is expected to be defined especially when an extension project is located outside of the core area.

An e.g would be to look into the admin/controller/report/report.php file on line 39 and line 46. There are no validation methods during the loop where the loader would confirm that this method name does or doesn't exist. All it does is tracking the permissions and loading the URL as is without lookups. This methodology needs to be improved to, at least, ensure awareness to supporters and store owners while troubleshooting the issue based on extension lookups.