### PR TITLE
Fixed separated IFs with elseIFs statements - catalog/controller/api/sale/payment_method.php file

### DIFF
--- a/upload/catalog/controller/api/sale/payment_method.php
+++ b/upload/catalog/controller/api/sale/payment_method.php
@@ -62,15 +62,11 @@ class PaymentMethod extends \Opencart\System\Engine\Controller {
 		// Payment Address
 		if (!isset($this->session->data['payment_address'])) {
 			$json['error'] = $this->language->get('error_address');
-		}
-
+			
 		// Payment Method
-		if (!isset($this->request->post['payment_method'])) {
+		} elseif (!isset($this->request->post['payment_method'])) {
 			$json['error'] = $this->language->get('error_payment_method');
-		}
-
-
-		if (!$this->session->data['payment_methods'] || !isset($this->session->data['payment_methods'][$this->request->post['payment_method']])) {
+		} elseif (!$this->session->data['payment_methods'] || !isset($this->session->data['payment_methods'][$this->request->post['payment_method']])) {
 			$json['error'] = $this->language->get('error_payment_method');
 		}
 


### PR DESCRIPTION
Only one dimensional $json['error'] array is created here. They'd be something odd to set separated IF statements in the lookup since only one error at a time would be returned in this case.