### PR TITLE
Update .editorconfig to match Coding Standards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,5 +8,9 @@ charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+indent_style = tab
+indent_size = 4
+
+[*.twig]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
https://github.com/opencart/opencart/wiki/Coding-Standards#indentation

Always going to have issues due to the mixed indentation in the .twig files.