### PR TITLE
Add language parameter where missing in catalog side

### DIFF
--- a/upload/catalog/controller/account/address.php
+++ b/upload/catalog/controller/account/address.php
@@ -84,6 +84,8 @@ class Address extends \Opencart\System\Engine\Controller {
 	public function form(): void {
 		$this->load->language('account/address');
 
+		$data['language'] = $this->config->get('config_language');
+
 		if (!$this->customer->isLogged() || (!isset($this->request->get['customer_token']) || !isset($this->session->data['customer_token']) || ($this->request->get['customer_token'] != $this->session->data['customer_token']))) {
 			$this->session->data['redirect'] = $this->url->link('account/address', 'language=' . $this->config->get('config_language'));
 

--- a/upload/catalog/controller/account/register.php
+++ b/upload/catalog/controller/account/register.php
@@ -8,6 +8,8 @@ class Register extends \Opencart\System\Engine\Controller {
 
 		$this->load->language('account/register');
 
+		$data['language'] = $this->config->get('config_language');
+
 		$this->document->setTitle($this->language->get('heading_title'));
 
 		$this->document->addScript('catalog/view/javascript/jquery/datetimepicker/moment.min.js');

--- a/upload/catalog/controller/account/tracking.php
+++ b/upload/catalog/controller/account/tracking.php
@@ -22,6 +22,8 @@ class Tracking extends \Opencart\System\Engine\Controller {
 
 		$this->load->language('account/tracking');
 
+		$data['language'] = $this->config->get('config_language');
+
 		$this->document->setTitle($this->language->get('heading_title'));
 
 		$data['breadcrumbs'] = [];

--- a/upload/catalog/view/template/account/address_form.twig
+++ b/upload/catalog/view/template/account/address_form.twig
@@ -238,7 +238,7 @@ $('#input-country').on('change', function () {
     var element = this;
 
     $.ajax({
-        url: 'index.php?route=localisation/country&country_id=' + this.value,
+        url: 'index.php?route=localisation/country&country_id=' + this.value + '&language={{ language }}',
         dataType: 'json',
         beforeSend: function () {
             $(element).prop('disabled', true);

--- a/upload/catalog/view/template/account/register.twig
+++ b/upload/catalog/view/template/account/register.twig
@@ -223,7 +223,7 @@
 <script type="text/javascript"><!--
 $('#input-customer-group').on('change', function () {
     $.ajax({
-        URL: 'INDEX.php?route=account/custom_field&customer_group_id=' + this.value + '&language={{ language }}',
+        url: 'index.php?route=account/custom_field&customer_group_id=' + this.value + '&language={{ language }}',
         dataType: 'json',
         success: function (json) {
             $('.custom-field').hide();

--- a/upload/catalog/view/template/account/register.twig
+++ b/upload/catalog/view/template/account/register.twig
@@ -223,7 +223,7 @@
 <script type="text/javascript"><!--
 $('#input-customer-group').on('change', function () {
     $.ajax({
-        url: 'index.php?route=account/custom_field&customer_group_id=' + this.value,
+        URL: 'INDEX.php?route=account/custom_field&customer_group_id=' + this.value + '&language={{ language }}',
         dataType: 'json',
         success: function (json) {
             $('.custom-field').hide();

--- a/upload/catalog/view/template/account/tracking.twig
+++ b/upload/catalog/view/template/account/tracking.twig
@@ -41,7 +41,7 @@
 $('#input-generator').autocomplete({
     'source': function (request, response) {
         $.ajax({
-            url: 'index.php?route=account/tracking|autocomplete&customer_token={{ customer_token }}&filter_name=' + encodeURIComponent(request) + '&tracking=' + encodeURIComponent($('#input-code').val()),
+            url: 'index.php?route=account/tracking|autocomplete&customer_token={{ customer_token }}&filter_name=' + encodeURIComponent(request) + '&tracking=' + encodeURIComponent($('#input-code').val()) + '&language={{ language }}',
             dataType: 'json',
             success: function (json) {
                 response($.map(json, function (item) {

--- a/upload/catalog/view/template/product/product.twig
+++ b/upload/catalog/view/template/product/product.twig
@@ -383,7 +383,7 @@ $('#review').load('index.php?route=product/review|review&product_id={{ product_i
 
 $('#button-review').on('click', function () {
     $.ajax({
-        url: 'index.php?route=product/review|write&product_id={{ product_id }}',
+        url: 'index.php?route=product/review|write&product_id={{ product_id }}&language={{ language }}',
         type: 'post',
         dataType: 'json',
         data: $('#form-review').serialize(),

--- a/upload/extension/opencart/catalog/controller/total/shipping.php
+++ b/upload/extension/opencart/catalog/controller/total/shipping.php
@@ -5,6 +5,8 @@ class Shipping extends \Opencart\System\Engine\Controller {
 		if ($this->config->get('total_shipping_status') && $this->config->get('total_shipping_estimator') && $this->cart->hasShipping()) {
 			$this->load->language('extension/opencart/total/shipping');
 
+            $data['language'] = $this->config->get('config_language');
+
 			if (isset($this->session->data['shipping_address'])) {
 				$shipping_address = $this->session->data['shipping_address'];
 

--- a/upload/extension/opencart/catalog/view/template/payment/bank_transfer.twig
+++ b/upload/extension/opencart/catalog/view/template/payment/bank_transfer.twig
@@ -14,7 +14,7 @@ $('#button-confirm').on('click', function() {
     var element = this;
 
     $.ajax({
-        url: 'index.php?route=extension/opencart/payment/bank_transfer|confirm',
+        url: 'index.php?route=extension/opencart/payment/bank_transfer|confirm&language={{ language }}',
         dataType: 'json',
         beforeSend: function() {
             $(element).prop('disabled', true).addClass('loading');

--- a/upload/extension/opencart/catalog/view/template/payment/cheque.twig
+++ b/upload/extension/opencart/catalog/view/template/payment/cheque.twig
@@ -17,7 +17,7 @@ $('#button-confirm').on('click', function() {
     var element = this;
 
     $.ajax({
-        url: 'index.php?route=extension/opencart/payment/cheque|confirm',
+        url: 'index.php?route=extension/opencart/payment/cheque|confirm&language={{ language }}',
         dataType: 'json',
         beforeSend: function() {
             $(element).prop('disabled', true).addClass('loading');

--- a/upload/extension/opencart/catalog/view/template/payment/cod.twig
+++ b/upload/extension/opencart/catalog/view/template/payment/cod.twig
@@ -6,7 +6,7 @@ $('#button-confirm').on('click', function() {
     var element = this;
 
     $.ajax({
-        url: 'index.php?route=extension/opencart/payment/cod|confirm',
+        url: 'index.php?route=extension/opencart/payment/cod|confirm&language={{ language }}',
         dataType: 'json',
         beforeSend: function() {
             $(element).prop('disabled', true).addClass('loading');

--- a/upload/extension/opencart/catalog/view/template/payment/free_checkout.twig
+++ b/upload/extension/opencart/catalog/view/template/payment/free_checkout.twig
@@ -6,7 +6,7 @@ $('#button-confirm').on('click', function() {
     var element = this;
 
     $.ajax({
-        url: 'index.php?route=extension/opencart/payment/free_checkout|confirm',
+        url: 'index.php?route=extension/opencart/payment/free_checkout|confirm&language={{ language }}',
         dataType: 'json',
         beforeSend: function() {
             $(element).prop('disabled', true).addClass('loading');

--- a/upload/extension/opencart/catalog/view/template/total/shipping.twig
+++ b/upload/extension/opencart/catalog/view/template/total/shipping.twig
@@ -47,7 +47,7 @@
       e.preventDefault();
 
       $.ajax({
-          url: 'index.php?route=extension/opencart/total/shipping|quote',
+          url: 'index.php?route=extension/opencart/total/shipping|quote&language={{ language }}',
           type: 'post',
           data: $('#form-quote').serialize(),
           dataType: 'json',
@@ -132,7 +132,7 @@
       e.preventDefault();
 
       $.ajax({
-          url: 'index.php?route=extension/opencart/total/shipping|save',
+          url: 'index.php?route=extension/opencart/total/shipping|save&language={{ language }}',
           type: 'post',
           data: $('#form-shipping').serialize(),
           dataType: 'json',
@@ -170,7 +170,7 @@
       var element = this;
 
       $.ajax({
-          url: 'index.php?route=localisation/country&country_id=' + this.value,
+          url: 'index.php?route=localisation/country&country_id=' + this.value + '&language={{ language }}',
           dataType: 'json',
           beforeSend: function () {
               $(element).prop('disabled', true);


### PR DESCRIPTION
Thi resolves the issue #10887

Description: Since in Opencart 4 the selected language in the front part of the site is transmitted as a GET parameter, for all links and ajax calls that depend on the language, they must contain the selected language as a parameter. This is done in general, in this PR are added in places where it is missing and this leads to unexpected changes in the language for the user.