### PR TITLE
Fixed conflict of error_default language key - catalog/controller/account/address.php file

### DIFF
--- a/upload/catalog/controller/account/address.php
+++ b/upload/catalog/controller/account/address.php
@@ -380,12 +380,11 @@ class Address extends \Opencart\System\Engine\Controller {
 			$this->load->model('account/address');
 
 			if ($this->model_account_address->getTotalAddresses() == 1) {
-
 				$json['error'] = $this->language->get('error_delete');
 			}
 
 			if ($this->customer->getAddressId() == $address_id) {
-				$json['error'] = $this->language->get('error_default');
+				$json['error'] = $this->language->get('error_default_delete');
 			}
 		}
 


### PR DESCRIPTION
save() and delete() methods leads to the same language key ```error_default``` but one is meant to check if it's saved but the other is meant to check if it can be deleted as the default address.