### PR TITLE
Cache Problem : here I recommond these lines to solve cache problem i…

### DIFF
--- a/upload/system/framework.php
+++ b/upload/system/framework.php
@@ -116,6 +116,8 @@ $response->addHeader('Access-Control-Allow-Credentials: true');
 $response->addHeader('Access-Control-Max-Age: 1000');
 $response->addHeader('Access-Control-Allow-Headers: X-Requested-With, Content-Type, Origin, Cache-Control, Pragma, Authorization, Accept, Accept-Encoding');
 $response->addHeader('Access-Control-Allow-Methods: PUT, POST, GET, OPTIONS, DELETE');
+$response->addHeader('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0');
+$response->addHeader('Pragma: no-cache');
 $response->setCompression($config->get('response_compression'));
 $registry->set('response', $response);
 


### PR DESCRIPTION
…n opencart pages. the main problem is whole page will be cached and cause bad ux but I figure out these two lines help to disable caching for entire page, the problem is observed even in product, catalog , .. forms when all javascript actions will not work properly on submiting or reloading the page.

```
$response->addHeader('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0');
$response->addHeader('Pragma: no-cache');
```