### PR TITLE
Use instant log writes

### DIFF
--- a/upload/system/library/log.php
+++ b/upload/system/library/log.php
@@ -12,8 +12,7 @@
 */
 namespace Opencart\System\Library;
 class Log {
-	private string $file;
-	private string $message = '';
+	private $handle;
 
 	/**
 	 * Constructor
@@ -21,23 +20,23 @@ class Log {
 	 * @param	string	$filename
  	*/
 	public function __construct(string $filename) {
-		$this->file = DIR_LOGS . $filename;
+		$this->handle = fopen(DIR_LOGS . $filename, 'a');
 	}
-	
+
 	/**
-     * 
+     *
      *
      * @param	string	$message
      */
-	public function write(string|array $message): void {
-		$this->message .= date('Y-m-d H:i:s') . ' - ' . print_r($message, true) . "\n";
+	public function write(string $message): void {
+		fwrite($this->handle, date('Y-m-d G:i:s') . ' - ' . print_r($message, true) . "\n");
 	}
-	
+
 	/**
-     * 
+     *
      *
      */
 	public function __destruct() {
-		if (is_file($this->file)) file_put_contents($this->file, $this->message, FILE_APPEND);
+		fclose($this->handle);
 	}
 }

--- a/upload/system/library/log.php
+++ b/upload/system/library/log.php
@@ -18,24 +18,24 @@ class Log {
 	 * Constructor
 	 *
 	 * @param	string	$filename
- 	*/
+	*/
 	public function __construct(string $filename) {
 		$this->handle = fopen(DIR_LOGS . $filename, 'a');
 	}
 
 	/**
-     *
-     *
-     * @param	string	$message
-     */
+	 *
+	 *
+	 * @param	string	$message
+	*/
 	public function write(string $message): void {
 		fwrite($this->handle, date('Y-m-d G:i:s') . ' - ' . print_r($message, true) . "\n");
 	}
 
 	/**
-     *
-     *
-     */
+	 *
+	 *
+	*/
 	public function __destruct() {
 		fclose($this->handle);
 	}


### PR DESCRIPTION
This is better for developers.

Currently, log entries often show up in quite a delayed manner in the DIR_LOGS.'error.log', which makes it harder for testing and development.
