### PR TITLE
Update smtp.php - invalid mailbox

### DIFF
--- a/upload/system/library/mail/smtp.php
+++ b/upload/system/library/mail/smtp.php
@@ -222,7 +222,7 @@ class Smtp {
 
 			fputs($handle, '.' . "\r\n");
 
-			$this->handleReply($handle, 250, 'Error: DATA not accepted from server!');
+			//$this->handleReply($handle, 250, 'Error: DATA not accepted from server!');
 
 			fputs($handle, 'QUIT' . "\r\n");
 


### PR DESCRIPTION
If the user does not specify the mail correctly, this error causes fake problems.
SMTP replies: 550 Message was not accepted -- invalid mailbox.
But why does the store stop all the work of the site, it is not a critical error. For example, it is not possible to change the order status of a product. All these errors should just write errors into the log, not stop the store in any way.