### PR TITLE
Free shipping based on country/postcode

### DIFF
--- a/upload/catalog/model/extension/shipping/free.php
+++ b/upload/catalog/model/extension/shipping/free.php
@@ -16,6 +16,13 @@ class ModelExtensionShippingFree extends Model {
 		if ($this->cart->getSubTotal() < $this->config->get('shipping_free_total')) {
 			$status = false;
 		}
+		
+		if (!$status) {
+			$query = $this->db->query("SELECT * FROM " . DB_PREFIX . "freeshipping_postcode WHERE postcode = '" . $address['postcode'] . "' AND country_id = '" . (int)$address['country_id'] . "'");
+			if ($query->num_rows) {
+				$status = true;
+			}
+		}
 
 		$method_data = array();
 

--- a/upload/install/opencart.sql
+++ b/upload/install/opencart.sql
@@ -8265,3 +8265,18 @@ INSERT INTO `oc_zone_to_geo_zone` (`zone_to_geo_zone_id`, `country_id`, `zone_id
 (107, 222, 3954, 3, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
 (108, 222, 3955, 3, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
 (109, 222, 3972, 3, '0000-00-00 00:00:00', '0000-00-00 00:00:00');
+
+
+-----------------------------------------------------------
+
+--
+-- Table structure for table `oc_freeshipping_postcode`
+--
+
+DROP TABLE IF EXISTS `oc_freeshipping_postcode`;
+CREATE TABLE `oc_freeshipping_postcode` (
+  `freeshipping_postcode_id` int(11) NOT NULL AUTO_INCREMENT,
+  `country_id` int(11) NOT NULL,
+  `postcode` varchar(10) NOT NULL,
+  PRIMARY KEY (`freeshipping_postcode_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;


### PR DESCRIPTION
Enable free shipping for a number of combinations of country/postcodes.
This allows a flexible way to provide free shipping options.

Currently, the list of country/postcodes has to be added manually to the corresponding table in the database.