### PR TITLE
Added full subscription price validation - catalog/controller/cron/subscription.php file

### DIFF
--- a/upload/catalog/controller/cron/subscription.php
+++ b/upload/catalog/controller/cron/subscription.php
@@ -56,8 +56,12 @@ class Subscription extends \Opencart\System\Engine\Controller {
 						}
 					} else {
 						$subscription_status_id = $this->config->get('config_subscription_failed_status_id');
-
-						$this->model_sale_subscription->addHistory($result['subscription_id'], $subscription_status_id, $this->language->get('error_extension'), true);
+        
+                        if ((int)$result['price'] < 1) {
+                            $this->model_sale_subscription->addHistory($result['subscription_id'], $subscription_status_id, $this->language->get('error_extension'));
+                        } else {
+                            $this->model_sale_subscription->addHistory($result['subscription_id'], $subscription_status_id, $this->language->get('error_extension'), true);
+                        }
 					}
 				} else {
 					$subscription_status_id = $this->config->get('config_subscription_failed_status_id');

--- a/upload/catalog/controller/cron/subscription.php
+++ b/upload/catalog/controller/cron/subscription.php
@@ -38,7 +38,7 @@ class Subscription extends \Opencart\System\Engine\Controller {
 
 				if ($payment_info) {
 					// Check payment status
-					if ($this->config->get('payment_' . $payment_info['code'] . '_status')) {
+					if ($this->config->get('payment_' . $payment_info['code'] . '_status') && (int)$result['price'] < 1) {
 						$this->load->model('extension/' . $payment_info['extension'] . '/payment/' . $payment_info['code']);
 
 						if (property_exists($this->{'model_extension_' . $payment_info['extension'] . '_payment_' . $payment_info['code']}, 'charge') ) {

--- a/upload/catalog/controller/cron/subscription.php
+++ b/upload/catalog/controller/cron/subscription.php
@@ -38,7 +38,7 @@ class Subscription extends \Opencart\System\Engine\Controller {
 
 				if ($payment_info) {
 					// Check payment status
-					if ($this->config->get('payment_' . $payment_info['code'] . '_status') && (int)$result['price'] < 1) {
+					if ($this->config->get('payment_' . $payment_info['code'] . '_status') && $result['price']) {
 						$this->load->model('extension/' . $payment_info['extension'] . '/payment/' . $payment_info['code']);
 
 						if (property_exists($this->{'model_extension_' . $payment_info['extension'] . '_payment_' . $payment_info['code']}, 'charge') ) {


### PR DESCRIPTION
While a trial price cannot be charged to a customer, a financial institution won't successfully validate a full membership price under a dollar. Therefore, as per the admin/controller/catalog/subscription_plan/validateForm() dictates: https://github.com/opencart/opencart/pull/11922/commits/a8be70ca1f7e8c2771591557abed486d14588873, we must ensure the subscription plan's price field has been filled whether it's for a trial period or a full membership.