### PR TITLE
Removed multiple rows for order product ID - catalog/model/checkout/subscription.php file

### DIFF
--- a/upload/catalog/model/checkout/subscription.php
+++ b/upload/catalog/model/checkout/subscription.php
@@ -21,7 +21,7 @@ class Subscription extends \Opencart\System\Engine\Model {
 		$this->db->query("DELETE FROM `" . DB_PREFIX . "subscription` WHERE `order_id` = '" . (int)$order_id . "'");
 	}
 
-	public function getSubscriptionByOrderProductId(int $order_product_id): int {
+	public function getSubscriptionByOrderProductId(int $order_product_id): array {
 		$this->db->query("SELECT * FROM  `" . DB_PREFIX . "subscription` WHERE `order_product_id` = '" . (int)$order_product_id . "'");
 
 		return $this->db->row;

--- a/upload/catalog/model/checkout/subscription.php
+++ b/upload/catalog/model/checkout/subscription.php
@@ -24,6 +24,6 @@ class Subscription extends \Opencart\System\Engine\Model {
 	public function getSubscriptionByOrderProductId(int $order_product_id): int {
 		$this->db->query("SELECT * FROM  `" . DB_PREFIX . "subscription` WHERE `order_product_id` = '" . (int)$order_product_id . "'");
 
-		return $this->db->rows;
+		return $this->db->row;
 	}
 }


### PR DESCRIPTION
catalog/model/checkout/order.php file - $order_product_id already returns a unique order product ID in the foreach loop. Therefore, it is impossible to have multiple identical order product IDs in the subscriptions for each $order_id that is also unique.