### PR TITLE
Remove html_entity_decode from PayPal Standard

### DIFF
--- a/upload/catalog/controller/extension/payment/pp_standard.php
+++ b/upload/catalog/controller/extension/payment/pp_standard.php
@@ -80,28 +80,28 @@ class ControllerExtensionPaymentPPStandard extends Controller {
 			if ($this->cart->hasShipping()) {
 				$data['no_shipping'] = 2;
 				$data['address_override'] = 1;
-				$data['first_name'] = html_entity_decode($order_info['shipping_firstname'], ENT_QUOTES, 'UTF-8');
-				$data['last_name'] = html_entity_decode($order_info['shipping_lastname'], ENT_QUOTES, 'UTF-8');
-				$data['address1'] = html_entity_decode($order_info['shipping_address_1'], ENT_QUOTES, 'UTF-8');
-				$data['address2'] = html_entity_decode($order_info['shipping_address_2'], ENT_QUOTES, 'UTF-8');
-				$data['city'] = html_entity_decode($order_info['shipping_city'], ENT_QUOTES, 'UTF-8');
-				$data['zip'] = html_entity_decode($order_info['shipping_postcode'], ENT_QUOTES, 'UTF-8');
+				$data['first_name'] = $order_info['shipping_firstname'];
+				$data['last_name'] = $order_info['shipping_lastname'];
+				$data['address1'] = $order_info['shipping_address_1'];
+				$data['address2'] = $order_info['shipping_address_2'];
+				$data['city'] = $order_info['shipping_city'];
+				$data['zip'] = $order_info['shipping_postcode'];
 				$data['country'] = $order_info['shipping_iso_code_2'];
 			} else {
 				$data['no_shipping'] = 1;
 				$data['address_override'] = 0;
-				$data['first_name'] = html_entity_decode($order_info['payment_firstname'], ENT_QUOTES, 'UTF-8');
-				$data['last_name'] = html_entity_decode($order_info['payment_lastname'], ENT_QUOTES, 'UTF-8');
-				$data['address1'] = html_entity_decode($order_info['payment_address_1'], ENT_QUOTES, 'UTF-8');
-				$data['address2'] = html_entity_decode($order_info['payment_address_2'], ENT_QUOTES, 'UTF-8');
-				$data['city'] = html_entity_decode($order_info['payment_city'], ENT_QUOTES, 'UTF-8');
-				$data['zip'] = html_entity_decode($order_info['payment_postcode'], ENT_QUOTES, 'UTF-8');
+				$data['first_name'] = $order_info['payment_firstname'];
+				$data['last_name'] = $order_info['payment_lastname'];
+				$data['address1'] = $order_info['payment_address_1'];
+				$data['address2'] = $order_info['payment_address_2'];
+				$data['city'] = $order_info['payment_city'];
+				$data['zip'] = $order_info['payment_postcode'];
 				$data['country'] = $order_info['payment_iso_code_2'];
 			}
 
 			$data['currency_code'] = $order_info['currency_code'];
 			$data['email'] = $order_info['email'];
-			$data['invoice'] = $this->session->data['order_id'] . ' - ' . html_entity_decode($order_info['payment_firstname'], ENT_QUOTES, 'UTF-8') . ' ' . html_entity_decode($order_info['payment_lastname'], ENT_QUOTES, 'UTF-8');
+			$data['invoice'] = $this->session->data['order_id'] . ' - ' . $order_info['payment_firstname'] . ' ' . $order_info['payment_lastname'];
 			$data['lc'] = $this->session->data['language'];
 			$data['return'] = $this->url->link('checkout/success');
 			$data['notify_url'] = $this->url->link('extension/payment/pp_standard/callback', '', true);


### PR DESCRIPTION
Redo https://github.com/opencart/opencart/commit/bc8603cd1a43a68db2324604b6e7ea6f8203792e which seems to have been undone.