### PR TITLE
[OC 4.0 Master] Resolve undefined originalEvent on ajax form submit

### DIFF
--- a/upload/admin/view/javascript/common.js
+++ b/upload/admin/view/javascript/common.js
@@ -165,7 +165,7 @@ $(document).on('submit', 'form[data-oc-toggle=\'ajax\']', function (e) {
 
     var action = $(form).attr('action');
 
-    if (e.originalEvent.submitter !== undefined) {
+    if (e.originalEvent !== undefined && e.originalEvent.submitter !== undefined) {
         var button = e.originalEvent.submitter;
     } else {
         var button = '';


### PR DESCRIPTION
This PR resolves problem and javascript error in common.js when submit ajax form by jQuery.submit()

**Current state**
All works fine when ajax form is submitted by pressing a button.

**Problem**
Imagine you like to write on click handler for the button to check conditions, and in the handler you submit the form by jQuery.submit().
In this case in the line
`if (e.originalEvent.submitter !== undefined) {`
the script generates error, because e.originalEvent is not defined, and this prevent script to continue.

**Resolution**
Above line is replaced by
`if (e.originalEvent !== undefined && e.originalEvent.submitter !== undefined) {`