### PR TITLE
Fixes the maintenance page from startup - catalog/controller/startup/maintenance.php file

### DIFF
--- a/upload/catalog/controller/startup/maintenance.php
+++ b/upload/catalog/controller/startup/maintenance.php
@@ -18,7 +18,7 @@ class Maintenance extends \Opencart\System\Engine\Controller {
 			// Show site if logged in as admin
 			$user = new \Opencart\System\Library\Cart\User($this->registry);
 
-			if (substr($route, 0, 3) != 'api' && !in_array($route, $ignore) && !$user->isLogged()) {
+			if (substr($route, 0, 3) != 'api' && !in_array($route, $ignore) && $user->isLogged() !== true) {
 				return new \Opencart\System\Engine\Action('common/maintenance');
 			}
 		}

--- a/upload/catalog/controller/startup/maintenance.php
+++ b/upload/catalog/controller/startup/maintenance.php
@@ -18,7 +18,7 @@ class Maintenance extends \Opencart\System\Engine\Controller {
 			// Show site if logged in as admin
 			$user = new \Opencart\System\Library\Cart\User($this->registry);
 
-			if (substr($route, 0, 3) != 'api' && !in_array($route, $ignore) && $user->isLogged() !== true) {
+			if (substr($route, 0, 3) != 'api' && !in_array($route, $ignore) && ($user->isLogged() !== true)) {
 				return new \Opencart\System\Engine\Action('common/maintenance');
 			}
 		}


### PR DESCRIPTION
Obviously, the system/library/cart/user.php file is enforcing its validation to be either set to true or false. Therefore, this fix resolves the issue.