### PR TITLE
captcha check after form validation

### DIFF
--- a/upload/catalog/controller/account/register.php
+++ b/upload/catalog/controller/account/register.php
@@ -182,6 +182,17 @@ class Register extends \Opencart\System\Engine\Controller {
 				$json['error']['password'] = $this->language->get('error_password');
 			}
 
+			// Agree to terms
+			$this->load->model('catalog/information');
+
+			$information_info = $this->model_catalog_information->getInformation($this->config->get('config_account_id'));
+
+			if ($information_info && !$this->request->post['agree']) {
+				$json['error']['warning'] = sprintf($this->language->get('error_agree'), $information_info['title']);
+			}
+		}
+
+		if (!$json) {
 			// Captcha
 			$this->load->model('setting/extension');
 
@@ -193,15 +204,6 @@ class Register extends \Opencart\System\Engine\Controller {
 				if ($captcha) {
 					$json['error']['captcha'] = $captcha;
 				}
-			}
-
-			// Agree to terms
-			$this->load->model('catalog/information');
-
-			$information_info = $this->model_catalog_information->getInformation($this->config->get('config_account_id'));
-
-			if ($information_info && !$this->request->post['agree']) {
-				$json['error']['warning'] = sprintf($this->language->get('error_agree'), $information_info['title']);
 			}
 		}
 

--- a/upload/catalog/controller/account/returns.php
+++ b/upload/catalog/controller/account/returns.php
@@ -405,6 +405,18 @@ class Returns extends \Opencart\System\Engine\Controller {
 				$json['error']['reason'] = $this->language->get('error_reason');
 			}
 
+			if ($this->config->get('config_return_id')) {
+				$this->load->model('catalog/information');
+
+				$information_info = $this->model_catalog_information->getInformation($this->config->get('config_return_id'));
+
+				if ($information_info && !isset($this->request->post['agree'])) {
+					$json['error']['warning'] = sprintf($this->language->get('error_agree'), $information_info['title']);
+				}
+			}
+		}
+
+		if (!$json) {
 			// Captcha
 			$this->load->model('setting/extension');
 
@@ -415,16 +427,6 @@ class Returns extends \Opencart\System\Engine\Controller {
 
 				if ($captcha) {
 					$json['error']['captcha'] = $captcha;
-				}
-			}
-
-			if ($this->config->get('config_return_id')) {
-				$this->load->model('catalog/information');
-
-				$information_info = $this->model_catalog_information->getInformation($this->config->get('config_return_id'));
-
-				if ($information_info && !isset($this->request->post['agree'])) {
-					$json['error']['warning'] = sprintf($this->language->get('error_agree'), $information_info['title']);
 				}
 			}
 		}

--- a/upload/catalog/controller/checkout/register.php
+++ b/upload/catalog/controller/checkout/register.php
@@ -357,7 +357,7 @@ class Register extends \Opencart\System\Engine\Controller {
 			// Captcha
 			$this->load->model('setting/extension');
 
-			if (!$this->customer->isLogged()) {
+			if (!$json && !$this->customer->isLogged()) {
 				$extension_info = $this->model_setting_extension->getExtensionByCode('captcha', $this->config->get('config_captcha'));
 
 				if ($extension_info && $this->config->get('captcha_' . $this->config->get('config_captcha') . '_status') && in_array('register', (array)$this->config->get('config_captcha_page'))) {

--- a/upload/catalog/controller/information/contact.php
+++ b/upload/catalog/controller/information/contact.php
@@ -122,7 +122,7 @@ class Contact extends \Opencart\System\Engine\Controller {
 
 		$extension_info = $this->model_setting_extension->getExtensionByCode('captcha', $this->config->get('config_captcha'));
 
-		if ($extension_info && $this->config->get('captcha_' . $this->config->get('config_captcha') . '_status') && in_array('contact', (array)$this->config->get('config_captcha_page'))) {
+		if (!$json && $extension_info && $this->config->get('captcha_' . $this->config->get('config_captcha') . '_status') && in_array('contact', (array)$this->config->get('config_captcha_page'))) {
 			$captcha = $this->load->controller('extension/' . $extension_info['extension'] . '/captcha/' . $extension_info['code'] . '|validate');
 
 			if ($captcha) {

--- a/upload/catalog/controller/product/review.php
+++ b/upload/catalog/controller/product/review.php
@@ -62,7 +62,7 @@ class Review extends \Opencart\System\Engine\Controller {
 
 		$extension_info = $this->model_setting_extension->getExtensionByCode('captcha', $this->config->get('config_captcha'));
 
-		if ($extension_info && $this->config->get('captcha_' . $this->config->get('config_captcha') . '_status') && in_array('review', (array)$this->config->get('config_captcha_page'))) {
+		if (!$json && $extension_info && $this->config->get('captcha_' . $this->config->get('config_captcha') . '_status') && in_array('review', (array)$this->config->get('config_captcha_page'))) {
 			$captcha = $this->load->controller('extension/'  . $extension_info['extension'] . '/captcha/' . $extension_info['code'] . '|validate');
 
 			if ($captcha) {


### PR DESCRIPTION
checking captcha only after form passed validation -> more useful for end users because google recaptcha invalidates captcha every failed form request. !do not use this logic when checking login or any other security forms!