### PR TITLE
Fix null credentials in marketplace for PHP 8

### DIFF
--- a/upload/admin/controller/marketplace/marketplace.php
+++ b/upload/admin/controller/marketplace/marketplace.php
@@ -108,9 +108,9 @@ class ControllerMarketplaceMarketplace extends Controller {
 		$string .= VERSION . "\n";
 		$string .= $time . "\n";
 
-		$signature = base64_encode(hash_hmac('sha1', $string, $this->config->get('opencart_secret'), 1));
+		$signature = base64_encode(hash_hmac('sha1', $string, (string)$this->config->get('opencart_secret'), 1));
 
-		$url  = '&username=' . urlencode($this->config->get('opencart_username'));
+		$url  = '&username=' . urlencode((string)$this->config->get('opencart_username'));
 		$url .= '&domain=' . $this->request->server['HTTP_HOST'];
 		$url .= '&version=' . urlencode(VERSION);
 		$url .= '&time=' . $time;


### PR DESCRIPTION
Fixes hash_hmac(): Passing null to parameter 3 ($key) of type string is
deprecated and urlencode(): Passing null to parameter 1 ($string) of
type string is deprecated.