### PR TITLE
Banner images don't update on existing rows

### DIFF
--- a/upload/admin/view/template/design/banner_form.twig
+++ b/upload/admin/view/template/design/banner_form.twig
@@ -74,8 +74,8 @@
                               <input type="hidden" name="banner_image[{{ language.language_id }}][{{ image_row }}][image]" value="{{ banner_image.image }}" id="input-image-{{ language.language_id }}-{{ image_row }}-image"/>
 
                               <div class="card-body">
-                                <button type="button" data-oc-toggle="image" data-oc-target="#input-image-{{ image_row }}" data-oc-thumb="#thumb-image-{{ language.language_id }}-{{ image_row }}" class="btn btn-primary btn-sm btn-block"><i class="fa-solid fa-pencil"></i> {{ button_edit }}</button>
-                                <button type="button" data-oc-toggle="clear" data-oc-target="#input-image-{{ image_row }}" data-oc-thumb="#thumb-image-{{ language.language_id }}-{{ image_row }}" class="btn btn-warning btn-sm btn-block"><i class="fa-regular fa-trash-can"></i> {{ button_clear }}</button>
+                                <button type="button" data-oc-toggle="image" data-oc-target="#input-image-{{ language.language_id }}-{{ image_row }}-image" data-oc-thumb="#thumb-image-{{ language.language_id }}-{{ image_row }}" class="btn btn-primary btn-sm btn-block"><i class="fa-solid fa-pencil"></i> {{ button_edit }}</button>
+                                <button type="button" data-oc-toggle="clear" data-oc-target="#input-image-{{ language.language_id }}-{{ image_row }}-image" data-oc-thumb="#thumb-image-{{ language.language_id }}-{{ image_row }}" class="btn btn-warning btn-sm btn-block"><i class="fa-regular fa-trash-can"></i> {{ button_clear }}</button>
                               </div>
 
                             </div>
@@ -118,10 +118,10 @@ $('button[id^=\'button-banner\']').on('click', function () {
     html += '  <td class="text-center">';
     html += '    <div class="card">';
     html += '      <img src="{{ placeholder }}" alt="" title="" id="thumb-image-' + $(element).attr('data-language') + '-' + image_row + '" data-oc-placeholder="{{ placeholder }}" class="card-img-top"/>';
-    html += '      <input type="hidden" name="banner_image[' + $(element).attr('data-language') + '][' + image_row + '][image]" value="" id="input-image-' + $(element).attr('data-language') + '-' + image_row + '"/>';
+    html += '      <input type="hidden" name="banner_image[' + $(element).attr('data-language') + '][' + image_row + '][image]" value="" id="input-image-' + $(element).attr('data-language') + '-' + image_row + '-image"/>';
     html += '      <div class="card-body">';
-    html += '        <button type="button" data-oc-toggle="image" data-oc-target="#input-image-' + $(element).attr('data-language') + '-' + image_row + '" data-oc-thumb="#thumb-image-' + $(element).attr('data-language') + '-' + image_row + '" class="btn btn-primary btn-sm btn-block"><i class="fa-solid fa-pencil"></i> {{ button_edit }}</button>';
-    html += '        <button type="button" data-oc-toggle="clear" data-oc-target="#input-image-' + $(element).attr('data-language') + '-' + image_row + '" data-oc-thumb="#thumb-image-' + $(element).attr('data-language') + '-' + image_row + '" class="btn btn-warning btn-sm btn-block"><i class="fa-regular fa-trash-can"></i> {{ button_clear }}</button>';
+    html += '        <button type="button" data-oc-toggle="image" data-oc-target="#input-image-' + $(element).attr('data-language') + '-' + image_row + '-image" data-oc-thumb="#thumb-image-' + $(element).attr('data-language') + '-' + image_row + '" class="btn btn-primary btn-sm btn-block"><i class="fa-solid fa-pencil"></i> {{ button_edit }}</button>';
+    html += '        <button type="button" data-oc-toggle="clear" data-oc-target="#input-image-' + $(element).attr('data-language') + '-' + image_row + '-image" data-oc-thumb="#thumb-image-' + $(element).attr('data-language') + '-' + image_row + '" class="btn btn-warning btn-sm btn-block"><i class="fa-regular fa-trash-can"></i> {{ button_clear }}</button>';
     html += '      </div>';
     html += '    </div>';
     html += '  </td>';


### PR DESCRIPTION
Editing or clearing an image from a existing banner row would not save correctly. Existing rows were missing the language id in the data-oc-target attribute on the edit/clear buttons causing a mismatch between them and the image input tag. The JavaScript to create additional rows already had the language id on them and would thus correctly save change done to them. Though they had slightly different id names that I normalized adding in the -image to the end of them like the existing ones for -title, -link, and -sort-order which both the existing and added rows have.

You can see this behavior if you open up an existing banner design and try changing or clearing an existing image. When saved if you refresh the previous image will still be set.

Steps to reproduce issue:
1. Navigate to Design->Banners in the admin section
2. Open a Banner
3. Change or Clear an image on an existing row
4. Save
5. Refresh the page to see that the previously set image is still there.