### PR TITLE
Update install.php

### DIFF
--- a/upload/install/model/install/install.php
+++ b/upload/install/model/install/install.php
@@ -46,7 +46,7 @@ class Install extends \Opencart\System\Engine\Model {
 			}
 
 			$sql = rtrim($sql, ",\n") . "\n";
-			$sql .= ") ENGINE=" . $table['engine'] . " CHARSET=" . $table['charset'] . " COLLATE=" . $table['collate'] . ";\n";
+			$sql .= ") ENGINE=" . $table['engine'] . " CHARSET=" . $table['charset'] . " ROW_FORMAT=DYNAMIC COLLATE=" . $table['collate'] . ";\n";
 
 			$db->query($sql);
 		}


### PR DESCRIPTION
hot fix bug Index column size too large. The maximum column size is 767 bytes (maybe need another better way) for table *_description for index 'name' column   => it can't create table (tested on localhost with wamp64, 10.5.13-MariaDB)
https://stackoverflow.com/questions/54541448/how-to-fix-1709-index-column-size-too-large-the-maximum-column-size-is-767-by

