### PR TITLE
Added date_next field - system/library/cart/cart.php file

### DIFF
--- a/upload/system/library/cart/cart.php
+++ b/upload/system/library/cart/cart.php
@@ -274,6 +274,7 @@ class Cart {
 							'cycle'                	=> $subscription_query->row['cycle'],
 							'duration'             	=> $subscription_query->row['duration'],
 							'remaining'            	=> $subscription_query->row['duration'],
+							'date_next'            	=> $subscription_query->row['date_next'],
 							'status'				=> $subscription_query->row['status']
 						];
 					}


### PR DESCRIPTION
model/checkout/order requires the date_next field from the ```$product['subscription']['date_next']```