### PR TITLE
Added validation on subscription status ID - admin/controller/sale/subscription.php file

### DIFF
--- a/upload/admin/controller/sale/subscription.php
+++ b/upload/admin/controller/sale/subscription.php
@@ -689,8 +689,8 @@ class Subscription extends \Opencart\System\Engine\Controller {
 
 		if (!$this->user->hasPermission('modify', 'sale/subscription')) {
 			$json['error'] = $this->language->get('error_permission');
-		} elseif ($this->request->post['subscription_plan_id'] == '') {
-			$json['error'] = $this->language->get('error_subscription_plan');
+		} elseif ($this->request->post['subscription_status_id'] == '') {
+			$json['error'] = $this->language->get('error_subscription_status');
 		}
 
 		if (!$json) {

--- a/upload/admin/controller/sale/subscription.php
+++ b/upload/admin/controller/sale/subscription.php
@@ -689,6 +689,8 @@ class Subscription extends \Opencart\System\Engine\Controller {
 
 		if (!$this->user->hasPermission('modify', 'sale/subscription')) {
 			$json['error'] = $this->language->get('error_permission');
+		} elseif ($this->request->post['subscription_plan_id'] == '') {
+			$json['error'] = $this->language->get('error_subscription_plan');
 		}
 
 		if (!$json) {


### PR DESCRIPTION
The subscription status ID from sale/subscription_info indicates an option value of: "" by default and requests to select a value. However, the serialized form submitted through AJAX does not validate on the target PHP controller/method if the subscription status ID has been selected or not. Therefore, the current code will only show a popup error message in regard to the ```$this->request->post['subscription_status_id']``` .