### PR TITLE
OC4: Admin, Sale, Order, Filter: added date from/to possible

### DIFF
--- a/upload/admin/controller/sale/order.php
+++ b/upload/admin/controller/sale/order.php
@@ -40,8 +40,24 @@ class Order extends \Opencart\System\Engine\Controller {
 			$url .= '&filter_date_added=' . $this->request->get['filter_date_added'];
 		}
 
+		if (isset($this->request->get['filter_date_added_from'])) {
+			$url .= '&filter_date_added_from=' . $this->request->get['filter_date_added_from'];
+		}
+
+		if (isset($this->request->get['filter_date_added_to'])) {
+			$url .= '&filter_date_added_to=' . $this->request->get['filter_date_added_to'];
+		}
+
 		if (isset($this->request->get['filter_date_modified'])) {
 			$url .= '&filter_date_modified=' . $this->request->get['filter_date_modified'];
+		}
+
+		if (isset($this->request->get['filter_date_modified_from'])) {
+			$url .= '&filter_date_modified_from=' . $this->request->get['filter_date_modified_from'];
+		}
+
+		if (isset($this->request->get['filter_date_modified_to'])) {
+			$url .= '&filter_date_modified_to=' . $this->request->get['filter_date_modified_to'];
 		}
 
 		if (isset($this->request->get['sort'])) {
@@ -161,10 +177,34 @@ class Order extends \Opencart\System\Engine\Controller {
 			$filter_date_added = '';
 		}
 
+		if (isset($this->request->get['filter_date_added_from'])) {
+			$filter_date_added_from = $this->request->get['filter_date_added_from'];
+		} else {
+			$filter_date_added_from = '';
+		}
+
+		if (isset($this->request->get['filter_date_added_to'])) {
+			$filter_date_added_to = $this->request->get['filter_date_added_to'];
+		} else {
+			$filter_date_added_to = '';
+		}
+
 		if (isset($this->request->get['filter_date_modified'])) {
 			$filter_date_modified = $this->request->get['filter_date_modified'];
 		} else {
 			$filter_date_modified = '';
+		}
+
+		if (isset($this->request->get['filter_date_modified_from'])) {
+			$filter_date_modified_from = $this->request->get['filter_date_modified_from'];
+		} else {
+			$filter_date_modified_from = '';
+		}
+
+		if (isset($this->request->get['filter_date_modified_to'])) {
+			$filter_date_modified_to = $this->request->get['filter_date_modified_to'];
+		} else {
+			$filter_date_modified_to = '';
 		}
 
 		if (isset($this->request->get['sort'])) {
@@ -219,8 +259,24 @@ class Order extends \Opencart\System\Engine\Controller {
 			$url .= '&filter_date_added=' . $this->request->get['filter_date_added'];
 		}
 
+		if (isset($this->request->get['filter_date_added_from'])) {
+			$url .= '&filter_date_added_from=' . $this->request->get['filter_date_added_from'];
+		}
+
+		if (isset($this->request->get['filter_date_added_to'])) {
+			$url .= '&filter_date_added_to=' . $this->request->get['filter_date_added_to'];
+		}
+
 		if (isset($this->request->get['filter_date_modified'])) {
 			$url .= '&filter_date_modified=' . $this->request->get['filter_date_modified'];
+		}
+
+		if (isset($this->request->get['filter_date_modified_from'])) {
+			$url .= '&filter_date_modified_from=' . $this->request->get['filter_date_modified_from'];
+		}
+
+		if (isset($this->request->get['filter_date_modified_to'])) {
+			$url .= '&filter_date_modified_to=' . $this->request->get['filter_date_modified_to'];
 		}
 
 		if (isset($this->request->get['sort'])) {
@@ -248,7 +304,11 @@ class Order extends \Opencart\System\Engine\Controller {
 			'filter_order_status_id' => $filter_order_status_id,
 			'filter_total'           => $filter_total,
 			'filter_date_added'      => $filter_date_added,
+			'filter_date_added_from' => $filter_date_added_from,
+			'filter_date_added_to'   => $filter_date_added_to,
 			'filter_date_modified'   => $filter_date_modified,
+			'filter_date_modified_from' => $filter_date_modified_from,
+			'filter_date_modified_to' => $filter_date_modified_to,
 			'sort'                   => $sort,
 			'order'                  => $order,
 			'start'                  => ($page - 1) * (int)$this->config->get('config_pagination_admin'),
@@ -309,8 +369,24 @@ class Order extends \Opencart\System\Engine\Controller {
 			$url .= '&filter_date_added=' . $this->request->get['filter_date_added'];
 		}
 
+		if (isset($this->request->get['filter_date_added_from'])) {
+			$url .= '&filter_date_added_from=' . $this->request->get['filter_date_added_from'];
+		}
+
+		if (isset($this->request->get['filter_date_added_to'])) {
+			$url .= '&filter_date_added_to=' . $this->request->get['filter_date_added_to'];
+		}
+
 		if (isset($this->request->get['filter_date_modified'])) {
 			$url .= '&filter_date_modified=' . $this->request->get['filter_date_modified'];
+		}
+
+		if (isset($this->request->get['filter_date_modified_from'])) {
+			$url .= '&filter_date_modified_from=' . $this->request->get['filter_date_modified_from'];
+		}
+
+		if (isset($this->request->get['filter_date_modified_to'])) {
+			$url .= '&filter_date_modified_to=' . $this->request->get['filter_date_modified_to'];
 		}
 
 		if ($order == 'ASC') {
@@ -361,8 +437,24 @@ class Order extends \Opencart\System\Engine\Controller {
 			$url .= '&filter_date_added=' . $this->request->get['filter_date_added'];
 		}
 
+		if (isset($this->request->get['filter_date_added_from'])) {
+			$url .= '&filter_date_added_from=' . $this->request->get['filter_date_added_from'];
+		}
+
+		if (isset($this->request->get['filter_date_added_to'])) {
+			$url .= '&filter_date_added_to=' . $this->request->get['filter_date_added_to'];
+		}
+
 		if (isset($this->request->get['filter_date_modified'])) {
 			$url .= '&filter_date_modified=' . $this->request->get['filter_date_modified'];
+		}
+
+		if (isset($this->request->get['filter_date_modified_from'])) {
+			$url .= '&filter_date_modified_from=' . $this->request->get['filter_date_modified_from'];
+		}
+
+		if (isset($this->request->get['filter_date_modified_to'])) {
+			$url .= '&filter_date_modified_to=' . $this->request->get['filter_date_modified_to'];
 		}
 
 		if (isset($this->request->get['sort'])) {
@@ -390,7 +482,11 @@ class Order extends \Opencart\System\Engine\Controller {
 		$data['filter_order_status_id'] = $filter_order_status_id;
 		$data['filter_total'] = $filter_total;
 		$data['filter_date_added'] = $filter_date_added;
+		$data['filter_date_added_from'] = $filter_date_added_from;
+		$data['filter_date_added_to'] = $filter_date_added_to;
 		$data['filter_date_modified'] = $filter_date_modified;
+		$data['filter_date_modified_from'] = $filter_date_modified_from;
+		$data['filter_date_modified_to'] = $filter_date_modified_to;
 
 		$data['sort'] = $sort;
 		$data['order'] = $order;
@@ -450,8 +546,24 @@ class Order extends \Opencart\System\Engine\Controller {
 			$url .= '&filter_date_added=' . $this->request->get['filter_date_added'];
 		}
 
+		if (isset($this->request->get['filter_date_added_from'])) {
+			$url .= '&filter_date_added_from=' . $this->request->get['filter_date_added_from'];
+		}
+
+		if (isset($this->request->get['filter_date_added_to'])) {
+			$url .= '&filter_date_added_to=' . $this->request->get['filter_date_added_to'];
+		}
+
 		if (isset($this->request->get['filter_date_modified'])) {
 			$url .= '&filter_date_modified=' . $this->request->get['filter_date_modified'];
+		}
+
+		if (isset($this->request->get['filter_date_modified_from'])) {
+			$url .= '&filter_date_modified_from=' . $this->request->get['filter_date_modified_from'];
+		}
+
+		if (isset($this->request->get['filter_date_modified_to'])) {
+			$url .= '&filter_date_modified_to=' . $this->request->get['filter_date_modified_to'];
 		}
 
 		if (isset($this->request->get['sort'])) {

--- a/upload/admin/language/en-gb/sale/order.php
+++ b/upload/admin/language/en-gb/sale/order.php
@@ -112,7 +112,11 @@ $_['entry_payment_method']   = 'Payment Method';
 $_['entry_order_id']         = 'Order ID';
 $_['entry_total']            = 'Total';
 $_['entry_date_added']       = 'Date Added';
+$_['entry_date_added_from']  = 'Date Added From';
+$_['entry_date_added_to']    = 'Date Added To';
 $_['entry_date_modified']    = 'Date Modified';
+$_['entry_date_modified_from'] = 'Date Modified From';
+$_['entry_date_modified_to'] = 'Date Modified To';
 
 // Help
 $_['help_override']          = 'If the customers order is being blocked from changing the order status due to an anti-fraud extension enable override.';

--- a/upload/admin/model/sale/order.php
+++ b/upload/admin/model/sale/order.php
@@ -190,8 +190,24 @@ class Order extends \Opencart\System\Engine\Model {
 			$sql .= " AND DATE(o.`date_added`) = DATE('" . $this->db->escape((string)$data['filter_date_added']) . "')";
 		}
 
+		if (!empty($data['filter_date_added_from'])) {
+			$sql .= " AND DATE(o.`date_added`) >= DATE('" . $this->db->escape((string)$data['filter_date_added_from']) . "')";
+		}
+
+		if (!empty($data['filter_date_added_to'])) {
+			$sql .= " AND DATE(o.`date_added`) <= DATE('" . $this->db->escape((string)$data['filter_date_added_to']) . "')";
+		}
+
 		if (!empty($data['filter_date_modified'])) {
 			$sql .= " AND DATE(o.`date_modified`) = DATE('" . $this->db->escape((string)$data['filter_date_modified']) . "')";
+		}
+
+		if (!empty($data['filter_date_modified_from'])) {
+			$sql .= " AND DATE(o.`date_modified`) >= DATE('" . $this->db->escape((string)$data['filter_date_modified_from']) . "')";
+		}
+
+		if (!empty($data['filter_date_modified_to'])) {
+			$sql .= " AND DATE(o.`date_modified`) <= DATE('" . $this->db->escape((string)$data['filter_date_modified_to']) . "')";
 		}
 
 		if (!empty($data['filter_total'])) {
@@ -318,8 +334,24 @@ class Order extends \Opencart\System\Engine\Model {
 			$sql .= " AND DATE(`date_added`) = DATE('" . $this->db->escape((string)$data['filter_date_added']) . "')";
 		}
 
+		if (!empty($data['filter_date_added_from'])) {
+			$sql .= " AND DATE(`date_added`) >= DATE('" . $this->db->escape((string)$data['filter_date_added_from']) . "')";
+		}
+
+		if (!empty($data['filter_date_added_to'])) {
+			$sql .= " AND DATE(`date_added`) >= DATE('" . $this->db->escape((string)$data['filter_date_added_to']) . "')";
+		}
+
 		if (!empty($data['filter_date_modified'])) {
 			$sql .= " AND DATE(`date_modified`) = DATE('" . $this->db->escape((string)$data['filter_date_modified']) . "')";
+		}
+
+		if (!empty($data['filter_date_modified_from'])) {
+			$sql .= " AND DATE(`date_modified`) >= DATE('" . $this->db->escape((string)$data['filter_date_modified_from']) . "')";
+		}
+
+		if (!empty($data['filter_date_modified_to'])) {
+			$sql .= " AND DATE(`date_modified`) <= DATE('" . $this->db->escape((string)$data['filter_date_modified_to']) . "')";
 		}
 
 		if (!empty($data['filter_total'])) {
@@ -436,8 +468,24 @@ class Order extends \Opencart\System\Engine\Model {
 			$sql .= " AND DATE(`date_added`) = DATE('" . $this->db->escape((string)$data['filter_date_added']) . "')";
 		}
 
+		if (!empty($data['filter_date_added_from'])) {
+			$sql .= " AND DATE(`date_added`) >= DATE('" . $this->db->escape((string)$data['filter_date_added_from']) . "')";
+		}
+
+		if (!empty($data['filter_date_added_to'])) {
+			$sql .= " AND DATE(`date_added`) >= DATE('" . $this->db->escape((string)$data['filter_date_added_to']) . "')";
+		}
+
 		if (!empty($data['filter_date_modified'])) {
 			$sql .= " AND DATE(`date_modified`) = DATE('" . $this->db->escape((string)$data['filter_date_modified']) . "')";
+		}
+
+		if (!empty($data['filter_date_modified_from'])) {
+			$sql .= " AND DATE(`date_modified`) >= DATE('" . $this->db->escape((string)$data['filter_date_modified_from']) . "')";
+		}
+
+		if (!empty($data['filter_date_modified_to'])) {
+			$sql .= " AND DATE(`date_modified`) <= DATE('" . $this->db->escape((string)$data['filter_date_modified_to']) . "')";
 		}
 
 		if (!empty($data['filter_total'])) {

--- a/upload/admin/view/template/sale/order.twig
+++ b/upload/admin/view/template/sale/order.twig
@@ -56,16 +56,30 @@
               <input type="text" name="filter_total" value="{{ filter_total }}" placeholder="{{ entry_total }}" id="input-total" class="form-control"/>
             </div>
             <div class="mb-3">
-              <label for="input-date-added" class="form-label">{{ entry_date_added }}</label>
+              <label for="input-date-added-from" class="form-label">{{ entry_date_added_from }}</label>
               <div class="input-group">
-                <input type="text" name="filter_date_added" value="{{ filter_date_added }}" placeholder="{{ entry_date_added }}" id="input-date-added" class="form-control date"/>
+                <input type="text" name="filter_date_added_from" value="{{ filter_date_added_from }}" placeholder="{{ entry_date_added_from }}" id="input-date-added-from" class="form-control date"/>
                 <div class="input-group-text"><i class="fas fa-calendar"></i></div>
               </div>
             </div>
             <div class="mb-3">
-              <label for="input-date-modified" class="form-label">{{ entry_date_modified }}</label>
+              <label for="input-date-added-to" class="form-label">{{ entry_date_added_to }}</label>
               <div class="input-group">
-                <input type="text" name="filter_date_modified" value="{{ filter_date_modified }}" placeholder="{{ entry_date_modified }}" id="input-date-modified" class="form-control date"/>
+                <input type="text" name="filter_date_added_to" value="{{ filter_date_added_to }}" placeholder="{{ entry_date_added_to }}" id="input-date-added-to" class="form-control date"/>
+                <div class="input-group-text"><i class="fas fa-calendar"></i></div>
+              </div>
+            </div>
+            <div class="mb-3">
+              <label for="input-date-modified-from" class="form-label">{{ entry_date_modified_from }}</label>
+              <div class="input-group">
+                <input type="text" name="filter_date_modified_from" value="{{ filter_date_modified_from }}" placeholder="{{ entry_date_modified_from }}" id="input-date-modified-from" class="form-control date"/>
+                <div class="input-group-text"><i class="fas fa-calendar"></i></div>
+              </div>
+            </div>
+            <div class="mb-3">
+              <label for="input-date-modified-to" class="form-label">{{ entry_date_modified_to }}</label>
+              <div class="input-group">
+                <input type="text" name="filter_date_modified_to" value="{{ filter_date_modified_to }}" placeholder="{{ entry_date_modified_to }}" id="input-date-modified-to" class="form-control date"/>
                 <div class="input-group-text"><i class="fas fa-calendar"></i></div>
               </div>
             </div>
@@ -124,16 +138,28 @@ $('#button-filter').on('click', function () {
         url += '&filter_total=' + encodeURIComponent(filter_total);
     }
 
-    var filter_date_added = $('#input-date-added').val();
+    var filter_date_added_from = $('#input-date-added-from').val();
 
-    if (filter_date_added) {
-        url += '&filter_date_added=' + encodeURIComponent(filter_date_added);
+    if (filter_date_added_from) {
+        url += '&filter_date_added_from=' + encodeURIComponent(filter_date_added_from);
     }
 
-    var filter_date_modified = $('#input-date-modified').val();
+    var filter_date_added_to = $('#input-date-added-to').val();
 
-    if (filter_date_modified) {
-        url += '&filter_date_modified=' + encodeURIComponent(filter_date_modified);
+    if (filter_date_added_to) {
+        url += '&filter_date_added_to=' + encodeURIComponent(filter_date_added_to);
+    }
+
+    var filter_date_modified_from = $('#input-date-modified-from').val();
+
+    if (filter_date_modified_from) {
+        url += '&filter_date_modified_from=' + encodeURIComponent(filter_date_modified_from);
+    }
+
+    var filter_date_modified_to = $('#input-date-modified-to').val();
+
+    if (filter_date_modified_to) {
+        url += '&filter_date_modified_to=' + encodeURIComponent(filter_date_modified_to);
     }
 
     $('#order').load('index.php?route=sale/order|list&user_token={{ user_token }}' + url);


### PR DESCRIPTION
**Version**: current in master branch Opencart 4

**Location**: In the admin panel, Orders, filter section.

**Problem**: Currently in the filter section for "Date added" and "Date modified" there is an option to enter a date, but not from / to. This makes the report almost unusable. In most cases, the desire is to see the orders after date, before date, or between dates.

**Solution**: The date controls change, with a date "from" and a date "to" for each of "Date added" and "Date modified" (see picture below).

![image](https://user-images.githubusercontent.com/628801/173236960-8ca08005-581b-4b75-be50-1d6cd5824b4e.png)


