### PR TITLE
OC4: utf8mb4 charset fix in db_schema

### DIFF
--- a/upload/system/helper/db_schema.php
+++ b/upload/system/helper/db_schema.php
@@ -87,7 +87,7 @@ function db_schema() {
 			]
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -115,7 +115,7 @@ function db_schema() {
 			'address_format_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -158,7 +158,7 @@ function db_schema() {
 			'api_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -186,7 +186,7 @@ function db_schema() {
 			'api_ip_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -229,7 +229,7 @@ function db_schema() {
 			'api_session_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -257,7 +257,7 @@ function db_schema() {
 			'attribute_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -285,7 +285,7 @@ function db_schema() {
 			'language_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -308,7 +308,7 @@ function db_schema() {
 			'attribute_group_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -336,7 +336,7 @@ function db_schema() {
 			'language_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -364,7 +364,7 @@ function db_schema() {
 			'banner_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -413,7 +413,7 @@ function db_schema() {
 			'banner_image_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -483,7 +483,7 @@ function db_schema() {
 			]
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -551,7 +551,7 @@ function db_schema() {
 			]
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -607,7 +607,7 @@ function db_schema() {
 			]
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -630,7 +630,7 @@ function db_schema() {
 			'filter_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -658,7 +658,7 @@ function db_schema() {
 			'path_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -686,7 +686,7 @@ function db_schema() {
 			'store_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -709,7 +709,7 @@ function db_schema() {
 			'store_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -758,7 +758,7 @@ function db_schema() {
 			'country_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -841,7 +841,7 @@ function db_schema() {
 			'coupon_id'
 		],
 		'engine'  => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -864,7 +864,7 @@ function db_schema() {
 			'category_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -907,7 +907,7 @@ function db_schema() {
 			'coupon_history_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -935,7 +935,7 @@ function db_schema() {
 			'coupon_product_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -988,7 +988,7 @@ function db_schema() {
 			'cron_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -1046,7 +1046,7 @@ function db_schema() {
 			'currency_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -1151,7 +1151,7 @@ function db_schema() {
 			'customer_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -1194,7 +1194,7 @@ function db_schema() {
 			'customer_activity_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -1292,7 +1292,7 @@ function db_schema() {
 			'customer_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -1335,7 +1335,7 @@ function db_schema() {
 			'customer_affiliate_report_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -1368,7 +1368,7 @@ function db_schema() {
 			'customer_approval_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -1396,7 +1396,7 @@ function db_schema() {
 			'customer_group_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -1429,7 +1429,7 @@ function db_schema() {
 			'language_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -1462,7 +1462,7 @@ function db_schema() {
 			'customer_history_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -1519,7 +1519,7 @@ function db_schema() {
 			]
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -1570,7 +1570,7 @@ function db_schema() {
 			]
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -1607,7 +1607,7 @@ function db_schema() {
 			'ip'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -1653,7 +1653,7 @@ function db_schema() {
 			'customer_reward_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -1696,7 +1696,7 @@ function db_schema() {
 			'customer_transaction_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -1764,7 +1764,7 @@ function db_schema() {
 			'customer_search_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -1792,7 +1792,7 @@ function db_schema() {
 			'product_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -1840,7 +1840,7 @@ function db_schema() {
 			'custom_field_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -1868,7 +1868,7 @@ function db_schema() {
 			'customer_group_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -1896,7 +1896,7 @@ function db_schema() {
 			'language_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -1924,7 +1924,7 @@ function db_schema() {
 			'custom_field_value_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -1957,7 +1957,7 @@ function db_schema() {
 			'language_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -1990,7 +1990,7 @@ function db_schema() {
 			'download_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -2018,7 +2018,7 @@ function db_schema() {
 			'language_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -2061,7 +2061,7 @@ function db_schema() {
 			'download_report_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -2111,7 +2111,7 @@ function db_schema() {
 			'event_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -2144,7 +2144,7 @@ function db_schema() {
 			'extension_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -2207,7 +2207,7 @@ function db_schema() {
 			'extension_install_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -2243,7 +2243,7 @@ function db_schema() {
 			]
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -2271,7 +2271,7 @@ function db_schema() {
 			'filter_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -2304,7 +2304,7 @@ function db_schema() {
 			'language_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -2327,7 +2327,7 @@ function db_schema() {
 			'filter_group_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -2355,7 +2355,7 @@ function db_schema() {
 			'language_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -2408,7 +2408,7 @@ function db_schema() {
 			'gdpr_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -2446,7 +2446,7 @@ function db_schema() {
 			'geo_zone_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -2482,7 +2482,7 @@ function db_schema() {
 			'information_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -2530,7 +2530,7 @@ function db_schema() {
 			'language_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -2558,7 +2558,7 @@ function db_schema() {
 			'store_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -2581,7 +2581,7 @@ function db_schema() {
 			'store_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -2638,7 +2638,7 @@ function db_schema() {
 			]
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -2661,7 +2661,7 @@ function db_schema() {
 			'layout_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -2699,7 +2699,7 @@ function db_schema() {
 			'layout_module_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -2732,7 +2732,7 @@ function db_schema() {
 			'layout_route_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -2755,7 +2755,7 @@ function db_schema() {
 			'length_class_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -2788,7 +2788,7 @@ function db_schema() {
 			'language_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -2849,7 +2849,7 @@ function db_schema() {
 			]
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -2882,7 +2882,7 @@ function db_schema() {
 			'manufacturer_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -2910,7 +2910,7 @@ function db_schema() {
 			'store_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -2933,7 +2933,7 @@ function db_schema() {
 			'store_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -2977,7 +2977,7 @@ function db_schema() {
 			'marketing_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -3020,7 +3020,7 @@ function db_schema() {
 			'marketing_report_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -3053,7 +3053,7 @@ function db_schema() {
 			'module_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -3091,7 +3091,7 @@ function db_schema() {
 			'notification_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -3119,7 +3119,7 @@ function db_schema() {
 			'option_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -3147,7 +3147,7 @@ function db_schema() {
 			'language_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -3180,7 +3180,7 @@ function db_schema() {
 			'option_value_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -3213,7 +3213,7 @@ function db_schema() {
 			'language_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -3543,7 +3543,7 @@ function db_schema() {
 			'order_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -3587,7 +3587,7 @@ function db_schema() {
 			'order_history_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -3641,7 +3641,7 @@ function db_schema() {
 			'order_option_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -3720,7 +3720,7 @@ function db_schema() {
 			]
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -3749,7 +3749,7 @@ function db_schema() {
 			'language_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -3806,7 +3806,7 @@ function db_schema() {
 			]
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -3879,7 +3879,7 @@ function db_schema() {
 			'order_voucher_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -3960,7 +3960,7 @@ function db_schema() {
 			]
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -4161,7 +4161,7 @@ function db_schema() {
 			'product_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -4195,7 +4195,7 @@ function db_schema() {
 			'language_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -4256,7 +4256,7 @@ function db_schema() {
 			]
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -4320,7 +4320,7 @@ function db_schema() {
 			]
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -4343,7 +4343,7 @@ function db_schema() {
 			'filter_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -4385,7 +4385,7 @@ function db_schema() {
 			]
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -4423,7 +4423,7 @@ function db_schema() {
 			'product_option_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -4501,7 +4501,7 @@ function db_schema() {
 			'product_option_value_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -4530,7 +4530,7 @@ function db_schema() {
 			'customer_group_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -4553,7 +4553,7 @@ function db_schema() {
 			'related_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -4598,7 +4598,7 @@ function db_schema() {
 			'product_report_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -4634,7 +4634,7 @@ function db_schema() {
 			'product_reward_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -4692,7 +4692,7 @@ function db_schema() {
 			]
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -4723,7 +4723,7 @@ function db_schema() {
 			]
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -4746,7 +4746,7 @@ function db_schema() {
 			'download_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -4774,7 +4774,7 @@ function db_schema() {
 			'store_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -4798,7 +4798,7 @@ function db_schema() {
 			'store_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -4906,7 +4906,7 @@ function db_schema() {
 			'return_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -4936,7 +4936,7 @@ function db_schema() {
 			'language_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -4979,7 +4979,7 @@ function db_schema() {
 			'return_history_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -5009,7 +5009,7 @@ function db_schema() {
 			'language_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -5039,7 +5039,7 @@ function db_schema() {
 			'language_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -5106,7 +5106,7 @@ function db_schema() {
 			]
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -5144,7 +5144,7 @@ function db_schema() {
 			'startup_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -5172,7 +5172,7 @@ function db_schema() {
 			'statistics_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -5207,7 +5207,7 @@ function db_schema() {
 			]
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -5252,7 +5252,7 @@ function db_schema() {
 			'setting_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -5281,7 +5281,7 @@ function db_schema() {
 			'language_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -5309,7 +5309,7 @@ function db_schema() {
 			'store_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -5445,7 +5445,7 @@ function db_schema() {
 			]
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -5489,7 +5489,7 @@ function db_schema() {
 			'subscription_history_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -5563,7 +5563,7 @@ function db_schema() {
 			'subscription_plan_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -5596,7 +5596,7 @@ function db_schema() {
 			'language_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -5625,7 +5625,7 @@ function db_schema() {
 			'language_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -5697,7 +5697,7 @@ function db_schema() {
 			]
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -5735,7 +5735,7 @@ function db_schema() {
 			'tax_class_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -5785,7 +5785,7 @@ function db_schema() {
 			'tax_rate_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -5808,7 +5808,7 @@ function db_schema() {
 			'customer_group_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -5847,7 +5847,7 @@ function db_schema() {
 			'tax_rule_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -5885,7 +5885,7 @@ function db_schema() {
 			'theme_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -5933,7 +5933,7 @@ function db_schema() {
 			'translation_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -5971,7 +5971,7 @@ function db_schema() {
 			'upload_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -6034,7 +6034,7 @@ function db_schema() {
 			]
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -6110,7 +6110,7 @@ function db_schema() {
 			'user_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -6138,7 +6138,7 @@ function db_schema() {
 			'user_group_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -6176,7 +6176,7 @@ function db_schema() {
 			'vendor_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -6249,7 +6249,7 @@ function db_schema() {
 			'voucher_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -6287,7 +6287,7 @@ function db_schema() {
 			'voucher_history_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -6310,7 +6310,7 @@ function db_schema() {
 			'voucher_theme_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -6338,7 +6338,7 @@ function db_schema() {
 			'language_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -6362,7 +6362,7 @@ function db_schema() {
 			'weight_class_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -6395,7 +6395,7 @@ function db_schema() {
 			'language_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -6434,7 +6434,7 @@ function db_schema() {
 			'zone_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 
@@ -6478,7 +6478,7 @@ function db_schema() {
 			'zone_to_geo_zone_id'
 		],
 		'engine' => 'InnoDB',
-		'charset' => 'utf8',
+		'charset' => 'utf8mb4',
 		'collate' => 'utf8mb4_general_ci'
 	];
 


### PR DESCRIPTION
`utf8mb4_general_ci` cannot be used with charset `utf8`. Installation fails with SQL error.

Perhaps this is a last change needed for moving OC4 to `utf8mb4` charset.