### PR TITLE
Fix non-canonical URLs in sitemap

### DIFF
--- a/upload/catalog/controller/extension/feed/google_sitemap.php
+++ b/upload/catalog/controller/extension/feed/google_sitemap.php
@@ -11,19 +11,21 @@ class ControllerExtensionFeedGoogleSitemap extends Controller {
 			$products = $this->model_catalog_product->getProducts();
 
 			foreach ($products as $product) {
+				$output .= '<url>';
+				$output .= '  <loc>' . $this->url->link('product/product', 'product_id=' . $product['product_id']) . '</loc>';
+				$output .= '  <changefreq>weekly</changefreq>';
+				$output .= '  <lastmod>' . date('Y-m-d\TH:i:sP', strtotime($product['date_modified'])) . '</lastmod>';
+				$output .= '  <priority>1.0</priority>';
+
 				if ($product['image']) {
-					$output .= '<url>';
-					$output .= '  <loc>' . $this->url->link('product/product', 'product_id=' . $product['product_id']) . '</loc>';
-					$output .= '  <changefreq>weekly</changefreq>';
-					$output .= '  <lastmod>' . date('Y-m-d\TH:i:sP', strtotime($product['date_modified'])) . '</lastmod>';
-					$output .= '  <priority>1.0</priority>';
 					$output .= '  <image:image>';
 					$output .= '  <image:loc>' . $this->model_tool_image->resize($product['image'], $this->config->get('theme_' . $this->config->get('config_theme') . '_image_popup_width'), $this->config->get('theme_' . $this->config->get('config_theme') . '_image_popup_height')) . '</image:loc>';
 					$output .= '  <image:caption>' . $product['name'] . '</image:caption>';
 					$output .= '  <image:title>' . $product['name'] . '</image:title>';
 					$output .= '  </image:image>';
-					$output .= '</url>';
 				}
+
+				$output .= '</url>';
 			}
 
 			$this->load->model('catalog/category');
@@ -40,16 +42,6 @@ class ControllerExtensionFeedGoogleSitemap extends Controller {
 				$output .= '  <changefreq>weekly</changefreq>';
 				$output .= '  <priority>0.7</priority>';
 				$output .= '</url>';
-
-				$products = $this->model_catalog_product->getProducts(array('filter_manufacturer_id' => $manufacturer['manufacturer_id']));
-
-				foreach ($products as $product) {
-					$output .= '<url>';
-					$output .= '  <loc>' . $this->url->link('product/product', 'manufacturer_id=' . $manufacturer['manufacturer_id'] . '&product_id=' . $product['product_id']) . '</loc>';
-					$output .= '  <changefreq>weekly</changefreq>';
-					$output .= '  <priority>1.0</priority>';
-					$output .= '</url>';
-				}
 			}
 
 			$this->load->model('catalog/information');
@@ -71,35 +63,19 @@ class ControllerExtensionFeedGoogleSitemap extends Controller {
 		}
 	}
 
-	protected function getCategories($parent_id, $current_path = '') {
+	protected function getCategories($parent_id) {
 		$output = '';
 
 		$results = $this->model_catalog_category->getCategories($parent_id);
 
 		foreach ($results as $result) {
-			if (!$current_path) {
-				$new_path = $result['category_id'];
-			} else {
-				$new_path = $current_path . '_' . $result['category_id'];
-			}
-
 			$output .= '<url>';
-			$output .= '  <loc>' . $this->url->link('product/category', 'path=' . $new_path) . '</loc>';
+			$output .= '  <loc>' . $this->url->link('product/category', 'path=' . $result['category_id']) . '</loc>';
 			$output .= '  <changefreq>weekly</changefreq>';
 			$output .= '  <priority>0.7</priority>';
 			$output .= '</url>';
 
-			$products = $this->model_catalog_product->getProducts(array('filter_category_id' => $result['category_id']));
-
-			foreach ($products as $product) {
-				$output .= '<url>';
-				$output .= '  <loc>' . $this->url->link('product/product', 'path=' . $new_path . '&product_id=' . $product['product_id']) . '</loc>';
-				$output .= '  <changefreq>weekly</changefreq>';
-				$output .= '  <priority>1.0</priority>';
-				$output .= '</url>';
-			}
-
-			$output .= $this->getCategories($result['category_id'], $new_path);
+			$output .= $this->getCategories($result['category_id']);
 		}
 
 		return $output;


### PR DESCRIPTION
Having non-canonical URLs in the sitemap wastes crawl budget and gives mixed signals to search engines. Also fixes issue of products without images not being listed.