### PR TITLE
[Master] - Fixed collision problem in `Template` library.

### DIFF
--- a/upload/system/library/template/template.php
+++ b/upload/system/library/template/template.php
@@ -2,7 +2,8 @@
 namespace Opencart\System\Library\Template;
 class Template {
 	protected string $directory = '';
-	protected array $path = [];
+	protected array  $path = [];
+	private string   $code;
 
 	/**
 	 * addPath
@@ -55,11 +56,13 @@ class Template {
 		}
 
 		if ($code) {
+			$this->code = $code;
+
 			ob_start();
 
 			extract($data);
 
-			include($this->compile($filename, $code));
+			include($this->compile($filename, $this->code));
 
 			return ob_get_clean();
 		} else {


### PR DESCRIPTION
When using the template engine `Template` (.tpl), variables are not passed correctly to the template.
This is due to a data collision when using the `extract()` [function](https://www.php.net/manual/en/function.extract.php). The local variable `$code` will be overwritten by the variable `$_['code']` from [language](https://github.com/opencart/opencart/blob/master/upload/catalog/language/en-gb/en-gb.php#L3). To avoid this, the local `$code` must be stored as a property of the class.

**How ​​to reproduce the issue:**
1. Change the [settings](https://github.com/opencart/opencart/blob/master/upload/system/config/default.php#L49) in `default.php` to these:
```
$_['template_engine'] = 'template';
$_['template_extension'] = '.tpl';
```
2. Change the `home.php` [file](https://github.com/opencart/opencart/blob/master/upload/catalog/controller/common/home.php) so that only `footer` is displayed:
```
// $data['column_left'] = $this->load->controller('common/column_left');
// $data['column_right'] = $this->load->controller('common/column_right');
// $data['content_top'] = $this->load->controller('common/content_top');
// $data['content_bottom'] = $this->load->controller('common/content_bottom');
$data['footer'] = $this->load->controller('common/footer');
// $data['header'] = $this->load->controller('common/header');
```
3. Add `opencart/upload/catalog/view/template/common/footer.tpl` with some content.
4. Open the store home page. Instead of the contents of `footer.tpl`, the value of the variable `$_['code']` (en) will be displayed.