### PR TITLE
Update smtp.php

### DIFF
--- a/upload/system/library/mail/smtp.php
+++ b/upload/system/library/mail/smtp.php
@@ -146,7 +146,7 @@ class Smtp {
 			}
 
 			if (!empty($this->smtp_username) && !empty($this->smtp_password)) {
-				fputs($handle, 'EHLO ' . getenv('SERVER_NAME') . "\r\n");
+
 
 				$this->handleReply($handle, 250, 'Error: EHLO not accepted from server!');
 


### PR DESCRIPTION
Sometimes mail servers respond with an error to a second request. For example, smtp.yandex.ru does this.

openssl s_client -connect smtp.yandex.ru:465
>> EHLO c4ip.ru
250-iva4-50c21cb1cb18.qloud-c.yandex.net
250-8BITMIME
250-PIPELINING
250-SIZE 42991616
250-STARTTLS
250-AUTH LOGIN PLAIN XOAUTH2
250-DSN
250 ENHANCEDSTATUSCODES
>> EHLO c4ip.ru
503 5.5.4 Bad sequence of commands.
read:errno=0

Maybe we need to redo the STARTTLS check so that we don't have to send the "EHLO" query twice