### PR TITLE
Fix race condition that sometimes prevents users proceeding through t…

### DIFF
--- a/upload/catalog/view/theme/default/template/checkout/checkout.twig
+++ b/upload/catalog/view/theme/default/template/checkout/checkout.twig
@@ -311,24 +311,24 @@ $(document).delegate('#button-register', 'click', function() {
                     error: function(xhr, ajaxOptions, thrownError) {
                         alert(thrownError + "\r\n" + xhr.statusText + "\r\n" + xhr.responseText);
                     }
-                });
-                {% endif %}
-
-                $.ajax({
-                    url: 'index.php?route=checkout/payment_address',
-                    dataType: 'html',
-                    complete: function() {
-                        $('#button-register').button('reset');
-                    },
-                    success: function(html) {
-                        $('#collapse-payment-address .panel-body').html(html);
+                }).done(function() {
+                    $.ajax({
+                        url: 'index.php?route=checkout/payment_address',
+                        dataType: 'html',
+                        complete: function() {
+                            $('#button-register').button('reset');
+                        },
+                        success: function(html) {
+                            $('#collapse-payment-address .panel-body').html(html);
 
 						$('#collapse-payment-address').parent().find('.panel-heading .panel-title').html('<a href="#collapse-payment-address" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle">{{ text_checkout_payment_address }} <i class="fa fa-caret-down"></i></a>');
-                    },
-                    error: function(xhr, ajaxOptions, thrownError) {
-                        alert(thrownError + "\r\n" + xhr.statusText + "\r\n" + xhr.responseText);
-                    }
-                });
+                        },
+                        error: function(xhr, ajaxOptions, thrownError) {
+                            alert(thrownError + "\r\n" + xhr.statusText + "\r\n" + xhr.responseText);
+                        }
+                    });
+		});
+                {% endif %}
             }
         },
         error: function(xhr, ajaxOptions, thrownError) {

--- a/upload/catalog/view/theme/default/template/checkout/checkout.twig
+++ b/upload/catalog/view/theme/default/template/checkout/checkout.twig
@@ -254,7 +254,23 @@ $(document).delegate('#button-register', 'click', function() {
                                 success: function(html) {
                                     $('#collapse-shipping-address .panel-body').html(html);
 
-									$('#collapse-shipping-address').parent().find('.panel-heading .panel-title').html('<a href="#collapse-shipping-address" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle">{{ text_checkout_shipping_address }} <i class="fa fa-caret-down"></i></a>');
+                                    $('#collapse-shipping-address').parent().find('.panel-heading .panel-title').html('<a href="#collapse-shipping-address" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle">{{ text_checkout_shipping_address }} <i class="fa fa-caret-down"></i></a>');
+									
+                                    $.ajax({
+                                        url: 'index.php?route=checkout/payment_address',
+                                        dataType: 'html',
+                                        complete: function() {
+                                            $('#button-register').button('reset');
+                                        },
+                                        success: function(html) {
+                                            $('#collapse-payment-address .panel-body').html(html);
+
+                                            $('#collapse-payment-address').parent().find('.panel-heading .panel-title').html('<a href="#collapse-payment-address" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle">{{ text_checkout_payment_address }} <i class="fa fa-caret-down"></i></a>');
+                                        },
+                                        error: function(xhr, ajaxOptions, thrownError) {
+                                            alert(thrownError + "\r\n" + xhr.statusText + "\r\n" + xhr.responseText);
+                                        }
+                                    });
                                 },
                                 error: function(xhr, ajaxOptions, thrownError) {
                                     alert(thrownError + "\r\n" + xhr.statusText + "\r\n" + xhr.responseText);
@@ -293,6 +309,22 @@ $(document).delegate('#button-register', 'click', function() {
                         error: function(xhr, ajaxOptions, thrownError) {
                             alert(thrownError + "\r\n" + xhr.statusText + "\r\n" + xhr.responseText);
                         }
+                    }).done(function() {
+                        $.ajax({
+                            url: 'index.php?route=checkout/payment_address',
+                            dataType: 'html',
+                            complete: function() {
+                                $('#button-register').button('reset');
+                            },
+                            success: function(html) {
+                                $('#collapse-payment-address .panel-body').html(html);
+
+                                $('#collapse-payment-address').parent().find('.panel-heading .panel-title').html('<a href="#collapse-payment-address" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle">{{ text_checkout_payment_address }} <i class="fa fa-caret-down"></i></a>');
+                            },
+                            error: function(xhr, ajaxOptions, thrownError) {
+                                alert(thrownError + "\r\n" + xhr.statusText + "\r\n" + xhr.responseText);
+                            }
+                        });
                     });
                 }
                 {% else %}


### PR DESCRIPTION
…he checkout

There is a race condition where the payment_address call fires at the same time as the payment_method, or shipping_method calls. If the payment_address call completes after the other call, the session is wiped, preventing customers from proceeding past the shipping method step of the checkout.