### PR TITLE
Added COVID-19 notes once the upgrade completes - install/upgrade/en-gb/upgrade/upgrade.php file.

### DIFF
--- a/upload/install/language/en-gb/upgrade/upgrade.php
+++ b/upload/install/language/en-gb/upgrade/upgrade.php
@@ -14,7 +14,7 @@ $_['text_user']       = 'Goto Admin -> Users -> User Groups and Edit the Top Adm
 $_['text_setting']    = 'Goto Admin and Edit the main System Settings. Update all fields and click save, even if nothing changed.';
 $_['text_store']      = 'Load the store front & press Ctrl+F5 twice to force the browser to update the css changes.';
 $_['text_progress']   = 'Patch %s has been applied (%s of %s)';
-$_['text_success']    = 'Congratulations! You have successfuly upgraded your OpenCart installation!';
+$_['text_success']    = 'Congratulations! You have successfuly upgraded your OpenCart installation. Please ensure to inform your customers, via the information agreement form, regarding restrictions that may imply due to the COVID-19 situation!';
 
 // Entry
 $_['entry_progress']  = 'Progress';


### PR DESCRIPTION
Due to the COVID-19 situation, I thought to bring the importance to remind store owners to expand their OC admin > catalog > information > Terms and Agreements form by informing their customers due to restrictions that may be implied throughout geographic areas when the goods are being delivered.