### PR TITLE
fix removePermission

### DIFF
--- a/upload/admin/model/user/user_group.php
+++ b/upload/admin/model/user/user_group.php
@@ -3,7 +3,7 @@ namespace Opencart\Application\Model\User;
 class UserGroup extends \Opencart\System\Engine\Model {
 	public function addUserGroup($data) {
 		$this->db->query("INSERT INTO `" . DB_PREFIX . "user_group` SET `name` = '" . $this->db->escape((string)$data['name']) . "', `permission` = '" . (isset($data['permission']) ? $this->db->escape(json_encode($data['permission'])) : '') . "'");
-	
+
 		return $this->db->getLastId();
 	}
 
@@ -75,7 +75,7 @@ class UserGroup extends \Opencart\System\Engine\Model {
 	public function removePermission($user_group_id, $type, $route) {
 		$user_group_query = $this->db->query("SELECT DISTINCT * FROM `" . DB_PREFIX . "user_group` WHERE `user_group_id` = '" . (int)$user_group_id . "'");
 
-		if ($user_group_query->num_rows && $user_group_query->row['permission']) {
+		if ($user_group_query->num_rows) {
 			$data = json_decode($user_group_query->row['permission'], true);
 
 			if (isset($data[$type])) {

--- a/upload/admin/model/user/user_group.php
+++ b/upload/admin/model/user/user_group.php
@@ -75,10 +75,12 @@ class UserGroup extends \Opencart\System\Engine\Model {
 	public function removePermission($user_group_id, $type, $route) {
 		$user_group_query = $this->db->query("SELECT DISTINCT * FROM `" . DB_PREFIX . "user_group` WHERE `user_group_id` = '" . (int)$user_group_id . "'");
 
-		if ($user_group_query->num_rows) {
+		if ($user_group_query->num_rows && $user_group_query->row['permission']) {
 			$data = json_decode($user_group_query->row['permission'], true);
 
-			$data[$type] = array_diff($data[$type], [$route]);
+			if (isset($data[$type])) {
+				$data[$type] = array_diff($data[$type], [$route]);
+			}
 
 			$this->db->query("UPDATE `" . DB_PREFIX . "user_group` SET `permission` = '" . $this->db->escape(json_encode($data)) . "' WHERE `user_group_id` = '" . (int)$user_group_id . "'");
 		}


### PR DESCRIPTION
PHP Warning:  array_diff(): Argument #1 is not an array in

В лучшем случае нужно весь документ переделать.

			$this->load->model('user/user_group');

			foreach ($this->model_user_user_group->getUserGroups() as $result) {
				$this->model_user_user_group->removePermission($result['user_group_id'], 'access', 'extension/module/mymodule');
				$this->model_user_user_group->removePermission($result['user_group_id'], 'modify', 'extension/module/mymodule');
			}