### PR TITLE
Disable unnecessary controller output

### DIFF
--- a/upload/admin/controller/user/user_permission.php
+++ b/upload/admin/controller/user/user_permission.php
@@ -215,7 +215,23 @@ class UserPermission extends \Opencart\System\Engine\Controller {
 			'common/footer',
 			'common/header',
 			'error/not_found',
-			'error/permission'
+			'error/permission',
+			'event/currency',
+			'event/debug',
+			'event/language',
+			'event/statistics',
+			'startup/application',
+			'startup/error',
+			'startup/event',
+			'startup/extension',
+			'startup/language',
+			'startup/login',
+			'startup/notification',
+			'startup/permission',
+			'startup/sass',
+			'startup/session',
+			'startup/setting',
+			'startup/startup'
 		];
 
 		$files = [];


### PR DESCRIPTION
			'event/currency',
			'event/debug',
			'event/language',
			'event/statistics',
			'startup/application',
			'startup/error',
			'startup/event',
			'startup/extension',
			'startup/language',
			'startup/login',
			'startup/notification',
			'startup/permission',
			'startup/sass',
			'startup/session',
			'startup/setting',
			'startup/startup'