### PR TITLE
OC4: Add extension code to install.xml

### DIFF
--- a/upload/admin/controller/marketplace/installer.php
+++ b/upload/admin/controller/marketplace/installer.php
@@ -190,6 +190,14 @@ class Installer extends \Opencart\System\Engine\Controller {
 							$name = '';
 						}
 
+						$code = $dom->getElementsByTagName('code')->item(0);
+
+						if ($code) {
+							$code = $code->nodeValue;
+						} else {
+							$code = basename($filename, '.ocmod.zip');
+						}
+
 						$version = $dom->getElementsByTagName('version')->item(0);
 
 						if ($version) {
@@ -230,7 +238,7 @@ class Installer extends \Opencart\System\Engine\Controller {
 							'extension_id'          => 0,
 							'extension_download_id' => 0,
 							'name'                  => $name,
-							'code'              	=> basename($filename, '.ocmod.zip'),
+							'code'              	=> $code,
 							'version'               => $version,
 							'author'                => $author,
 							'link'                  => $link,


### PR DESCRIPTION
Take extension code from install.xml

This will give more freedom for developers in naming their extension packs. For example include extension version to name.

Example: 
Many extensions come with names like
oc2x-my-extension-v1234.ocmod.zip
oc30-my-extension-v3456.ocmod.zip
oc30-my-extension-v3456-seo.ocmod.zip
oc30-my-extension-v3456-journal.ocmod.zip
etc.

This is very comfortable for both customers and developers. 

The way it is done in OC4 now, you cannot ever store additional data in filename. 
Otherwise it will break extension folder structure and create folder "extension/oc40-my-extension-v4567". 
While code inside install.xml may contain correct string "my_extension" for any version and modification.