### PR TITLE
OC4: utf8mb4 in mysqli.php

### DIFF
--- a/upload/system/library/db/mysqli.php
+++ b/upload/system/library/db/mysqli.php
@@ -13,7 +13,7 @@ class MySQLi {
 
 			$this->connection = $mysqli;
 			$this->connection->report_mode = MYSQLI_REPORT_ERROR;
-			$this->connection->set_charset('utf8');
+			$this->connection->set_charset('utf8mb4');
 			$this->connection->query("SET SESSION sql_mode = 'NO_ZERO_IN_DATE,NO_ENGINE_SUBSTITUTION'");
 		} catch (\mysqli_sql_exception $e) {
 			throw new \Exception('Error: Could not make a database link using ' . $username . '@' . $hostname . '!');


### PR DESCRIPTION
https://github.com/opencart/opencart/blob/8c5b3da32fc2be141283e5fcedbb04f96122a556/upload/system/helper/db_schema.php#L119

If OC4 is going to use `utf8mb4` charset and collation you need to set connection charset to `utf8mb4` too. Otherwise it has no sense.
Just try to store any emoji icon 🏘 in product name and you will see the difference. With connection charset `utf8` it will be converted and stored in DB as ???.

In my opinion it is time to move to advanced `utf8mb4` because it allows to store more data in different languages plus emoji.