### PR TITLE
Fix not working links to write a review on product.twig

### DIFF
--- a/upload/catalog/view/template/product/product.twig
+++ b/upload/catalog/view/template/product/product.twig
@@ -219,7 +219,7 @@
                       <span class="fa-stack"><i class="fa-solid fa-star fa-stack-1x"></i><i class="fa-regular fa-star fa-stack-1x"></i></span>
                     {% endif %}
                     {% endfor %}
-                    <a href="" onclick="$('a[href=\'#tab-review\']').trigger('click'); return false;">{{ text_reviews }}</a> / <a href="" onclick="$('a[href=\'#tab-review\']').trigger('click'); return false;">{{ text_write }}</a></p>
+                    <a href="" onclick="document.getElementById('review-tab').click(); return false;">{{ text_reviews }}</a> / <a href="" onclick="document.getElementById('review-tab').click(); return false;">{{ text_write }}</a></p>
                 </div>
               {% endif %}
             </form>


### PR DESCRIPTION
The two links for seeing the review tab in the product.twig doesn't work anymore. This fixes it and replaces the Jquery variant with vanilla JS instead.