### PR TITLE
Removing subscriptions in editOrder() method - catalog/model/checkout/order.php file

### DIFF
--- a/upload/catalog/model/checkout/order.php
+++ b/upload/catalog/model/checkout/order.php
@@ -93,8 +93,6 @@ class Order extends \Opencart\System\Engine\Model {
 
 			$this->load->model('checkout/subscription');
 
-			$this->model_checkout_subscription->deleteSubscriptionByOrderId($order_id);
-
 			// Products
 			if (isset($data['products'])) {
 				foreach ($data['products'] as $product) {
@@ -104,10 +102,6 @@ class Order extends \Opencart\System\Engine\Model {
 
 					foreach ($product['option'] as $option) {
 						$this->db->query("INSERT INTO `" . DB_PREFIX . "order_option` SET `order_id` = '" . (int)$order_id . "', `order_product_id` = '" . (int)$order_product_id . "', `product_option_id` = '" . (int)$option['product_option_id'] . "', `product_option_value_id` = '" . (int)$option['product_option_value_id'] . "', `name` = '" . $this->db->escape($option['name']) . "', `value` = '" . $this->db->escape($option['value']) . "', `type` = '" . $this->db->escape($option['type']) . "'");
-					}
-
-					if ($product['subscription']) {
-						$this->model_checkout_subscription->addSubscription($order_id, $product['subscription'] + ['order_product_id' => $order_product_id]);
 					}
 				}
 			}


### PR DESCRIPTION
As per this issue commit's explanation: https://github.com/opencart/opencart/issues/11935 . As a solution, the charge() method in the cron/subscription needs to create a new order by extension prior to return the subscription_status_id. If active, the addTransaction() gets added based on this (which we already have in the cron/subscription). Therefore, to ensure that a new order gets created, we need to ensure the subscription is removed from the editOrder().