### PR TITLE
Replaced editSubscriptionPlan parameters - admin/controller/sale/subscription.php file

### DIFF
--- a/upload/admin/controller/sale/subscription.php
+++ b/upload/admin/controller/sale/subscription.php
@@ -619,7 +619,7 @@ class Subscription extends \Opencart\System\Engine\Controller {
 		if (!$json) {
 			$this->load->model('sale/subscription');
 
-			$this->model_sale_subscription->editSubscriptionPlan($subscription_id, $this->request->post);
+			$this->model_sale_subscription->editSubscriptionPlan($subscription_id, $this->request->post['subscription_plan_id']);
 
 			$json['success'] = $this->language->get('text_success');
 		}


### PR DESCRIPTION
The subscription plan ID would be needed since #form-subscription allows selection of the subscription_plan_id in the select form.