### PR TITLE
Deleting the default address doesn't clear the customers default setting

### DIFF
--- a/upload/catalog/model/account/address.php
+++ b/upload/catalog/model/account/address.php
@@ -22,7 +22,7 @@ class ModelAccountAddress extends Model {
 
 	public function deleteAddress($address_id) {
 		$this->db->query("DELETE FROM " . DB_PREFIX . "address WHERE address_id = '" . (int)$address_id . "' AND customer_id = '" . (int)$this->customer->getId() . "'");
-		$default_query = $this->db->query("SELECT address_id FROM " . DB_PREFIX . "customer WHERE address_id = '" . (int)$address_id . "' WHERE customer_id = '" . (int)$this->customer->getId() . "'");
+		$default_query = $this->db->query("SELECT address_id FROM " . DB_PREFIX . "customer WHERE address_id = '" . (int)$address_id . "' AND customer_id = '" . (int)$this->customer->getId() . "'");
 		if ($default_query->num_rows) {
 			$this->db->query("UPDATE " . DB_PREFIX . "customer SET address_id = 0 WHERE customer_id = '" . (int)$this->customer->getId() . "'");
 		}

--- a/upload/catalog/model/account/address.php
+++ b/upload/catalog/model/account/address.php
@@ -22,6 +22,10 @@ class ModelAccountAddress extends Model {
 
 	public function deleteAddress($address_id) {
 		$this->db->query("DELETE FROM " . DB_PREFIX . "address WHERE address_id = '" . (int)$address_id . "' AND customer_id = '" . (int)$this->customer->getId() . "'");
+		$default_query = $this->db->query("SELECT address_id FROM " . DB_PREFIX . "customer WHERE address_id = '" . (int)$address_id . "' WHERE customer_id = '" . (int)$this->customer->getId() . "'");
+		if ($default_query->num_rows) {
+			$this->db->query("UPDATE " . DB_PREFIX . "customer SET address_id = 0 WHERE customer_id = '" . (int)$this->customer->getId() . "'");
+		}
 	}
 
 	public function getAddress($address_id) {


### PR DESCRIPTION
Deleting the customers default address should clear the address_id to reflect that they no longer have a default address.
see also issue #8148