### PR TITLE
Added the rest of mandatory subscription fields - admin/model/sale/subscription.php file

### DIFF
--- a/upload/admin/model/sale/subscription.php
+++ b/upload/admin/model/sale/subscription.php
@@ -177,10 +177,13 @@ class Subscription extends \Opencart\System\Engine\Model {
 
 		foreach ($query->rows as $result) {
 			$transaction_data[] = [
-				'date_added'  => $result['date_added'],
-				'description' => $result['description'],
-				'amount'      => $result['amount'],
-				'order_id'    => $result['order_id']
+				'order_id'       => $result['order_id'],
+				'description'    => $result['description'],
+				'amount'         => $result['amount'],
+				'type'           => $result['type'],
+				'payment_method' => $result['payment_method'],
+				'payment_code'   => $result['payment_code'],
+				'date_added'     => $result['date_added']
 			];
 		}
 


### PR DESCRIPTION
These fields needs to be added in the array in order to complete the transaction with the addTransaction() method as to fill the mandatory fields on the database. The subscription_id is not included because we are already mentoring the user to lookup the subscription prior to add it to the subscription transaction table.