### PR TITLE
fix Chrome error off/block cookie

### DIFF
--- a/upload/catalog/view/javascript/common.js
+++ b/upload/catalog/view/javascript/common.js
@@ -1,3 +1,18 @@
+/* Chrome error off/block cookie "'Window': Access is denied for this document." */
+try {
+	window.localStorage.length;
+} catch {
+	delete window.localStorage;
+	window.localStorage = {
+		'getItem':function(a) {},
+		'setItem':function(a, b) {},
+		'key':function(a) {},
+		'removeItem':function(a) {},
+		'clear':function() {},
+		'length':0
+	};
+}
+
 function getURLVar(key) {
 	var value = [];
 


### PR DESCRIPTION
Chrome error off/block cookie "'Window': Access is denied for this document."

```
<script type="text/javascript"><!--
try {
	window.localStorage.length;
	window.localStorage.status = true;
	window.sessionStorage.length;
	window.sessionStorage.status = true;
} catch {
	delete window.localStorage;
	delete window.sessionStorage;
	window.localStorage = {
		'status':false,
		'getItem':function(a) {},
		'setItem':function(a, b) {},
		'key':function(a) {},
		'removeItem':function(a) {},
		'clear':function() {},
		'length':0
	};
	window.sessionStorage = window.localStorage;
}

window.addEventListener('load', function(e) {
	if (!window.localStorage.status && !window.sessionStorage.status) {
		window.alert('To use all the features of the site, you must enable cookies.');
	}
});
//--></script>
```