### PR TITLE
Update order.php

### DIFF
--- a/upload/admin/controller/sale/order.php
+++ b/upload/admin/controller/sale/order.php
@@ -1721,7 +1721,7 @@ class Order extends \Opencart\System\Engine\Controller {
 			$order_id = 0;
 		}
 
-		if (isset($this->request->get['page'])) {
+		if (isset($this->request->get['page']) && $this->request->get['route'] == 'sale/order|history') {
 			$page = (int)$this->request->get['page'];
 		} else {
 			$page = 1;


### PR DESCRIPTION
fixed bug load order history when seeing order from sale/order with page > 1  
it likes admin/index.php?route=sale/order|info&user_token=1bef9c62ea988977358cdf135665fc02&order_id=14&page=3
this condition will set page only from Ajax load => route == 'sale/order|history'