### PR TITLE
Avoid division by zero error

### DIFF
--- a/upload/admin/controller/common/pagination.php
+++ b/upload/admin/controller/common/pagination.php
@@ -14,7 +14,7 @@ class Pagination extends \Opencart\System\Engine\Controller {
 			$page = 1;
 		}
 
-		if (isset($setting['limit'])) {
+		if (isset($setting['limit']) && (int)$setting['limit']>10) {
 			$limit = (int)$setting['limit'];
 		} else {
 			$limit = 10;


### PR DESCRIPTION
I got this error when trying to run OC in headless manner, without browser.