### PR TITLE
OC4: Fix Ukrainian Crimea and Sevastopol

### DIFF
--- a/upload/install/opencart.sql
+++ b/upload/install/opencart.sql
@@ -6395,12 +6395,10 @@ INSERT INTO `oc_zone` (`zone_id`, `country_id`, `name`, `code`, `status`) VALUES
 (4332, 176, 'Khanty–Mansi Autonomous Okrug – Yugra', 'RU-KHM', 1),
 (4333, 176, 'Chukotka Autonomous Okrug', 'RU-CHU', 1),
 (4334, 176, 'Yamalo-Nenets Autonomous Okrug', 'RU-YAN', 1),
-(4335, 176, 'Republic of Crimea', 'UA-43', 1),
-(4336, 176, 'Sevastopol', 'UA-40', 1),
-(4337, 117, 'Aglonas novads', '001', 1),
-(4338, 99, 'Chhattisgarh', 'CT', 1),
-(4339, 99, 'Ladakh', 'LA', 1),
-(4340, 99, 'Uttarakhand', 'UT', 1);
+(4335, 117, 'Aglonas novads', '001', 1),
+(4336, 99, 'Chhattisgarh', 'CT', 1),
+(4337, 99, 'Ladakh', 'LA', 1),
+(4338, 99, 'Uttarakhand', 'UT', 1);
 
 -----------------------------------------------------------
 


### PR DESCRIPTION
Crimea and Sevastopol already exist in DB and these are Ukrainian regions.
https://github.com/opencart/opencart/blob/1fcadadbe2506fb81b4600147518bec6d3255d6f/upload/install/opencart.sql#L5641
https://github.com/opencart/opencart/blob/1fcadadbe2506fb81b4600147518bec6d3255d6f/upload/install/opencart.sql#L5656

@danielkerr Please fix this.

I don't think it is a good idea to commit these regions as russian now.

This is an insult for the whole Ukrainian nation.
https://github.com/opencart/opencart/pull/8802