### PR TITLE
Fix seo url PDO error

### DIFF
--- a/upload/catalog/model/design/seo_url.php
+++ b/upload/catalog/model/design/seo_url.php
@@ -2,7 +2,7 @@
 namespace Opencart\Catalog\Model\Design;
 class SeoUrl extends \Opencart\System\Engine\Model {
 	public function getSeoUrlByKeyword(string $keyword): array {
-		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "seo_url` WHERE (`keyword` = '" . $this->db->escape($keyword) . "' OR `keyword` LIKE '%/" . $this->db->escape($keyword) . "') AND `store_id` = '" . (int)$this->config->get('config_store_id') . "' AND `language_id` = '" . (int)$this->config->get('config_language_id') . "'");
+		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "seo_url` WHERE (`keyword` = '" . $this->db->escape($keyword) . "' OR `keyword` LIKE '" . $this->db->escape('%/' . $keyword) . "') AND `store_id` = '" . (int)$this->config->get('config_store_id') . "' AND `language_id` = '" . (int)$this->config->get('config_language_id') . "'");
 
 		return $query->row;
 	}


### PR DESCRIPTION
Error: SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match number of tokens Error Code : HY093
SELECT * FROM `oc_seo_url` WHERE (`keyword` = :0 OR `keyword` LIKE '%/:1') AND `store_id` = '0' AND `language_id` = '1' in /app/system/library/db/pdo.php