### PR TITLE
Update free.php

### DIFF
--- a/upload/extension/opencart/admin/language/en-gb/shipping/free.php
+++ b/upload/extension/opencart/admin/language/en-gb/shipping/free.php
@@ -8,7 +8,7 @@ $_['text_success']     = 'Success: You have modified free shipping!';
 $_['text_edit']        = 'Edit Free Shipping';
 
 // Entry
-$_['entry_total']      = 'Total';
+$_['entry_total']      = 'Sub-Total';
 $_['entry_geo_zone']   = 'Geo Zone';
 $_['entry_status']     = 'Status';
 $_['entry_sort_order'] = 'Sort Order';


### PR DESCRIPTION
Inside the "Free" shopping method, this wording is confusing:
https://github.com/opencart/opencart/blob/8c7bb184fd94f9fa6045ca2b2b2c3a7283bb3663/upload/extension/opencart/admin/language/en-gb/shipping/free.php#L11

After it says:
https://github.com/opencart/opencart/blob/8c7bb184fd94f9fa6045ca2b2b2c3a7283bb3663/upload/extension/opencart/admin/language/en-gb/shipping/free.php#L17

While both should be **Sub-Total**