### PR TITLE
Admin additional emails when a space is used between

### DIFF
--- a/upload/catalog/controller/mail/order.php
+++ b/upload/catalog/controller/mail/order.php
@@ -463,6 +463,7 @@ class ControllerMailOrder extends Controller {
 			$emails = explode(',', $this->config->get('config_mail_alert_email'));
 
 			foreach ($emails as $email) {
+				$email = trim($email);
 				if ($email && filter_var($email, FILTER_VALIDATE_EMAIL)) {
 					$mail->setTo($email);
 					$mail->send();


### PR DESCRIPTION
Regarding this issue here: https://github.com/opencart/opencart/issues/8659
If additional admin alert emails are defined like (space after the comma):

> admin1@opencart.com, admin2@opencart.com 

only the first will receive an email.
Trim would prevent in future such issues, the more because there is no help (text) for this.