### PR TITLE
Bootstrap fix tooltips onclick

### DIFF
--- a/upload/admin/view/javascript/common.js
+++ b/upload/admin/view/javascript/common.js
@@ -90,8 +90,11 @@ $(document).ready(function () {
 
     $(document).on('mouseenter', '[data-bs-toggle=\'tooltip\']', oc_tooltip);
 
-    $(document).on('click', 'button', function () {
-        $('.tooltip').remove();
+    $(document).on('click', '[data-bs-toggle=\'tooltip\']', function () {
+        tooltip = bootstrap.Tooltip.getInstance(this);
+        if (tooltip) {
+            tooltip.hide();
+        }
     });
 
     // Date

--- a/upload/catalog/view/javascript/common.js
+++ b/upload/catalog/view/javascript/common.js
@@ -36,8 +36,11 @@ $(document).ready(function () {
 
     $(document).on('mouseenter', '[data-bs-toggle=\'tooltip\']', oc_tooltip);
 
-    $(document).on('click', 'button', function () {
-        $('.tooltip').remove();
+    $(document).on('click', '[data-bs-toggle=\'tooltip\']', function () {
+        tooltip = bootstrap.Tooltip.getInstance(this);
+        if (tooltip) {
+            tooltip.hide();
+        }
     });
 
     // Date


### PR DESCRIPTION
Found another bug with tooltips.

After a button is clicked, tooltip does not work anymore because of `$('.tooltip').remove();`

We should use the same approach as on `mouseenter` to hide a tooltip correctly `tooltip.hide();`