### PR TITLE
Added validation for posted amount - admin/controller/customer/customer.php file

### DIFF
--- a/upload/admin/controller/customer/customer.php
+++ b/upload/admin/controller/customer/customer.php
@@ -906,6 +906,12 @@ class Customer extends \Opencart\System\Engine\Controller {
 		if (!$this->user->hasPermission('modify', 'customer/customer')) {
 			$json['error'] = $this->language->get('error_permission');
 		}
+		
+		if (!$json) {
+			if (!filter_var($this->request->post['amount'], FILTER_VALIDATE_FLOAT)) {
+				$json['error'] = $this->language->get('error_amount');
+			}
+		}
 
 		if (!$json) {
 			$this->load->model('customer/customer');

--- a/upload/admin/controller/customer/customer.php
+++ b/upload/admin/controller/customer/customer.php
@@ -908,7 +908,7 @@ class Customer extends \Opencart\System\Engine\Controller {
 		}
 		
 		if (!$json) {
-			if (!filter_var($this->request->post['amount'], FILTER_VALIDATE_FLOAT)) {
+			if (filter_var($this->request->post['amount'], FILTER_VALIDATE_FLOAT) === false) {
 				$json['error'] = $this->language->get('error_amount');
 			}
 		}


### PR DESCRIPTION
Now that the master branch uses the API from the admin-end side, the order ID may not be passed with the addTransaction but the posted amount can still be tricky if that API is used as opposed to before when the admin did not had an API built-in.