### PR TITLE
Make product order consistent on fragmented tables

### DIFF
--- a/upload/admin/model/sale/order.php
+++ b/upload/admin/model/sale/order.php
@@ -241,7 +241,7 @@ class Order extends \Opencart\System\Engine\Model {
 	}
 
 	public function getProducts($order_id) {
-		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "order_product` WHERE `order_id` = '" . (int)$order_id . "'");
+		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "order_product` WHERE `order_id` = '" . (int)$order_id . "' ORDER BY order_product_id ASC");
 
 		return $query->rows;
 	}


### PR DESCRIPTION
Otherwise the original order of the purchased products may be lost. See https://stackoverflow.com/questions/1949641/what-is-mysql-row-order-for-select-from-table-name/1949663#1949663