### PR TITLE
Fix "lines too long for transport" Mail() Error

### DIFF
--- a/upload/system/library/mail/mail.php
+++ b/upload/system/library/mail/mail.php
@@ -61,7 +61,7 @@ class Mail {
 			$message .= 'Content-Transfer-Encoding: base64' . $eol . $eol;
 
 			if ($this->text) {
-				$message .= base64_encode($this->text) . $eol;
+				$message .= chunk_split(base64_encode($this->text)) . $eol;
 			} else {
 				$message .= base64_encode('This is a HTML email and your email client software does not support HTML email!') . $eol;
 			}
@@ -69,7 +69,7 @@ class Mail {
 			$message .= '--' . $boundary . '_alt' . $eol;
 			$message .= 'Content-Type: text/html; charset="utf-8"' . $eol;
 			$message .= 'Content-Transfer-Encoding: base64' . $eol . $eol;
-			$message .= base64_encode($this->html) . $eol;
+			$message .= chunk_split(base64_encode($this->html)) . $eol;
 			$message .= '--' . $boundary . '_alt--' . $eol;
 		}
 

--- a/upload/system/library/mail/mail.php
+++ b/upload/system/library/mail/mail.php
@@ -36,12 +36,12 @@ class Mail {
 
 		$header  = 'MIME-Version: 1.0' . $eol;
 		$header .= 'Date: ' . date('D, d M Y H:i:s O') . $eol;
-		$header .= 'From: =?UTF-8?B?' . base64_encode($this->sender) . '?= <' . $this->from . '>' . $eol;
+		$header .= 'From: =?UTF-8?B?' . chunk_split(base64_encode($this->sender)) . '?= <' . $this->from . '>' . $eol;
 
 		if (!$this->reply_to) {
-			$header .= 'Reply-To: =?UTF-8?B?' . base64_encode($this->sender) . '?= <' . $this->from . '>' . $eol;
+			$header .= 'Reply-To: =?UTF-8?B?' . chunk_split(base64_encode($this->sender)) . '?= <' . $this->from . '>' . $eol;
 		} else {
-			$header .= 'Reply-To: =?UTF-8?B?' . base64_encode($this->reply_to) . '?= <' . $this->reply_to . '>' . $eol;
+			$header .= 'Reply-To: =?UTF-8?B?' . chunk_split(base64_encode($this->reply_to)) . '?= <' . $this->reply_to . '>' . $eol;
 		}
 
 		$header .= 'Return-Path: ' . $this->from . $eol;
@@ -52,7 +52,7 @@ class Mail {
 			$message  = '--' . $boundary . $eol;
 			$message .= 'Content-Type: text/plain; charset="utf-8"' . $eol;
 			$message .= 'Content-Transfer-Encoding: base64' . $eol . $eol;
-			$message .= base64_encode($this->text) . $eol;
+			$message .= chunk_split(base64_encode($this->text)) . $eol;
 		} else {
 			$message  = '--' . $boundary . $eol;
 			$message .= 'Content-Type: multipart/alternative; boundary="' . $boundary . '_alt"' . $eol . $eol;
@@ -63,7 +63,7 @@ class Mail {
 			if ($this->text) {
 				$message .= chunk_split(base64_encode($this->text)) . $eol;
 			} else {
-				$message .= base64_encode('This is a HTML email and your email client software does not support HTML email!') . $eol;
+				$message .= chunk_split(base64_encode('This is a HTML email and your email client software does not support HTML email!')) . $eol;
 			}
 
 			$message .= '--' . $boundary . '_alt' . $eol;
@@ -96,9 +96,9 @@ class Mail {
 		ini_set('sendmail_from', $this->from);
 
 		if ($this->parameter) {
-			return mail($to, '=?UTF-8?B?' . base64_encode($this->subject) . '?=', $message, $header, $this->parameter);
+			return mail($to, '=?UTF-8?B?' . chunk_split(base64_encode($this->subject)) . '?=', $message, $header, $this->parameter);
 		} else {
-			return mail($to, '=?UTF-8?B?' . base64_encode($this->subject) . '?=', $message, $header);
+			return mail($to, '=?UTF-8?B?' . chunk_split(base64_encode($this->subject)) . '?=', $message, $header);
 		}
 	}
 }


### PR DESCRIPTION
Fixes a pretty nasty "message has lines too long for transport" email error from the overwhelming majority of CPanel based hosts.
This error is especially prominent on the Gift Certificate OpenCart emails. I believe it's caused by the image within the html email?
Anyways this bugfix can be ported easily to OpenCart 3.0.3.8 too, which is what I've done to my personal host.

HTML Source before fix:
![fixbefore](https://user-images.githubusercontent.com/33023808/172339403-3d2c0d96-02c4-4d0a-87e4-a3b36f9e3e41.PNG)
HTML Source after fix:
![fixafter](https://user-images.githubusercontent.com/33023808/172339396-631f61ff-0f01-4cc3-a408-d03cdbc2ec00.PNG)