### PR TITLE
Use seperate success message for guest checkout

### DIFF
--- a/upload/catalog/controller/checkout/register.php
+++ b/upload/catalog/controller/checkout/register.php
@@ -577,7 +577,7 @@ class Register extends \Opencart\System\Engine\Controller {
 				} elseif ($this->customer->isLogged()) {
 					$json['success'] = $this->language->get('text_success_edit');
 				} else {
-					$json['success'] = $this->language->get('text_success_add');
+					$json['success'] = $this->language->get('text_success_guest');
 				}
 
 				unset($this->session->data['payment_methods']);


### PR DESCRIPTION
Maybe we should use a different success message when a user has selected "Guest Checkout" while checking out, to avoid confusion. Because the message right now says "Success: Your account has been created!".