### PR TITLE
fix for gc into session\db

### DIFF
--- a/upload/system/library/session/db.php
+++ b/upload/system/library/session/db.php
@@ -49,7 +49,7 @@ final class DB {
 			$gc_probability = 1;
 		}
 
-		if (mt_rand() / mt_getrandmax() > $gc_probability / $gc_divisor) {
+		if (mt_rand() / mt_getrandmax() < $gc_probability / $gc_divisor) {
 			$this->db->query("DELETE FROM `" . DB_PREFIX . "session` WHERE `expire` < '" . $this->db->escape(date('Y-m-d H:i:s', time())) . "'");
 
 			return true;


### PR DESCRIPTION
mt_rand() / mt_getrandmax() SHOULD BE LESS THAN $gc_probability / $gc_divisor.
so, setting up higher gc_divisor we will decrase gc startup chance.