### PR TITLE
OC4 fix admin extension startup

### DIFF
--- a/upload/admin/controller/startup/extension.php
+++ b/upload/admin/controller/startup/extension.php
@@ -5,24 +5,24 @@ class Extension extends \Opencart\System\Engine\Controller {
 		// Add extension paths from the DB
 		$this->load->model('setting/extension');
 
-		$results = $this->model_setting_extension->getExtensions();
+		$results = $this->model_setting_extension->getInstalls();
 
 		foreach ($results as $result) {
-			$extension = str_replace(['_', '/'], ['', '\\'], ucwords($result['extension'], '_/'));
+			$extension = str_replace(['_', '/'], ['', '\\'], ucwords($result['code'], '_/'));
 
 			// Register controllers, models and system extension folders
-			$this->autoloader->register('Opencart\Application\Controller\Extension\\' . $extension, DIR_EXTENSION . $result['extension'] . '/admin/controller/');
-			$this->autoloader->register('Opencart\Application\Model\Extension\\' . $extension, DIR_EXTENSION . $result['extension'] . '/admin/model/');
-			$this->autoloader->register('Opencart\System\Extension\\' . $extension, DIR_EXTENSION . $result['extension'] . '/system/');
+			$this->autoloader->register('Opencart\Application\Controller\Extension\\' . $extension, DIR_EXTENSION . $result['code'] . '/admin/controller/');
+			$this->autoloader->register('Opencart\Application\Model\Extension\\' . $extension, DIR_EXTENSION . $result['code'] . '/admin/model/');
+			$this->autoloader->register('Opencart\System\Extension\\' . $extension, DIR_EXTENSION . $result['code'] . '/system/');
 
 			// Template directory
-			$this->template->addPath('extension/' . $result['extension'], DIR_EXTENSION . $result['extension'] . '/admin/view/template/');
+			$this->template->addPath('extension/' . $result['code'], DIR_EXTENSION . $result['code'] . '/admin/view/template/');
 
 			// Language directory
-			$this->language->addPath('extension/' . $result['extension'], DIR_EXTENSION . $result['extension'] . '/admin/language/');
+			$this->language->addPath('extension/' . $result['code'], DIR_EXTENSION . $result['code'] . '/admin/language/');
 
 			// Config directory
-			$this->config->addPath('extension/' . $result['extension'], DIR_EXTENSION . $result['extension'] . '/system/config/');
+			$this->config->addPath('extension/' . $result['code'], DIR_EXTENSION . $result['code'] . '/system/config/');
 		}
 	}
 }


### PR DESCRIPTION
Fix language and install() function for uninstalled modules

https://github.com/opencart/opencart/issues/9069#issuecomment-757287925

If extension have no modules installed, it is absent in oc_extension table, so it's route will be never autoloaded at startup.

This breaks language titles and call to $this->controller->load(route)->install() function on module installation.

A fix is to take extensions codes from oc_extension_install table.