### PR TITLE
Update order.php for vivification error in PHP 8.1

### DIFF
--- a/upload/admin/controller/extension/dashboard/sale.php
+++ b/upload/admin/controller/extension/dashboard/sale.php
@@ -104,6 +104,8 @@ class ControllerExtensionDashboardSale extends Controller {
 
 		$sale_total = $this->model_extension_dashboard_sale->getTotalSales();
 
+		if (!isset($sale_total))  $sale_total = 0;
+		
 		if ($sale_total > 1000000000000) {
 			$data['total'] = round($sale_total / 1000000000000, 1) . 'T';
 		} elseif ($sale_total > 1000000000) {

--- a/upload/admin/controller/sale/order.php
+++ b/upload/admin/controller/sale/order.php
@@ -387,6 +387,7 @@ class ControllerSaleOrder extends Controller {
 			
 			$this->model_user_api->addApiSession($api_info['api_id'], $session->getId(), $this->request->server['REMOTE_ADDR']);
 			
+			if (!is_array($session->data))  $session->data = [];
 			$session->data['api_id'] = $api_info['api_id'];
 
 			$data['api_token'] = $session->getId();


### PR DESCRIPTION
$session->data is not yet an array at line 391.  So PHP 8.1 warns that auto vivification is deprecated.
Check for the condition, and ensure that it is an array.