### PR TITLE
OC4 return created module_id

### DIFF
--- a/upload/admin/model/setting/module.php
+++ b/upload/admin/model/setting/module.php
@@ -3,8 +3,12 @@ namespace Opencart\Admin\Model\Setting;
 use Aws\signer\signerClient;
 
 class Module extends \Opencart\System\Engine\Model {
-	public function addModule(string $code, array $data): void {
+	public function addModule(string $code, array $data): int {
 		$this->db->query("INSERT INTO `" . DB_PREFIX . "module` SET `name` = '" . $this->db->escape((string)$data['name']) . "', `code` = '" . $this->db->escape($code) . "', `setting` = '" . $this->db->escape(json_encode($data)) . "'");
+
+		$module_id = $this->db->getLastId();
+
+		return (int)$module_id;
 	}
 	
 	public function editModule(int $module_id, array $data): void {


### PR DESCRIPTION
IMHO every single model function, creating a row in DB, must return this row id after executed.

I can check `$module_id = $this->db->getLastId();` in my code on clean opencart installation.
But what if this model function calls any `after` events which also insert rows into DB?

This is not a developer friendly software architecture when you need to create hacks, hooks, workarounds and other voodoo magic to get a single value for page redirect.

BUG:
By the way, on creating, for example a banner module, on save you are not redirected to created module page. 
So every click on Save button just creates a duplicate of a module.