### PR TITLE
Fix FontAwesome5 left menu icons - p2

### DIFF
--- a/upload/admin/view/template/common/column_left.twig
+++ b/upload/admin/view/template/common/column_left.twig
@@ -5,9 +5,9 @@
     {% for menu in menus %}
       <li id="{{ menu.id }}">
         {% if menu.href %}
-          <a href="{{ menu.href }}"><i class="fas {{ menu.icon }}"></i> {{ menu.name }}</a>
+          <a href="{{ menu.href }}"><i class="{{ menu.icon }}"></i> {{ menu.name }}</a>
         {% else %}
-          <a href="#collapse{{ i }}" data-toggle="collapse" class="parent collapsed"><i class="fa {{ menu.icon }}"></i> {{ menu.name }}</a>
+          <a href="#collapse{{ i }}" data-toggle="collapse" class="parent collapsed"><i class="{{ menu.icon }}"></i> {{ menu.name }}</a>
         {% endif %}
 
         {% if menu.children %}


### PR DESCRIPTION
Since FontAwesome5 may contain not only fas class, it is preferred to pass both classes in controller.

3d party extensions may use far, fab, etc. classes in left_column menu.

Sorry for two separate pull requests. Web version of GitHub seems does not allow pulling several files in one request