### PR TITLE
fix: add slash ("/") at the end of the directory when generating autoload

### DIFF
--- a/upload/admin/controller/marketplace/installer.php
+++ b/upload/admin/controller/marketplace/installer.php
@@ -555,10 +555,10 @@ class Installer extends \Opencart\System\Engine\Controller {
 
 						foreach ($autoload as $namespace => $path) {
 							if (!is_array($path)) {
-								$code .= '$autoloader->register(\'' . rtrim($namespace, '\\') . '\', DIR_STORAGE . \'vendor/' . $directory . '/' . $path . '\', true);' . "\n";
+								$code .= '$autoloader->register(\'' . rtrim($namespace, '\\') . '\', DIR_STORAGE . \'vendor/' . $directory . '/' . rtrim($path, '/') . '/' . '\', true);' . "\n";
 							} else {
 								foreach ($path as $value) {
-									$code .= '$autoloader->register(\'' . rtrim($namespace, '\\') . '\', DIR_STORAGE . \'vendor/' . $directory . '/' . $value . '\', true);' . "\n";
+									$code .= '$autoloader->register(\'' . rtrim($namespace, '\\') . '\', DIR_STORAGE . \'vendor/' . $directory . '/' . rtrim($value, '/') . '/' . '\', true);' . "\n";
 								}
 							}
 						}
@@ -570,10 +570,10 @@ class Installer extends \Opencart\System\Engine\Controller {
 
 						foreach ($autoload as $namespace => $path) {
 							if (!is_array($path)) {
-								$code .= '$autoloader->register(\'' . rtrim($namespace, '\\') . '\', DIR_STORAGE . \'vendor/' . $directory . '/' . $path . '\', true);' . "\n";
+								$code .= '$autoloader->register(\'' . rtrim($namespace, '\\') . '\', DIR_STORAGE . \'vendor/' . $directory . '/' . rtrim($path, '/') . '/' . '\', true);' . "\n";
 							} else {
 								foreach ($path as $value) {
-									$code .= '$autoloader->register(\'' . rtrim($namespace, '\\') . '\', DIR_STORAGE . \'vendor/' . $directory . '/' . $value . '\', true);' . "\n";
+									$code .= '$autoloader->register(\'' . rtrim($namespace, '\\') . '\', DIR_STORAGE . \'vendor/' . $directory . '/' . rtrim($value, '/') . '/' . '\', true);' . "\n";
 								}
 							}
 						}
@@ -610,7 +610,7 @@ class Installer extends \Opencart\System\Engine\Controller {
 						}
 
 						foreach ($autoload as $namespace => $path) {
-							$code .= '$autoloader->register(\'' . rtrim($namespace, '\\') . '\', DIR_STORAGE . \'vendor/' . $path . '\', true);' . "\n";
+							$code .= '$autoloader->register(\'' . rtrim($namespace, '\\') . '\', DIR_STORAGE . \'vendor/' . rtrim($path, '/') . '/' . '\', true);' . "\n";
 						}
 					}
 


### PR DESCRIPTION
# Error Description

Some libraries don't add slash at the end of directory when setting autoload (psr-4)

When generating the autoload.php file, OpenCart does not check and ends up generating a wrong path to the file.

**Monolog Composer**

```json
{
    "name": "monolog/monolog",
    ...
    "autoload": {
        "psr-4": {"Monolog\\": "src/Monolog"}
    }
}
```

**system/autoload.php with error (after extension install)**

```php
// monolog/monolog
$autoloader->register('Monolog', DIR_STORAGE . 'vendor/monolog/monolog/src/Monolog', true); // No slash at the end
```

**How should system/autoload.php be generated (after extension install)**

```php
// monolog/monolog
$autoloader->register('Monolog', DIR_STORAGE . 'vendor/monolog/monolog/src/Monolog/', true);
```

# Reproduce error

The extension below uses Monolog, when installing it you can check the error

https://github.com/opencart-extension/LetMeKnowWheItsAvailable