### PR TITLE
OC4 Stop reconstructing controllers on each call

### DIFF
--- a/upload/system/engine/action.php
+++ b/upload/system/engine/action.php
@@ -62,7 +62,13 @@ class Action {
 
 		// Initialize the class
 		if (class_exists($this->class)) {
-			$controller = new $this->class($registry);
+			$controller_route = 'controller_' . str_replace(array('/', '|'), '_', (string)$this->route);
+			if (!$registry->has($controller_route)) {
+				$controller = new $this->class($registry);
+				$registry->set($controller_route, $controller);
+			} else {
+				$controller = $registry->get($controller_route);
+			}
 		} else {
 			return new \Exception('Error: Could not call route ' . $this->route . '!');
 		}


### PR DESCRIPTION
Fix controllers calls:
1. Allows storing variables inside controller classes.
2. Also most 3rd party extensions call lots of init functions on their controllers __construct(). This may cause significant performance loss which is hard to debug.
3. Event system would make things only worse, calling more controller functions and reconstructing controller on each call.