### PR TITLE
FIX: When all language are DISABLED the Web Catalog (frontend) show an error

### DIFF
--- a/upload/admin/language/en-gb/localisation/language.php
+++ b/upload/admin/language/en-gb/localisation/language.php
@@ -31,6 +31,7 @@ $_['error_exists']      = 'Warning: You have already added this language!';
 $_['error_name']        = 'Language Name must be between 1 and 32 characters!';
 $_['error_code']        = 'Language Code must be between 2 and 5 characters!';
 $_['error_locale']      = 'Locale required!';
+$_['error_status']      = 'All languages are inactived. You must active one of them!';
 $_['error_default']     = 'Warning: This language cannot be deleted as it is currently assigned as the default store language!';
 $_['error_admin']       = 'Warning: This Language cannot be deleted as it is currently assigned as the administration language!';
 $_['error_store']       = 'Warning: This language cannot be deleted as it is currently assigned to %s stores!';

--- a/upload/admin/view/template/localisation/language_list.twig
+++ b/upload/admin/view/template/localisation/language_list.twig
@@ -27,7 +27,13 @@
 					{% for language in languages %}
 						<tr>
 							<td class="text-center"><input type="checkbox" name="selected[]" value="{{ language.language_id }}" class="form-check-input"/></td>
-							<td class="text-start">{{ language.name }}</td>
+							<td class="text-start">{{ language.name }}
+	                        <br/>
+	                        {% if language.status %}
+	                          <small class="text-success">{{ text_enabled }}</small>
+	                        {% else %}
+	                          <small class="text-danger">{{ text_disabled }}</small>
+	                        {% endif %}</td>
 							<td class="text-start">{{ language.code }}</td>
 							<td class="text-end">{{ language.sort_order }}</td>
 							<td class="text-end"><a href="{{ language.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fas fa-pencil-alt"></i></a></td>

--- a/upload/catalog/controller/startup/language.php
+++ b/upload/catalog/controller/startup/language.php
@@ -112,7 +112,10 @@ class Language extends \Opencart\System\Engine\Controller {
 		// Set the config language_id
 		if (isset($language_codes[$code])) {
 			$this->config->set('config_language_id', $language_codes[$code]);
-		}
+		} else {
+			// language_codes not exists, set default to en-gb
+			$this->config->set('config_language_id', 1 );
+ 		}
 
 		$this->config->set('config_language', $code);
 	}


### PR DESCRIPTION
When All language are DISABLED, the website catalog show an error. This patch set an default language and avoid set all language to DISABLE.