### PR TITLE
Allow longer module code

### DIFF
--- a/upload/system/helper/db_schema.php
+++ b/upload/system/helper/db_schema.php
@@ -3022,7 +3022,7 @@ function db_schema() {
 			],
 			[
 				'name' => 'code',
-				'type' => 'varchar(32)',
+				'type' => 'varchar(64)',
 				'not_null' => true
 			],
 			[


### PR DESCRIPTION
Cause now it also includes extension code prefix

What was `my_beautiful_module` now will look like `my_awesome_extension.my_beautiful_module`