### PR TITLE
OC4: Proposal to add extension code before module

### DIFF
--- a/upload/admin/controller/extension/module.php
+++ b/upload/admin/controller/extension/module.php
@@ -70,7 +70,7 @@ class Module extends \Opencart\System\Engine\Controller {
 				if ($module_data) {
 					$status = '';
 				} else {
-					$status = $this->config->get('module_' . $code . '_status') ? $this->language->get('text_enabled') : $this->language->get('text_disabled');
+					$status = $this->config->get('module_' . $extension . '_' . $code . '_status') ? $this->language->get('text_enabled') : $this->language->get('text_disabled');
 				}
 
 				$data['extensions'][] = [


### PR DESCRIPTION
Add extension code to module code settings.

This will make module code unique in oc_setting table.

Different developers can use same module codes for their extensions.
Like blog, filter, banner, slider, shipping, coupon, etc. And rewrite module settings for each other.

This pr is just a concept for @danielkerr. This requires modification of all default opencart extensions templates and controllers.

oc_module table already contain extension code. I think this should be done for oc_setting too.