### PR TITLE
error else not string

### DIFF
--- a/upload/system/helper/utf8.php
+++ b/upload/system/helper/utf8.php
@@ -4,7 +4,11 @@ if (extension_loaded('mbstring')) {
 	mb_internal_encoding('UTF-8');
 
 	function utf8_strlen($string) {
-		return mb_strlen($string);
+		if (is_string($string)) {
+			return mb_strlen($string);
+		} else {
+			return 0;
+		}
 	}
 
 	function utf8_strpos($string, $needle, $offset = 0) {
@@ -33,7 +37,11 @@ if (extension_loaded('mbstring')) {
 
 } elseif (function_exists('iconv')) {
 	function utf8_strlen($string) {
-		return iconv_strlen($string, 'UTF-8');
+		if (is_string($string)) {
+			return iconv_strlen($string, 'UTF-8');
+		} else {
+			return 0;
+		}
 	}
 
 	function utf8_strpos($string, $needle, $offset = 0) {


### PR DESCRIPTION
If, when submitting a form, for example, a message on the contact page, change the enquiry variable to enquiry[], then we get an error that the field must be a string.
Therefore, if the function requires a string, then other data types are set to zero.