### PR TITLE
Fix for bug #10197 in maintenance branch

### DIFF
--- a/upload/admin/view/template/sale/order_invoice.twig
+++ b/upload/admin/view/template/sale/order_invoice.twig
@@ -14,7 +14,7 @@
 <div class="container">
   {% for order in orders %}
   <div style="page-break-after: always;">
-    <h1>{% if order.invoice_no %}{{ text_invoice }} #{{ order.invoice_no }}{% else %}{{ text_order }}{% endif %}</h1>
+    <h1>{% if order.invoice_no %}{{ text_invoice }} #{{ order.invoice_no }}{% else %}{{ order.order_id }}{% endif %}</h1>
     <table class="table table-bordered">
       <thead>
         <tr>


### PR DESCRIPTION
Fix for bug: Print Order - if multiple orders are printed at once the order numbers are all the same #10197