### PR TITLE
Fix product variant main image override

### DIFF
--- a/upload/admin/view/template/catalog/product_form.twig
+++ b/upload/admin/view/template/catalog/product_form.twig
@@ -1245,7 +1245,7 @@
                         {% if master_id %}
                           <div class="mx-auto w-25">
                             <div class="form-check form-switch">
-                              <input type="checkbox" name="override[product_image]" value="1" id="input-variant-image" data-oc-toggle="switch" data-oc-target="#image" class="form-check-input"{% if override.product_image %} checked{% endif %}/> <label for="input-variant-image" class="custom-control-label"></label>
+                              <input type="checkbox" name="override[image]" value="1" id="input-variant-image" data-oc-toggle="switch" data-oc-target="#image" class="form-check-input"{% if override.image %} checked{% endif %}/> <label for="input-variant-image" class="custom-control-label"></label>
                             </div>
                           </div>
                         {% endif %}


### PR DESCRIPTION
override[product_image] is for additional images

override[image] must be used for main image