### PR TITLE
Patch 006 admin installer.php uninstall wrong trim in  glob

### DIFF
--- a/upload/admin/controller/marketplace/installer.php
+++ b/upload/admin/controller/marketplace/installer.php
@@ -406,7 +406,7 @@ class Installer extends \Opencart\System\Engine\Controller {
 				$next = array_shift($directory);
 
 				if (is_dir($next)) {
-					foreach (glob(trim($next, '/') . '/{*,.[!.]*,..?*}', GLOB_BRACE) as $file) {
+					foreach (glob(rtrim($next, '/') . '/{*,.[!.]*,..?*}', GLOB_BRACE) as $file) {
 						// If directory add to path array
 						$directory[] = $file;
 					}

--- a/upload/admin/view/javascript/common.js
+++ b/upload/admin/view/javascript/common.js
@@ -165,7 +165,7 @@ $(document).on('submit', 'form[data-oc-toggle=\'ajax\']', function (e) {
 
     var action = $(form).attr('action');
 
-    if (e.originalEvent.submitter !== undefined) {
+    if (e.originalEvent !== undefined && e.originalEvent.submitter !== undefined) {
         var button = e.originalEvent.submitter;
     } else {
         var button = '';


### PR DESCRIPTION
This PR resolves problem in deleting extension files on linux server

**Problem**
In line:
https://github.com/opencart/opencart/blob/0fdb8b9bbe4fd5aa4fdda2e955bb982f33b3a10d/upload/admin/controller/marketplace/installer.php#L409
is used:
`glob(trim($next, '/') . '/{*,.[!.]*,..?*}', GLOB_BRACE)`
where in linux file names starting slash is removed. It results in nothing deleted on the server.

**Resolution**
Just use rtrim instead of trim
`glob(rtrim($next, '/') . '/{*,.[!.]*,..?*}', GLOB_BRACE)`