### PR TITLE
Fixes "Error: MAIL FROM not accepted from server!" with SMTP.

### DIFF
--- a/upload/system/library/mail/smtp.php
+++ b/upload/system/library/mail/smtp.php
@@ -169,9 +169,9 @@ class Smtp {
 			}
 
 			if ($this->verp) {
-				fputs($handle, 'MAIL FROM: <' . $this->smtp_username . '>XVERP' . "\r\n");
+				fputs($handle, 'MAIL FROM: <' . $this->from . '>XVERP' . "\r\n");
 			} else {
-				fputs($handle, 'MAIL FROM: <' . $this->smtp_username . '>' . "\r\n");
+				fputs($handle, 'MAIL FROM: <' . $this->from . '>' . "\r\n");
 			}
 
 			$this->handleReply($handle, 250, 'Error: MAIL FROM not accepted from server!');


### PR DESCRIPTION
This fixes the error "Error: MAIL FROM not accepted from server!" when using SMTP with Amazon SES, Sendgrid or any other provider where the username to authenticate with the SMTP server is not as same as the from email address.

I understand you guys may not want to use external libraries in your code, but this is where time tested stuff like PHPMailer comes very handy.