### PR TITLE
The Countable interface compatibility in php-8.1.

### DIFF
--- a/upload/system/storage/vendor/twig/twig/src/Node/Node.php
+++ b/upload/system/storage/vendor/twig/twig/src/Node/Node.php
@@ -145,7 +145,7 @@ class Node implements \Countable, \IteratorAggregate
         unset($this->nodes[$name]);
     }
 
-    public function count()
+    public function count(): int
     {
         return \count($this->nodes);
     }


### PR DESCRIPTION
Fix for the warning in php-8.1:
Unknown: Return type of Twig\Node\Node::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in ../opencart/upload/system/storage/vendor/twig/twig/src/Node/Node.php on line 148