### PR TITLE
Bootstrap 5.2.1 fix tooltips

### DIFF
--- a/upload/admin/view/javascript/common.js
+++ b/upload/admin/view/javascript/common.js
@@ -79,7 +79,14 @@ $(document).ready(function () {
 $(document).ready(function () {
     // Tooltip
     var oc_tooltip = function () {
-        // Apply to all on current page
+        // BS 5.2.1: Destroy tooltip, otherwise it has wrong position when displayed second time
+        // Get tooltip instance
+        tooltip = bootstrap.Tooltip.getInstance(this);
+        if (tooltip) {
+            // Destroy tooltip
+            tooltip.dispose();
+        }
+        // Apply to current element
         tooltip = bootstrap.Tooltip.getOrCreateInstance(this);
         tooltip.show();
     }

--- a/upload/catalog/view/javascript/common.js
+++ b/upload/catalog/view/javascript/common.js
@@ -25,7 +25,14 @@ function getURLVar(key) {
 $(document).ready(function () {
     // Tooltip
     var oc_tooltip = function () {
-        // Apply to all on current page
+        // BS 5.2.1: Destroy tooltip, otherwise it has wrong position when displayed second time
+        // Get tooltip instance
+        tooltip = bootstrap.Tooltip.getInstance(this);
+        if (tooltip) {
+            // Destroy tooltip
+            tooltip.dispose();
+        }
+        // Apply to current element
         tooltip = bootstrap.Tooltip.getOrCreateInstance(this);
         tooltip.show();
     }


### PR DESCRIPTION
Tooltips are shown in the bottom of a page when hovered second time. 
Added a fix destroying an old tooltip instance before showing.

First hover:
![image](https://user-images.githubusercontent.com/6297070/192753058-d760e60b-1beb-4dc5-9d94-645233122b36.png)

Second hover:
![image](https://user-images.githubusercontent.com/6297070/192753124-f3907526-5cfa-43d5-b93d-94702cabe252.png)
