### PR TITLE
Remove outdated query from CliInstall

### DIFF
--- a/upload/install/cli_install.php
+++ b/upload/install/cli_install.php
@@ -336,8 +336,6 @@ class CliInstall extends \Opencart\System\Engine\Controller {
 			$db->query("DELETE FROM `" . $db_prefix . "setting` WHERE `key` = 'config_encryption'");
 			$db->query("INSERT INTO `" . $db_prefix . "setting` SET `code` = 'config', `key` = 'config_encryption', `value` = '" . $db->escape(Helper\General\token(1024)) . "'");
 
-			$db->query("UPDATE `" . $db_prefix . "product` SET `viewed` = '0'");
-
 			$db->query("INSERT INTO `" . $db_prefix . "api` SET `username` = 'Default', `key` = '" . $db->escape(Helper\General\token(256)) . "', `status` = 1, `date_added` = NOW(), `date_modified` = NOW()");
 
 			$last_id = $db->getLastId();


### PR DESCRIPTION
This is the first PR from a serie, which I have locally, to propose a solution to fix the cli_install.php, partially described in #11545. I think for code review purposes is easy to deal which each error in a separated PR. 

In this case, is simple, is removing an outdated query, because "DB_PREFIX . product" table does not contain a column "viewed" since 4.0.1.0. 

That column is now in a "DB_PREFIX . product_viewed"