### PR TITLE
Correction in Bootstrap Class

### DIFF
--- a/upload/catalog/view/template/common/success.twig
+++ b/upload/catalog/view/template/common/success.twig
@@ -9,7 +9,7 @@
     <div id="content" class="col">{{ content_top }}
       <h1>{{ heading_title }}</h1>
       {{ text_message }}
-      <div class="d-inline-block pt-2 pd-2 w-100">
+      <div class="d-inline-block py-2 w-100">
         <div class="float-end"><a href="{{ continue }}" class="btn btn-primary">{{ button_continue }}</a></div>
       </div>
       {{ content_bottom }}</div>


### PR DESCRIPTION
Earlier it was "pt-2 pd-2" class, `.pt-2` is for adding top padding. however no `.pd` class & styling exists in Bootstrap or custom CSS. On inspection, it seems - it could be `.pb-2` class.

Since `pt-2 pb-2` is equivalent to `py-2`, I have replaced it.

Hope I am not wrong?