### PR TITLE
fix email url

### DIFF
--- a/upload/catalog/controller/mail/order.php
+++ b/upload/catalog/controller/mail/order.php
@@ -310,7 +310,7 @@ class Order extends \Opencart\System\Engine\Controller {
 			$store_url = $store_info['url'];
 		} else {
 			$store_name = html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8');
-			$store_url = HTTP_SERVER;
+			$store_url = HTTP_CATALOG;
 		}
 
 		$this->load->model('localisation/language');


### PR DESCRIPTION
currently when you add history to an order and select notify customer, the email that is sent out contains the back-end's url instead of the storefront url.