### PR TITLE
Fix mail for PHP 8

### DIFF
--- a/upload/system/library/mail/mail.php
+++ b/upload/system/library/mail/mail.php
@@ -26,45 +26,51 @@ class Mail {
 			$to = $this->to;
 		}
 
-		$boundary = '----=_NextPart_' . md5(time());
-
-		$header  = 'MIME-Version: 1.0' . PHP_EOL;
-		$header .= 'Date: ' . date('D, d M Y H:i:s O') . PHP_EOL;
-		$header .= 'From: =?UTF-8?B?' . base64_encode($this->sender) . '?= <' . $this->from . '>' . PHP_EOL;
-
-		if (!$this->reply_to) {
-			$header .= 'Reply-To: =?UTF-8?B?' . base64_encode($this->sender) . '?= <' . $this->from . '>' . PHP_EOL;
+		if (version_compare(phpversion(), '8.0', '>=') || substr(PHP_OS, 0, 3) == 'WIN') {
+			$eol = "\r\n";
 		} else {
-			$header .= 'Reply-To: =?UTF-8?B?' . base64_encode($this->reply_to) . '?= <' . $this->reply_to . '>' . PHP_EOL;
+			$eol = PHP_EOL;
 		}
 
-		$header .= 'Return-Path: ' . $this->from . PHP_EOL;
-		$header .= 'X-Mailer: PHP/' . phpversion() . PHP_EOL;
-		$header .= 'Content-Type: multipart/mixed; boundary="' . $boundary . '"' . PHP_EOL . PHP_EOL;
+		$boundary = '----=_NextPart_' . md5(time());
+
+		$header  = 'MIME-Version: 1.0' . $eol;
+		$header .= 'Date: ' . date('D, d M Y H:i:s O') . $eol;
+		$header .= 'From: =?UTF-8?B?' . base64_encode($this->sender) . '?= <' . $this->from . '>' . $eol;
+
+		if (!$this->reply_to) {
+			$header .= 'Reply-To: =?UTF-8?B?' . base64_encode($this->sender) . '?= <' . $this->from . '>' . $eol;
+		} else {
+			$header .= 'Reply-To: =?UTF-8?B?' . base64_encode($this->reply_to) . '?= <' . $this->reply_to . '>' . $eol;
+		}
+
+		$header .= 'Return-Path: ' . $this->from . $eol;
+		$header .= 'X-Mailer: PHP/' . phpversion() . $eol;
+		$header .= 'Content-Type: multipart/mixed; boundary="' . $boundary . '"' . $eol . $eol;
 
 		if (!$this->html) {
-			$message  = '--' . $boundary . PHP_EOL;
-			$message .= 'Content-Type: text/plain; charset="utf-8"' . PHP_EOL;
-			$message .= 'Content-Transfer-Encoding: base64' . PHP_EOL . PHP_EOL;
-			$message .= base64_encode($this->text) . PHP_EOL;
+			$message  = '--' . $boundary . $eol;
+			$message .= 'Content-Type: text/plain; charset="utf-8"' . $eol;
+			$message .= 'Content-Transfer-Encoding: base64' . $eol . $eol;
+			$message .= chunk_split(base64_encode($this->text)) . $eol;
 		} else {
-			$message  = '--' . $boundary . PHP_EOL;
-			$message .= 'Content-Type: multipart/alternative; boundary="' . $boundary . '_alt"' . PHP_EOL . PHP_EOL;
-			$message .= '--' . $boundary . '_alt' . PHP_EOL;
-			$message .= 'Content-Type: text/plain; charset="utf-8"' . PHP_EOL;
-			$message .= 'Content-Transfer-Encoding: base64' . PHP_EOL . PHP_EOL;
+			$message  = '--' . $boundary . $eol;
+			$message .= 'Content-Type: multipart/alternative; boundary="' . $boundary . '_alt"' . $eol . $eol;
+			$message .= '--' . $boundary . '_alt' . $eol;
+			$message .= 'Content-Type: text/plain; charset="utf-8"' . $eol;
+			$message .= 'Content-Transfer-Encoding: base64' . $eol . $eol;
 
 			if ($this->text) {
-				$message .= base64_encode($this->text) . PHP_EOL;
+				$message .= chunk_split(base64_encode($this->text)) . $eol;
 			} else {
-				$message .= base64_encode('This is a HTML email and your email client software does not support HTML email!') . PHP_EOL;
+				$message .= chunk_split(base64_encode('This is a HTML email and your email client software does not support HTML email!')) . $eol;
 			}
 
-			$message .= '--' . $boundary . '_alt' . PHP_EOL;
-			$message .= 'Content-Type: text/html; charset="utf-8"' . PHP_EOL;
-			$message .= 'Content-Transfer-Encoding: base64' . PHP_EOL . PHP_EOL;
-			$message .= base64_encode($this->html) . PHP_EOL;
-			$message .= '--' . $boundary . '_alt--' . PHP_EOL;
+			$message .= '--' . $boundary . '_alt' . $eol;
+			$message .= 'Content-Type: text/html; charset="utf-8"' . $eol;
+			$message .= 'Content-Transfer-Encoding: base64' . $eol . $eol;
+			$message .= chunk_split(base64_encode($this->html)) . $eol;
+			$message .= '--' . $boundary . '_alt--' . $eol;
 		}
 
 		foreach ($this->attachments as $attachment) {
@@ -75,17 +81,17 @@ class Mail {
 
 				fclose($handle);
 
-				$message .= '--' . $boundary . PHP_EOL;
-				$message .= 'Content-Type: application/octet-stream; name="' . basename($attachment) . '"' . PHP_EOL;
-				$message .= 'Content-Transfer-Encoding: base64' . PHP_EOL;
-				$message .= 'Content-Disposition: attachment; filename="' . basename($attachment) . '"' . PHP_EOL;
-				$message .= 'Content-ID: <' . urlencode(basename($attachment)) . '>' . PHP_EOL;
-				$message .= 'X-Attachment-Id: ' . urlencode(basename($attachment)) . PHP_EOL . PHP_EOL;
+				$message .= '--' . $boundary . $eol;
+				$message .= 'Content-Type: application/octet-stream; name="' . basename($attachment) . '"' . $eol;
+				$message .= 'Content-Transfer-Encoding: base64' . $eol;
+				$message .= 'Content-Disposition: attachment; filename="' . basename($attachment) . '"' . $eol;
+				$message .= 'Content-ID: <' . urlencode(basename($attachment)) . '>' . $eol;
+				$message .= 'X-Attachment-Id: ' . urlencode(basename($attachment)) . $eol . $eol;
 				$message .= chunk_split(base64_encode($content));
 			}
 		}
 
-		$message .= '--' . $boundary . '--' . PHP_EOL;
+		$message .= '--' . $boundary . '--' . $eol;
 
 		ini_set('sendmail_from', $this->from);
 


### PR DESCRIPTION
PHP 8 mail() requires all headers to end CRLF.
Split base64 encoded lines.