### PR TITLE
Theme Editor > using default and custom templates side by side

### DIFF
--- a/upload/admin/controller/design/theme.php
+++ b/upload/admin/controller/design/theme.php
@@ -106,7 +106,7 @@ class ControllerDesignTheme extends Controller {
 		$theme = $this->model_setting_setting->getSettingValue('config_theme', $store_id);
 
 		// This is only here for compatibility with old themes.
-		if ($theme == 'theme_default') {
+		if ($theme == 'default') {
 			$theme = $this->model_setting_setting->getSettingValue('theme_default_directory', $store_id);
 		}
 
@@ -172,7 +172,7 @@ class ControllerDesignTheme extends Controller {
 		$theme = $this->model_setting_setting->getSettingValue('config_theme', $store_id);
 
 		// This is only here for compatibility with old themes.
-		if ($theme == 'theme_default') {
+		if ($theme == 'default') {
 			$theme = $this->model_setting_setting->getSettingValue('theme_default_directory', $store_id);
 		}
 
@@ -214,7 +214,7 @@ class ControllerDesignTheme extends Controller {
 		$theme = $this->model_setting_setting->getSettingValue('config_theme', $store_id);
 
 		// This is only here for compatibility with old themes.
-		if ($theme == 'theme_default') {
+		if ($theme == 'default') {
 			$theme = $this->model_setting_setting->getSettingValue('theme_default_directory', $store_id);
 		}
 
@@ -263,7 +263,7 @@ class ControllerDesignTheme extends Controller {
 		$theme = $this->model_setting_setting->getSettingValue('config_theme', $store_id);
 
 		// This is only here for compatibility with old themes.
-		if ($theme == 'theme_default') {
+		if ($theme == 'default') {
 			$theme = $this->model_setting_setting->getSettingValue('theme_default_directory', $store_id);
 		}
 


### PR DESCRIPTION
OC 3.0.3.6 & Custom Theme (only a few files from the default)

If OpenCart is used with a custom theme (e.g. default Theme but only a view modified templates), those custom templates are not affected.
Because the config setting is not **theme_default**, only **default**