### PR TITLE
[OC 4.0 MASTER] Installer, uninstall: recursive delete directories

### DIFF
--- a/upload/admin/controller/marketplace/installer.php
+++ b/upload/admin/controller/marketplace/installer.php
@@ -413,7 +413,7 @@ class Installer extends \Opencart\System\Engine\Controller {
 					if (is_file($path)) {
 						unlink($path);
 					} elseif (is_dir($path)) {
-						rmdir($path);
+						$this->recursiveDelDir($path);
 					}
 				}
 
@@ -435,6 +435,19 @@ class Installer extends \Opencart\System\Engine\Controller {
 		$this->response->addHeader('Content-Type: application/json');
 		$this->response->setOutput(json_encode($json));
 	}
+
+    protected function recursiveDelDir($directory) {
+        if (is_dir($directory)) {
+            foreach (glob($directory . '/*') as $file) {
+                if (is_dir($file)) { 
+                    $this->recursiveDelDir($file);
+                } else {
+                    unlink($file);
+                }
+            }
+            @rmdir($directory);
+        }
+    }
 
 	/* Generate new autoloader file */
 	public function vendor(): void {


### PR DESCRIPTION
 Installer, uninstall: recursive delete directories to prevent errors and partial uninstall.

Problem: When function uninstall in admin/controller/marketplace/installer.php tried to delete directories, and they are not empty, the procedure ends, but errors are registered in the log, and the extension directory remains undeleted.
This is a problem because if you try to install the same extension again, the procedure will not start.

With this PR the problem is solved.