### PR TITLE
fix: crash when listing scripts in footer

### DIFF
--- a/upload/catalog/view/template/common/footer.twig
+++ b/upload/catalog/view/template/common/footer.twig
@@ -55,6 +55,6 @@ Please donate via PayPal to donate@opencart.com
 {{ cookie }}
 <script src="{{ bootstrap }}" type="text/javascript"></script>
 {% for script in scripts %}
-  <script src="{{ script }}" type="text/javascript"></script>
+  <script src="{{ script.href }}" type="text/javascript"></script>
 {% endfor %}
 </body></html>


### PR DESCRIPTION
Before, when including the scripts, it generated the error below:

```html
<script src="[<b>Warning</b>: Array to string conversion in <b>/var/www/html/system/storage/cache/template/a1/a18ed9f2bc607ccb53f3b90175ba5382.php</b> on line <b>206</b>Array](http://localhost/%3Cb%3EWarning%3C/b%3E:%20Array%20to%20string%20conversion%20in%20%3Cb%3E/var/www/html/system/storage/cache/template/a1/a18ed9f2bc607ccb53f3b90175ba5382.php%3C/b%3E%20on%20line%20%3Cb%3E206%3C/b%3EArray)" type="text/javascript"></script>
```

The error happens as Twig tries to print an array