### PR TITLE
getTotalOrders() requires $this->load->model('sale/order')

### DIFF
--- a/upload/admin/controller/sale/order.php
+++ b/upload/admin/controller/sale/order.php
@@ -227,6 +227,8 @@ class Order extends \Opencart\System\Engine\Controller {
 			'limit'                  => $this->config->get('config_pagination_admin')
 		];
 
+		$this->load->model('sale/order');
+
 		$order_total = $this->model_sale_order->getTotalOrders($filter_data);
 
 		$results = $this->model_sale_order->getOrders($filter_data);


### PR DESCRIPTION
Error: Call to a member function getTotalOrders() on null