### PR TITLE
OC4 - Fix seo_url model

### DIFF
--- a/upload/catalog/model/design/seo_url.php
+++ b/upload/catalog/model/design/seo_url.php
@@ -21,7 +21,7 @@ class SeoUrl extends \Opencart\System\Engine\Model {
 
 			return $this->keyword[$key][$value];
 		} else {
-			return '';
+			return $this->keyword[$key][$value];
 		}
 	}
 }

--- a/upload/catalog/model/design/seo_url.php
+++ b/upload/catalog/model/design/seo_url.php
@@ -18,10 +18,8 @@ class SeoUrl extends \Opencart\System\Engine\Model {
 			} else {
 				$this->keyword[$key][$value] = '';
 			}
-
-			return $this->keyword[$key][$value];
-		} else {
-			return $this->keyword[$key][$value];
 		}
+		
+		return $this->keyword[$key][$value];
 	}
 }


### PR DESCRIPTION
Broken &language parameter
`http://website.loc/macbook?language=en-gb`
instead of
`http://website.loc/en-gb/laptop-notebook/macbook`

Fix returning empty string instead of cached keywords