### PR TITLE
Fix path check mixing byte and multi-byte functions

### DIFF
--- a/upload/admin/controller/common/filemanager.php
+++ b/upload/admin/controller/common/filemanager.php
@@ -33,7 +33,7 @@ class FileManager extends \Opencart\System\Engine\Controller {
 			$images = array_slice($directories, ($page - 1) * 16, 16);
 
 			foreach ($images as $image) {
-				if (substr(str_replace('\\', '/', realpath($image)), 0, utf8_strlen(DIR_IMAGE . 'catalog')) == DIR_IMAGE . 'catalog') {
+				if (substr(str_replace('\\', '/', realpath($image)), 0, strlen(DIR_IMAGE . 'catalog')) == DIR_IMAGE . 'catalog') {
 					$name = basename($image);
 
 					$url = '';
@@ -71,7 +71,7 @@ class FileManager extends \Opencart\System\Engine\Controller {
 			$images = array_slice($files, ($page - 1) * 16, 16 - count($data['directories']));
 
 			foreach ($images as $image) {
-				if (substr(str_replace('\\', '/', realpath($image)), 0, utf8_strlen(DIR_IMAGE . 'catalog')) == DIR_IMAGE . 'catalog') {
+				if (substr(str_replace('\\', '/', realpath($image)), 0, strlen(DIR_IMAGE . 'catalog')) == DIR_IMAGE . 'catalog') {
 					$name = basename($image);
 
 					$data['images'][] = [


### PR DESCRIPTION
Mixing single-byte substr with the multi-byte utf8_strlen will cause issues if DIR_IMAGE does include any multi-byte characters.
See https://github.com/opencart/opencart/pull/8718#issuecomment-728902719 for an explanation.