### PR TITLE
Added removal of promotion HTML Table fix - install/controller/upgrade/upgrade_8.php file

### DIFF
--- a/upload/install/controller/upgrade/upgrade_8.php
+++ b/upload/install/controller/upgrade/upgrade_8.php
@@ -162,6 +162,9 @@ class Upgrade8 extends \Opencart\System\Engine\Controller {
 			if (!$query->num_rows) {
 				$this->db->query("INSERT INTO `" . DB_PREFIX . "setting` SET `store_id` = '0', `code` = 'config', `key` = 'config_fraud_status_id', `value` = '8', `serialized` = '0'");
 			}
+			
+			// Config - Security
+			$this->db->query("UPDATE `" . DB_PREFIX . "setting` SET `key` = 'config_security', `value` = '1' WHERE `key` = 'config_password'");
 
 			// Country address_format_id
 			$query = $this->db->query("SELECT * FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = '" . DB_DATABASE . "' AND TABLE_NAME = '" . DB_PREFIX . "country' AND COLUMN_NAME = 'address_format_id'");

--- a/upload/install/controller/upgrade/upgrade_8.php
+++ b/upload/install/controller/upgrade/upgrade_8.php
@@ -74,6 +74,9 @@ class Upgrade8 extends \Opencart\System\Engine\Controller {
 					$this->db->query("UPDATE `" . DB_PREFIX . "order` SET `affiliate_id` = '" . (int)$customer_id . "' WHERE `affiliate_id` = '" . (int)$affiliate['affiliate_id'] . "'");
 				}
 			}
+			
+			// Event - Remove admin promotion from OC 3.x, since it is no longer required to have in OC v4.x releases.
+			$this->db->query("DELETE FROM `" . DB_PREFIX . "event` WHERE `action` = 'extension/extension/promotion/getList'");
 
 			// Config Session Expire
 			$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "setting` WHERE `key` = 'config_session_expire'");

--- a/upload/install/controller/upgrade/upgrade_8.php
+++ b/upload/install/controller/upgrade/upgrade_8.php
@@ -163,9 +163,6 @@ class Upgrade8 extends \Opencart\System\Engine\Controller {
 				$this->db->query("INSERT INTO `" . DB_PREFIX . "setting` SET `store_id` = '0', `code` = 'config', `key` = 'config_fraud_status_id', `value` = '8', `serialized` = '0'");
 			}
 			
-			// Config - Security
-			$this->db->query("UPDATE `" . DB_PREFIX . "setting` SET `key` = 'config_security', `value` = '1' WHERE `key` = 'config_password'");
-
 			// Country address_format_id
 			$query = $this->db->query("SELECT * FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = '" . DB_DATABASE . "' AND TABLE_NAME = '" . DB_PREFIX . "country' AND COLUMN_NAME = 'address_format_id'");
 


### PR DESCRIPTION
Exceptional removal request, since OC v3.x release requires HTML table addon with the promotion page from extension/extension along with the promotional banner. v4.x releases no longer requires this event (heading_title(0) fix)