### PR TITLE
Adding getTransactionTotal to admin subscriptions - admin/model/sale/subscription.php file

### DIFF
--- a/upload/admin/model/sale/subscription.php
+++ b/upload/admin/model/sale/subscription.php
@@ -190,6 +190,12 @@ class Subscription extends \Opencart\System\Engine\Model {
 
 		return $transaction_data;
 	}
+	
+	public function getTransactionTotal(int $subscription_id): float {
+        $query = $this->db->query("SELECT SUM(`amount`) AS `total` FROM `" . DB_PREFIX . "subscription_transaction` WHERE `subscription_id` = '" . (int)$subscription_id . "'");
+
+        return (float)$query->row['total'];
+    }
 
 	public function getTotalTransactions(int $subscription_id): int {
 		$query = $this->db->query("SELECT COUNT(*) AS `total` FROM `" . DB_PREFIX . "subscription_transaction` WHERE `subscription_id` = '" . (int)$subscription_id . "'");


### PR DESCRIPTION
catalog/model/account/customer also pulls the getTransactionTotal() method. Should access be restricted to see this information by subscriptions, user groups can be managed by authorized users. Besides, extensions can already managed the amount by service types which means that extensions can also restrict these information by their service amounts.