### PR TITLE
Fixed description array key - admin/view/template/sale/order_info.twig file

### DIFF
--- a/upload/admin/view/template/sale/order_info.twig
+++ b/upload/admin/view/template/sale/order_info.twig
@@ -89,7 +89,7 @@
 
                   {% if order_product.subscription %}
                     <br/>
-                    <small> - {{ text_subscription }}: {{ subscription.description }}</small>
+                    <small> - {{ text_subscription }}: {{ order_product.subscription }}</small>
                   {% endif %}
 
                 </td>


### PR DESCRIPTION
We are using the filter_data from the controller which means the description key from the order_products array does not contain the description key but rather the subscription key of the subscription_info['name] key . The values are, then, matched accordingly.