### PR TITLE
Fixes for deprecated dynamic properties for php 8.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@
 /upload/.idea/*
 /.idea/*
 /.DS_Store
+*.bak

--- a/upload/system/engine/proxy.php
+++ b/upload/system/engine/proxy.php
@@ -11,7 +11,8 @@
  * Proxy class
  */
 namespace Opencart\System\Engine;
-class Proxy {
+
+class Proxy extends \stdClass {
 	/**
 	 * __get
 	 *

--- a/upload/system/library/cart/cart.php
+++ b/upload/system/library/cart/cart.php
@@ -1,6 +1,6 @@
 <?php
 namespace Opencart\System\Library\Cart;
-class Cart {
+class Cart extends \stdClass {
 	private array $data = [];
 
 	/**

--- a/upload/system/library/cart/currency.php
+++ b/upload/system/library/cart/currency.php
@@ -1,6 +1,6 @@
 <?php
 namespace Opencart\System\Library\Cart;
-class Currency {
+class Currency extends \stdClass  {
 	private array $currencies = [];
 
 	/**

--- a/upload/system/library/cart/customer.php
+++ b/upload/system/library/cart/customer.php
@@ -1,7 +1,7 @@
 <?php
 namespace Opencart\System\Library\Cart;
 use \Opencart\System\Helper as Helper;
-class Customer {
+class Customer extends \stdClass  {
 	private int $customer_id = 0;
 	private string $firstname = '';
 	private string $lastname = '';

--- a/upload/system/library/cart/length.php
+++ b/upload/system/library/cart/length.php
@@ -1,6 +1,6 @@
 <?php
 namespace Opencart\System\Library\Cart;
-class Length {
+class Length extends \stdClass  {
 	private array $lengths = [];
 
 	/**

--- a/upload/system/library/cart/tax.php
+++ b/upload/system/library/cart/tax.php
@@ -1,6 +1,6 @@
 <?php
 namespace Opencart\System\Library\Cart;
-class Tax {
+class Tax extends \stdClass  {
 	private array $tax_rates = [];
 
 	/**

--- a/upload/system/library/cart/user.php
+++ b/upload/system/library/cart/user.php
@@ -1,6 +1,6 @@
 <?php
 namespace Opencart\System\Library\Cart;
-class User {
+class User extends \stdClass {
 	private int $user_id = 0;
 	private string $username = '';
 	private int $user_group_id = 0;

--- a/upload/system/library/cart/weight.php
+++ b/upload/system/library/cart/weight.php
@@ -1,6 +1,6 @@
 <?php
 namespace Opencart\System\Library\Cart;
-class Weight {
+class Weight extends \stdClass  {
 	private array $weights = [];
 
 	/**

--- a/upload/system/library/db/mysqli.php
+++ b/upload/system/library/db/mysqli.php
@@ -16,12 +16,11 @@ class MySQLi {
 		if (!$port) {
 			$port = '3306';
 		}
-
+		$mysqlDriver = new \mysqli_driver();
+		$mysqlDriver->report_mode = MYSQLI_REPORT_ERROR;
 		try {
 			$mysqli = @new \MySQLi($hostname, $username, $password, $database, $port);
-
 			$this->connection = $mysqli;
-			$this->connection->report_mode = MYSQLI_REPORT_ERROR;
 			$this->connection->set_charset('utf8mb4');
 			$this->connection->query("SET SESSION sql_mode = 'NO_ZERO_IN_DATE,NO_ENGINE_SUBSTITUTION'");
 			$this->connection->query("SET FOREIGN_KEY_CHECKS = 0");

--- a/upload/system/library/request.php
+++ b/upload/system/library/request.php
@@ -17,7 +17,7 @@ class Request {
 	public array $cookie = [];
 	public array $files = [];
 	public array $server = [];
-	
+	public array $request = [];
 	/**
 	 * Constructor
  	*/

--- a/upload/system/library/session/db.php
+++ b/upload/system/library/session/db.php
@@ -8,12 +8,7 @@ CREATE TABLE IF NOT EXISTS `session` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 */
 namespace Opencart\System\Library\Session;
-class DB {
-	/**
-	 * Constructor
-	 *
-	 * @param    object  $registry
-	 */
+class DB extends \stdClass {
 	public function __construct(\Opencart\System\Engine\Registry $registry) {
 		$this->db = $registry->get('db');
 		$this->config = $registry->get('config');


### PR DESCRIPTION
Fix for deprecated dynamic properties.  

MYSQLI_REPORT_ERROR is already a property of mysqli_driver see https://www.php.net/manual/en/mysqli-driver.report-mode.php

request seems to have been forgotten as a public property of the request class

Added extends stdClass to proxy and all classes in library/cart