### PR TITLE
Fix validation for custom_fields in checkout

### DIFF
--- a/upload/catalog/controller/checkout/guest.php
+++ b/upload/catalog/controller/checkout/guest.php
@@ -215,6 +215,10 @@ class ControllerCheckoutGuest extends Controller {
 			$custom_fields = $this->model_account_custom_field->getCustomFields($customer_group_id);
 
 			foreach ($custom_fields as $custom_field) {
+				if($custom_field['location'] == 'affiliate') {
+					continue;
+				}
+				
 				if ($custom_field['required'] && empty($this->request->post['custom_field'][$custom_field['location']][$custom_field['custom_field_id']])) {
 					$json['error']['custom_field' . $custom_field['custom_field_id']] = sprintf($this->language->get('error_custom_field'), $custom_field['name']);
 				} elseif (($custom_field['type'] == 'text') && !empty($custom_field['validation']) && !filter_var($this->request->post['custom_field'][$custom_field['location']][$custom_field['custom_field_id']], FILTER_VALIDATE_REGEXP, array('options' => array('regexp' => $custom_field['validation'])))) {

--- a/upload/catalog/controller/checkout/register.php
+++ b/upload/catalog/controller/checkout/register.php
@@ -186,6 +186,10 @@ class ControllerCheckoutRegister extends Controller {
 			$custom_fields = $this->model_account_custom_field->getCustomFields($customer_group_id);
 
 			foreach ($custom_fields as $custom_field) {
+				if($custom_field['location'] == 'affiliate') {
+					continue;
+				}
+
 				if ($custom_field['required'] && empty($this->request->post['custom_field'][$custom_field['location']][$custom_field['custom_field_id']])) {
 					$json['error']['custom_field' . $custom_field['custom_field_id']] = sprintf($this->language->get('error_custom_field'), $custom_field['name']);
 				} elseif (($custom_field['type'] == 'text') && !empty($custom_field['validation']) && !filter_var($this->request->post['custom_field'][$custom_field['location']][$custom_field['custom_field_id']], FILTER_VALIDATE_REGEXP, array('options' => array('regexp' => $custom_field['validation'])))) {


### PR DESCRIPTION
@mhcwebdesign 
Both checkout guest and register validate all custom fields. It is right to be done for customer and address but affiliate should not be validated here. Otherwise the checkout does not work when you have cretaed a required custom field for affiliate.

