### PR TITLE
OC4 TWIG proposal - add ids for category and product containers

### DIFF
--- a/upload/catalog/view/template/product/category.twig
+++ b/upload/catalog/view/template/product/category.twig
@@ -22,7 +22,7 @@
       {% if categories %}
         <h3>{{ text_refine }}</h3>
         {% if categories|length <= 5 %}
-          <div class="row">
+          <div id="category-container" class="row">
             <div class="col-sm-3">
               <ul>
                 {% for category in categories %}
@@ -32,7 +32,7 @@
             </div>
           </div>
         {% else %}
-          <div class="row">
+          <div id="category-container" class="row">
             {% for category in categories|batch((categories|length / 4)|round(1, 'ceil')) %}
               <div class="col-sm-3">
                 <ul>
@@ -92,7 +92,7 @@
             </div>
           </div>
         </div>
-        <div class="row">
+        <div id="product-container" class="row">
           {% for product in products %}
             <div class="product-layout product-list col-12">{{ product }}</div>
           {% endfor %}

--- a/upload/catalog/view/template/product/manufacturer_info.twig
+++ b/upload/catalog/view/template/product/manufacturer_info.twig
@@ -55,7 +55,7 @@
             </div>
           </div>
         </div>
-        <div class="row">
+        <div id="product-container" class="row">
           {% for product in products %}
             <div class="product-layout product-list col-12">{{ product }}</div>
           {% endfor %}

--- a/upload/catalog/view/template/product/search.twig
+++ b/upload/catalog/view/template/product/search.twig
@@ -110,7 +110,7 @@
 						</div>
 					</div>
 				</div>
-				<div class="row">
+				<div id="product-container" class="row">
 					{% for product in products %}
 						<div class="product-layout product-list col-12">{{ product }}</div>
 					{% endfor %}

--- a/upload/catalog/view/template/product/special.twig
+++ b/upload/catalog/view/template/product/special.twig
@@ -54,7 +54,7 @@
 						</div>
 					</div>
 				</div>
-				<div class="row">
+				<div id="product-container" class="row">
 					{% for product in products %}
 						<div class="product-layout product-list col-12">{{ product }}</div>
 					{% endfor %}


### PR DESCRIPTION
This will help developers to select blocks for ajax calls and template events.

Even  #display-control has own id, but these important blocks have not.

Perhaps Daniel have own thoughts about block id names, name itself does not matter, it just has to exist, this is just a proposal for more comfortable and standardized DOM structure management, better extensions and templates compatibility in upcoming OC4.