### PR TITLE
Update stream_socket_enable_crypto(..) when php >= 7.4.x  used

### DIFF
--- a/upload/system/library/mail/smtp.php
+++ b/upload/system/library/mail/smtp.php
@@ -126,7 +126,7 @@ class Smtp {
 
 				$this->handleReply($handle, 220, 'Error: STARTTLS not accepted from server!');
 
-				stream_socket_enable_crypto($handle, true, STREAM_CRYPTO_METHOD_TLS_CLIENT);
+				stream_socket_enable_crypto($handle, true, STREAM_CRYPTO_METHOD_SSLv23_CLIENT);
 			}
 
 			if (!empty($this->smtp_username) && !empty($this->smtp_password)) {


### PR DESCRIPTION
using SMP and tls:// results in en error:
PHP Warning:  stream_socket_enable_crypto(): SSL operation failed with code 1. OpenSSL Error messages:
error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed in ../system/library/mail.php on line xxx (xx = line depends on used OpenCart Version - this is taken from a 2.x installation).

Regarding php.net: https://www.php.net/manual/de/function.stream-socket-enable-crypto.php#119122
the usage of STREAM_CRYPTO_METHOD_SSLv23_CLIENT instead of STREAM_CRYPTO_METHOD_TLS_CLIENT should be used.

Tested already and is working