### PR TITLE
[3.0.x.x_] Fixed Api upgrade error from 2.3.0.2

### DIFF
--- a/upload/install/model/upgrade/1009.php
+++ b/upload/install/model/upgrade/1009.php
@@ -66,11 +66,14 @@ class ModelUpgrade1009 extends Model {
 			
 			$this->db->query("DROP TABLE `" . DB_PREFIX . "affiliate_transaction`");
 		}
-	
+		
+		// Api
 		$query = $this->db->query("SELECT * FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = '" . DB_DATABASE . "' AND TABLE_NAME = '" . DB_PREFIX . "api' AND COLUMN_NAME = 'name'");
 		
 		if ($query->num_rows) {
-			$this->db->query("ALTER TABLE `" . DB_PREFIX . "api` CHANGE `name` `username` VARCHAR(64) NOT NULL");
+		    $this->db->query("ALTER TABLE `" . DB_PREFIX . "api` DROP COLUMN `username`");
+			$this->db->query("ALTER TABLE `" . DB_PREFIX . "api` CHANGE COLUMN `name` `username` VARCHAR(64) NOT NULL");
+			$this->db->query("ALTER TABLE `" . DB_PREFIX . "api` MODIFY `username` VARCHAR(64) NOT NULL AFTER `api_id`");
 		}
 		
 		// Events


### PR DESCRIPTION
When you try to upgrade the store from Opencart 2.3.0.2 to 3.0.3.6 in database is created automatically username field taken from opencart.sql.
And when upgrade controller read command from this file will give duplicate for username.

With this fix first username (added by opencart.sql) will be deleted then name will be renamed to username.