### PR TITLE
OC4: Improved admin getProducts function

### DIFF
--- a/upload/admin/controller/catalog/product.php
+++ b/upload/admin/controller/catalog/product.php
@@ -152,6 +152,7 @@ class Product extends \Opencart\System\Engine\Controller {
 
 		$data['products'] = [];
 
+        $product_total = 0;
 		$filter_data = [
 			'filter_name'     => $filter_name,
 			'filter_model'    => $filter_model,
@@ -161,14 +162,15 @@ class Product extends \Opencart\System\Engine\Controller {
 			'sort'            => $sort,
 			'order'           => $order,
 			'start'           => ($page - 1) * $this->config->get('config_pagination_admin'),
-			'limit'           => $this->config->get('config_pagination_admin')
+			'limit'           => $this->config->get('config_pagination_admin'),
+            'total'           => &$product_total
 		];
 
 		$this->load->model('catalog/product');
 
 		$this->load->model('tool/image');
 
-		$product_total = $this->model_catalog_product->getTotalProducts($filter_data);
+		//$product_total = $this->model_catalog_product->getTotalProducts($filter_data);
 
 		$results = $this->model_catalog_product->getProducts($filter_data);
 


### PR DESCRIPTION
Admin product model function getProducts is improved to be used from Opencart and module developers:
- fully backward compatible
- possibility to filter by all product table columns
- possibility to sort by all product table columns
- possibility to specify sql comparison operator
- build in count total (no need to use getTotalProducts)
- possibility to filter by category, manufacturer, store, SEO keyword

If this PR is accepted, I can make in similar way PRs for opders and customers.