### PR TITLE
Fix DivisionByZeroException when limit in URL is not a number

### DIFF
--- a/upload/catalog/controller/common/pagination.php
+++ b/upload/catalog/controller/common/pagination.php
@@ -16,10 +16,14 @@ class Pagination extends \Opencart\System\Engine\Controller {
 
 		if (isset($setting['limit'])) {
 			$limit = (int)$setting['limit'];
+			if($limit == 0) {
+				$limit = 10;
+			}
 		} else {
 			$limit = 10;
 		}
 
+		
 		if (isset($setting['url'])) {
 			$url = str_replace('%7Bpage%7D', '{page}', (string)$setting['url']);
 		} else {

--- a/upload/catalog/controller/product/category.php
+++ b/upload/catalog/controller/product/category.php
@@ -37,9 +37,13 @@ class Category extends \Opencart\System\Engine\Controller {
 
 		if (isset($this->request->get['limit'])) {
 			$limit = (int)$this->request->get['limit'];
+			if($limit == 0) {
+				$limit = $this->config->get('config_pagination');
+			}
 		} else {
 			$limit = $this->config->get('config_pagination');
 		}
+
 
 		$data['breadcrumbs'] = [];
 

--- a/upload/catalog/controller/product/search.php
+++ b/upload/catalog/controller/product/search.php
@@ -61,6 +61,9 @@ class Search extends \Opencart\System\Engine\Controller {
 
 		if (isset($this->request->get['limit'])) {
 			$limit = (int)$this->request->get['limit'];
+			if($limit == 0) {
+				$limit = $this->config->get('config_pagination');	
+			}
 		} else {
 			$limit = $this->config->get('config_pagination');
 		}


### PR DESCRIPTION
When the user provides a non numeric value per get parameter, the store throws a DivisionByZero exception. This fills up server logs when bots trying out some values.

This fixes it for the category side in front-end. 