### PR TITLE
Revert change made to contact from address

### DIFF
--- a/upload/catalog/controller/information/contact.php
+++ b/upload/catalog/controller/information/contact.php
@@ -17,7 +17,7 @@ class ControllerInformationContact extends Controller {
 			$mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
 
 			$mail->setTo($this->config->get('config_email'));
-			$mail->setFrom($this->request->post['email']);
+			$mail->setFrom($this->config->get('config_email'));
 			$mail->setReplyTo($this->request->post['email']);
 			$mail->setSender(html_entity_decode($this->request->post['name'], ENT_QUOTES, 'UTF-8'));
 			$mail->setSubject(html_entity_decode(sprintf($this->language->get('email_subject'), $this->request->post['name']), ENT_QUOTES, 'UTF-8'));


### PR DESCRIPTION
The from address can't be the customers address. If the customer has DMARC (using SPF & DKIM) correctly set up on their domain, then the email could likely be rejected by the store owners mail server.

Setting the from address as the customers email address was a workaround for some buggy Microsoft email clients that ignored the reply-to address.