### PR TITLE
Added seo_url table lookup for previous versions - install/controller/upgrade/upgrade_9.php file

### DIFF
--- a/upload/install/controller/upgrade/upgrade_9.php
+++ b/upload/install/controller/upgrade/upgrade_9.php
@@ -746,9 +746,9 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
 
                 foreach ($seo_urls as $seo_url) {
                     $value = preg_replace('/[^a-zA-Z0-9_|\/\.]/', '', str_replace('|', '.', $seo_url['value']));
-                    
+
                     if ($value) {
-                        $this->db->query("INSERT INTO `" . DB_PREFIX . "seo_url` SET `store_id` = '" . (int)$seo_url['store_id'] . "', `language_id` = '" . (int)$seo_url['language_id'] . "', `key` = '" . $this->db->escape($seo_url['key']) . "', `value` = '" . (!filter_var($value, FILTER_VALIDATE_INT) ? $value : (int)$value) . "', `keyword` = '" . $this->db->escape($seo_url['keyword']) . "', `sort_order` = '" . (int)$seo_url['sort_order'] . "'");
+                        $this->db->query("INSERT INTO `" . DB_PREFIX . "seo_url` SET `store_id` = '" . (int)$seo_url['store_id'] . "', `language_id` = '" . (int)$seo_url['language_id'] . "', `key` = '" . $this->db->escape($seo_url['key']) . "', `value` = '" . (!filter_var($value, FILTER_VALIDATE_INT) ? $this->db->escape($value) : (int)$value) . "', `keyword` = '" . $this->db->escape($seo_url['keyword']) . "', `sort_order` = '" . (int)$seo_url['sort_order'] . "'");
                     }
                 }
             } catch (\ErrorException $exception) {

--- a/upload/install/controller/upgrade/upgrade_9.php
+++ b/upload/install/controller/upgrade/upgrade_9.php
@@ -68,7 +68,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'product_id',
-                    'value'       => 47,
+                    'value'       => '47',
                     'keyword'     => 'hp-lp3065',
                     'sort_order'  => 1
                 ];
@@ -77,7 +77,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'product_id',
-                    'value'       => 48,
+                    'value'       => '48',
                     'keyword'     => 'ipod-classic',
                     'sort_order'  => 1
                 ];
@@ -86,7 +86,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'product_id',
-                    'value'       => 28,
+                    'value'       => '28',
                     'keyword'     => 'htc-touch-hd',
                     'sort_order'  => 1
                 ];
@@ -95,7 +95,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'product_id',
-                    'value'       => 43,
+                    'value'       => '43',
                     'keyword'     => 'macbook',
                     'sort_order'  => 1
                 ];
@@ -104,7 +104,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'product_id',
-                    'value'       => 44,
+                    'value'       => '44',
                     'keyword'     => 'macbook-air',
                     'sort_order'  => 1
                 ];
@@ -113,7 +113,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'product_id',
-                    'value'       => 45,
+                    'value'       => '45',
                     'keyword'     => 'macbook-pro',
                     'sort_order'  => 1
                 ];
@@ -122,7 +122,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'product_id',
-                    'value'       => 30,
+                    'value'       => '30',
                     'keyword'     => 'canon-eos-5d',
                     'sort_order'  => 1
                 ];
@@ -131,7 +131,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'product_id',
-                    'value'       => 31,
+                    'value'       => '31',
                     'keyword'     => 'nikon-d300',
                     'sort_order'  => 1
                 ];
@@ -140,7 +140,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'product_id',
-                    'value'       => 29,
+                    'value'       => '29',
                     'keyword'     => 'palm-treo-pro',
                     'sort_order'  => 1
                 ];
@@ -149,7 +149,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'product_id',
-                    'value'       => 35,
+                    'value'       => '35',
                     'keyword'     => 'product-8',
                     'sort_order'  => 1
                 ];
@@ -158,7 +158,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'product_id',
-                    'value'       => 49,
+                    'value'       => '49',
                     'keyword'     => 'samsung-galaxy-tab-10-1',
                     'sort_order'  => 1
                 ];
@@ -167,7 +167,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'product_id',
-                    'value'       => 33,
+                    'value'       => '33',
                     'keyword'     => 'samsung-syncmaster-941bw',
                     'sort_order'  => 1
                 ];
@@ -176,7 +176,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'product_id',
-                    'value'       => 46,
+                    'value'       => '46',
                     'keyword'     => 'sony-vaio',
                     'sort_order'  => 1
                 ];
@@ -185,7 +185,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'product_id',
-                    'value'       => 41,
+                    'value'       => '41',
                     'keyword'     => 'imac',
                     'sort_order'  => 1
                 ];
@@ -194,7 +194,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'product_id',
-                    'value'       => 40,
+                    'value'       => '40',
                     'keyword'     => 'iphone',
                     'sort_order'  => 1
                 ];
@@ -203,7 +203,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'product_id',
-                    'value'       => 36,
+                    'value'       => '36',
                     'keyword'     => 'ipod-nano',
                     'sort_order'  => 1
                 ];
@@ -212,7 +212,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'product_id',
-                    'value'       => 34,
+                    'value'       => '34',
                     'keyword'     => 'ipod-shuffle',
                     'sort_order'  => 1
                 ];
@@ -221,7 +221,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'product_id',
-                    'value'       => 32,
+                    'value'       => '32',
                     'keyword'     => 'ipod-touch',
                     'sort_order'  => 1
                 ];
@@ -230,7 +230,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'product_id',
-                    'value'       => 50,
+                    'value'       => '50',
                     'keyword'     => 'apple-4',
                     'sort_order'  => 1
                 ];
@@ -239,7 +239,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'product_id',
-                    'value'       => 42,
+                    'value'       => '42',
                     'keyword'     => 'apple-cinema',
                     'sort_order'  => 1
                 ];
@@ -249,7 +249,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'manufacturer_id',
-                    'value'       => 5,
+                    'value'       => '5',
                     'keyword'     => 'htc',
                     'sort_order'  => 0
                 ];
@@ -258,7 +258,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'manufacturer_id',
-                    'value'       => 7,
+                    'value'       => '7',
                     'keyword'     => 'hewlett-packard',
                     'sort_order'  => 0
                 ];
@@ -267,7 +267,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'manufacturer_id',
-                    'value'       => 6,
+                    'value'       => '6',
                     'keyword'     => 'palm',
                     'sort_order'  => 0
                 ];
@@ -276,7 +276,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'manufacturer_id',
-                    'value'       => 10,
+                    'value'       => '10',
                     'keyword'     => 'sony',
                     'sort_order'  => 0
                 ];
@@ -285,7 +285,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'manufacturer_id',
-                    'value'       => 9,
+                    'value'       => '9',
                     'keyword'     => 'canon',
                     'sort_order'  => 0
                 ];
@@ -294,7 +294,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'manufacturer_id',
-                    'value'       => 8,
+                    'value'       => '8',
                     'keyword'     => 'apple',
                     'sort_order'  => 0
                 ];
@@ -304,7 +304,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'path',
-                    'value'       => 30,
+                    'value'       => '30',
                     'keyword'     => 'printer',
                     'sort_order'  => 0
                 ];
@@ -331,7 +331,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'path',
-                    'value'       => 25,
+                    'value'       => '25',
                     'keyword'     => 'component',
                     'sort_order'  => 0
                 ];
@@ -349,7 +349,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'path',
-                    'value'       => 33,
+                    'value'       => '33',
                     'keyword'     => 'cameras',
                     'sort_order'  => 0
                 ];
@@ -412,7 +412,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'path',
-                    'value'       => 20,
+                    'value'       => '20',
                     'keyword'     => 'desktops',
                     'sort_order'  => 0
                 ];
@@ -421,7 +421,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'path',
-                    'value'       => 18,
+                    'value'       => '18',
                     'keyword'     => 'laptop-notebook',
                     'sort_order'  => 0
                 ];
@@ -448,7 +448,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'path',
-                    'value'       => 34,
+                    'value'       => '34',
                     'keyword'     => 'mp3-players',
                     'sort_order'  => 0
                 ];
@@ -628,7 +628,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'path',
-                    'value'       => 24,
+                    'value'       => '24',
                     'keyword'     => 'smartphone',
                     'sort_order'  => 0
                 ];
@@ -637,7 +637,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'path',
-                    'value'       => 17,
+                    'value'       => '17',
                     'keyword'     => 'software',
                     'sort_order'  => 0
                 ];
@@ -646,7 +646,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'path',
-                    'value'       => 57,
+                    'value'       => '57',
                     'keyword'     => 'tablet',
                     'sort_order'  => 0
                 ];
@@ -656,7 +656,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'information_id',
-                    'value'       => 1,
+                    'value'       => '1',
                     'keyword'     => 'about-us',
                     'sort_order'  => 0
                 ];
@@ -665,7 +665,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'information_id',
-                    'value'       => 2,
+                    'value'       => '2',
                     'keyword'     => 'terms',
                     'sort_order'  => 0
                 ];
@@ -674,7 +674,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'information_id',
-                    'value'       => 4,
+                    'value'       => '4',
                     'keyword'     => 'delivery',
                     'sort_order'  => 0
                 ];
@@ -683,7 +683,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     'store_id'    => 0,
                     'language_id' => 1,
                     'key'         => 'information_id',
-                    'value'       => 3,
+                    'value'       => '3',
                     'keyword'     => 'privacy',
                     'sort_order'  => 0
                 ];
@@ -748,7 +748,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                     $value = preg_replace('/[^a-zA-Z0-9_|\/\.]/', '', str_replace('|', '.', $seo_url['value']));
 
                     if ($value) {
-                        $this->db->query("INSERT INTO `" . DB_PREFIX . "seo_url` SET `store_id` = '" . (int)$seo_url['store_id'] . "', `language_id` = '" . (int)$seo_url['language_id'] . "', `key` = '" . $this->db->escape($seo_url['key']) . "', `value` = '" . (!filter_var($value, FILTER_VALIDATE_INT) ? $this->db->escape($value) : (int)$value) . "', `keyword` = '" . $this->db->escape($seo_url['keyword']) . "', `sort_order` = '" . (int)$seo_url['sort_order'] . "'");
+                        $this->db->query("INSERT INTO `" . DB_PREFIX . "seo_url` SET `store_id` = '" . (int)$seo_url['store_id'] . "', `language_id` = '" . (int)$seo_url['language_id'] . "', `key` = '" . $this->db->escape($seo_url['key']) . "', `value` = '" . $this->db->escape($value) . "', `keyword` = '" . $this->db->escape($seo_url['keyword']) . "', `sort_order` = '" . (int)$seo_url['sort_order'] . "'");
                     }
                 }
             } catch (\ErrorException $exception) {

--- a/upload/install/controller/upgrade/upgrade_9.php
+++ b/upload/install/controller/upgrade/upgrade_9.php
@@ -1,782 +1,782 @@
 <?php
 namespace Opencart\Install\Controller\Upgrade;
 class Upgrade9 extends \Opencart\System\Engine\Controller {
-	public function index(): void {
-		$this->load->language('upgrade/upgrade');
-
-		$json = [];
-		
-		// Fix: https://github.com/opencart/opencart/issues/11971
-		// Previous SEO URL from OC v3.x releases
-		$query = $this->db->query("SELECT * FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = '" . DB_DATABASE . "' AND TABLE_NAME = '" . DB_PREFIX . "seo_url' AND COLUMN_NAME = 'sort_order'");
-
-		if (!$query->num_rows) {
-			$this->db->query("DROP TABLE IF EXISTS `" . DB_PREFIX . "seo_url`");
-
-			// It makes mass changes to the DB by creating tables that are not in the current db, changes the charset and DB engine to the SQL schema.
-			try {
-				// Structure
-				$this->load->helper('db_schema');
-
-				$tables = oc_db_schema();
-
-				foreach ($tables as $table) {
-					if ($table['name'] == 'seo_url') {
-						$table_query = $this->db->query("SELECT * FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = '" . DB_DATABASE . "' AND TABLE_NAME = '" . DB_PREFIX . $table['name'] . "'");
-
-						if (!$table_query->num_rows) {
-							$sql = "CREATE TABLE `" . DB_PREFIX . $table['name'] . "` (" . "\n";
-
-							foreach ($table['field'] as $field) {
-								$sql .= "  `" . $field['name'] . "` " . $field['type'] . (!empty($field['not_null']) ? " NOT NULL" : "") . (isset($field['default']) ? " DEFAULT '" . $this->db->escape($field['default']) . "'" : "") . (!empty($field['auto_increment']) ? " AUTO_INCREMENT" : "") . ",\n";
-							}
-
-							if (isset($table['primary'])) {
-								$primary_data = [];
-
-								foreach ($table['primary'] as $primary) {
-									$primary_data[] = "`" . $primary . "`";
-								}
-
-								$sql .= " PRIMARY KEY (" . implode(",", $primary_data) . "),\n";
-							}
-
-							if (isset($table['index'])) {
-								foreach ($table['index'] as $index) {
-									$index_data = [];
-
-									foreach ($index['key'] as $key) {
-										$index_data[] = "`" . $key . "`";
-									}
-
-									$sql .= " KEY `" . $index['name'] . "` (" . implode(",", $index_data) . "),\n";
-								}
-							}
-
-							$sql = rtrim($sql, ",\n") . "\n";
-							$sql .= ") ENGINE=" . $table['engine'] . " CHARSET=" . $table['charset'] . " COLLATE=" . $table['collate'] . ";\n";
-
-							$this->db->query($sql);
-						}
-					}
-				}
-
-				$seo_urls = [];
-
-				// product_id
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'product_id',
-					'value'       => 47,
-					'keyword'     => 'hp-lp3065',
-					'sort_order'  => 1
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'product_id',
-					'value'       => 48,
-					'keyword'     => 'ipod-classic',
-					'sort_order'  => 1
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'product_id',
-					'value'       => 28,
-					'keyword'     => 'htc-touch-hd',
-					'sort_order'  => 1
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'product_id',
-					'value'       => 43,
-					'keyword'     => 'macbook',
-					'sort_order'  => 1
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'product_id',
-					'value'       => 44,
-					'keyword'     => 'macbook-air',
-					'sort_order'  => 1
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'product_id',
-					'value'       => 45,
-					'keyword'     => 'macbook-pro',
-					'sort_order'  => 1
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'product_id',
-					'value'       => 30,
-					'keyword'     => 'canon-eos-5d',
-					'sort_order'  => 1
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'product_id',
-					'value'       => 31,
-					'keyword'     => 'nikon-d300',
-					'sort_order'  => 1
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'product_id',
-					'value'       => 29,
-					'keyword'     => 'palm-treo-pro',
-					'sort_order'  => 1
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'product_id',
-					'value'       => 35,
-					'keyword'     => 'product-8',
-					'sort_order'  => 1
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'product_id',
-					'value'       => 49,
-					'keyword'     => 'samsung-galaxy-tab-10-1',
-					'sort_order'  => 1
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'product_id',
-					'value'       => 33,
-					'keyword'     => 'samsung-syncmaster-941bw',
-					'sort_order'  => 1
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'product_id',
-					'value'       => 46,
-					'keyword'     => 'sony-vaio',
-					'sort_order'  => 1
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'product_id',
-					'value'       => 41,
-					'keyword'     => 'imac',
-					'sort_order'  => 1
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'product_id',
-					'value'       => 40,
-					'keyword'     => 'iphone',
-					'sort_order'  => 1
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'product_id',
-					'value'       => 36,
-					'keyword'     => 'ipod-nano',
-					'sort_order'  => 1
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'product_id',
-					'value'       => 34,
-					'keyword'     => 'ipod-shuffle',
-					'sort_order'  => 1
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'product_id',
-					'value'       => 32,
-					'keyword'     => 'ipod-touch',
-					'sort_order'  => 1
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'product_id',
-					'value'       => 50,
-					'keyword'     => 'apple-4',
-					'sort_order'  => 1
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'product_id',
-					'value'       => 42,
-					'keyword'     => 'apple-cinema',
-					'sort_order'  => 1
-				];
-
-				// manufacturer_id
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'manufacturer_id',
-					'value'       => 5,
-					'keyword'     => 'htc',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'manufacturer_id',
-					'value'       => 7,
-					'keyword'     => 'hewlett-packard',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'manufacturer_id',
-					'value'       => 6,
-					'keyword'     => 'palm',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'manufacturer_id',
-					'value'       => 10,
-					'keyword'     => 'sony',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'manufacturer_id',
-					'value'       => 9,
-					'keyword'     => 'canon',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'manufacturer_id',
-					'value'       => 8,
-					'keyword'     => 'apple',
-					'sort_order'  => 0
-				];
-
-				// path
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => 30,
-					'keyword'     => 'printer',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => '20_27',
-					'keyword'     => 'desktops/mac',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => '20_26',
-					'keyword'     => 'desktops/pc',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => 25,
-					'keyword'     => 'component',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => '25_29',
-					'keyword'     => 'component/mouse',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => 33,
-					'keyword'     => 'cameras',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => '25_28',
-					'keyword'     => 'component/monitor',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => '25_28_35',
-					'keyword'     => 'component/monitor/test-1',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => '25_28_36',
-					'keyword'     => 'component/monitor/test-2',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => '25_30',
-					'keyword'     => 'component/printers',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => '25_31',
-					'keyword'     => 'component/scanners',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => '25_32',
-					'keyword'     => 'component/web-camera',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => 20,
-					'keyword'     => 'desktops',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => 18,
-					'keyword'     => 'laptop-notebook',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => '18_46',
-					'keyword'     => 'laptop-notebook/macs',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => '18_45',
-					'keyword'     => 'laptop-notebook/windows',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => 34,
-					'keyword'     => 'mp3-players',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => '34_43',
-					'keyword'     => 'mp3-players/test-11',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => '34_44',
-					'keyword'     => 'mp3-players/test-12',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => '34_47',
-					'keyword'     => 'mp3-players/test-15',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => '34_48',
-					'keyword'     => 'mp3-players/test-16',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => '34_49',
-					'keyword'     => 'mp3-players/test-17',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => '34_50',
-					'keyword'     => 'mp3-players/test-18',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => '34_51',
-					'keyword'     => 'mp3-players/test-19',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => '34_52',
-					'keyword'     => 'mp3-players/test-20',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => '34_52_58',
-					'keyword'     => 'mp3-players/test-20/test-25',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => '34_53',
-					'keyword'     => 'mp3-players/test-21',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => '34_54',
-					'keyword'     => 'mp3-players/test-22',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => '34_55',
-					'keyword'     => 'mp3-players/test-23',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => '34_56',
-					'keyword'     => 'mp3-players/test-24',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => '34_38',
-					'keyword'     => 'mp3-players/test-4',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => '34_37',
-					'keyword'     => 'mp3-players/test-5',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => '34_39',
-					'keyword'     => 'mp3-players/test-6',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => '34_40',
-					'keyword'     => 'mp3-players/test-7',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => '34_41',
-					'keyword'     => 'mp3-players/test-8',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => '34_42',
-					'keyword'     => 'mp3-players/test-9',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => 24,
-					'keyword'     => 'smartphone',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => 17,
-					'keyword'     => 'software',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'path',
-					'value'       => 57,
-					'keyword'     => 'tablet',
-					'sort_order'  => 0
-				];
-
-				// information_id
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'information_id',
-					'value'       => 1,
-					'keyword'     => 'about-us',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'information_id',
-					'value'       => 2,
-					'keyword'     => 'terms',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'information_id',
-					'value'       => 4,
-					'keyword'     => 'delivery',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'information_id',
-					'value'       => 3,
-					'keyword'     => 'privacy',
-					'sort_order'  => 0
-				];
-
-				// language
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'language',
-					'value'       => 'en-gb',
-					'keyword'     => 'en-gb',
-					'sort_order'  => -2
-				];
-
-				// route
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'route',
-					'value'       => 'information/information.info',
-					'keyword'     => 'info',
-					'sort_order'  => 0
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'route',
-					'value'       => 'information/information',
-					'keyword'     => 'information',
-					'sort_order'  => -1
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'route',
-					'value'       => 'product/product',
-					'keyword'     => 'product',
-					'sort_order'  => -1
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'route',
-					'value'       => 'product/category',
-					'keyword'     => 'catalog',
-					'sort_order'  => -1
-				];
-
-				$seo_urls[] = [
-					'store_id'    => 0,
-					'language_id' => 1,
-					'key'         => 'route',
-					'value'       => 'product/manufacturer',
-					'keyword'     => 'brands',
-					'sort_order'  => -1
-				];
-
-				foreach ($seo_urls as $seo_url) {
-					if (!filter_var($seo_url['value'], FILTER_VALIDATE_INT)) {
-						$value = $this->db->escape($seo_url['value']);
-					} else {
-						$value = (int)$seo_url['value'];
-					}
-
-					$this->db->query("INSERT INTO `" . DB_PREFIX . "seo_url` SET `store_id` = '" . (int)$seo_url['store_id'] . "', `language_id` = '" . (int)$seo_url['language_id'] . "', `key` = '" . $this->db->escape($seo_url['key']) . "', `value` = '" . $value . "', `keyword` = '" . $this->db->escape($seo_url['keyword']) . "', `sort_order` = '" . (int)$seo_url['sort_order'] . "'");
-				}
-			} catch (\ErrorException $exception) {
-				$json['error'] = sprintf($this->language->get('error_exception'), $exception->getCode(), $exception->getMessage(), $exception->getFile(), $exception->getLine());
-			}
-		}
-
-		// Fix https://github.com/opencart/opencart/issues/11594
-		$this->db->query("UPDATE `" . DB_PREFIX . "layout_route` SET `route` = REPLACE(`route`, '|', '.')");
-		$this->db->query("UPDATE `" . DB_PREFIX . "seo_url` SET `value` = REPLACE(`value`, '|', '.') WHERE `key` = 'route'");
-		$this->db->query("UPDATE `" . DB_PREFIX . "event` SET `trigger` = REPLACE(`trigger`, '|', '.'), `action` = REPLACE(`action`, '|', '.')");
-		$this->db->query("UPDATE `" . DB_PREFIX . "banner_image` SET `link` = REPLACE(`link`, '|', '.')");
-
-		if (!$json) {
-			$json['success'] = $this->language->get('text_success');
-
-			$url = '';
-
-			if (isset($this->request->get['admin'])) {
-				$url .= '&admin=' . $this->request->get['admin'];
-			}
-
-			$json['redirect'] = $this->url->link('install/step_4', $url, true);
-		}
-
-		$this->response->addHeader('Content-Type: application/json');
-		$this->response->setOutput(json_encode($json));
-	}
+    public function index(): void {
+        $this->load->language('upgrade/upgrade');
+
+        $json = [];
+
+        // Fix: https://github.com/opencart/opencart/issues/11971
+        // Previous SEO URL from OC v3.x releases
+        $query = $this->db->query("SELECT * FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = '" . DB_DATABASE . "' AND TABLE_NAME = '" . DB_PREFIX . "seo_url' AND COLUMN_NAME = 'sort_order'");
+
+        if (!$query->num_rows) {
+            $this->db->query("DROP TABLE IF EXISTS `" . DB_PREFIX . "seo_url`");
+
+            // It makes mass changes to the DB by creating tables that are not in the current db, changes the charset and DB engine to the SQL schema.
+            try {
+                // Structure
+                $this->load->helper('db_schema');
+
+                $tables = oc_db_schema();
+
+                foreach ($tables as $table) {
+                    if ($table['name'] == 'seo_url') {
+                        $table_query = $this->db->query("SELECT * FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = '" . DB_DATABASE . "' AND TABLE_NAME = '" . DB_PREFIX . $table['name'] . "'");
+
+                        if (!$table_query->num_rows) {
+                            $sql = "CREATE TABLE `" . DB_PREFIX . $table['name'] . "` (" . "\n";
+
+                            foreach ($table['field'] as $field) {
+                                $sql .= "  `" . $field['name'] . "` " . $field['type'] . (!empty($field['not_null']) ? " NOT NULL" : "") . (isset($field['default']) ? " DEFAULT '" . $this->db->escape($field['default']) . "'" : "") . (!empty($field['auto_increment']) ? " AUTO_INCREMENT" : "") . ",\n";
+                            }
+
+                            if (isset($table['primary'])) {
+                                $primary_data = [];
+
+                                foreach ($table['primary'] as $primary) {
+                                    $primary_data[] = "`" . $primary . "`";
+                                }
+
+                                $sql .= " PRIMARY KEY (" . implode(",", $primary_data) . "),\n";
+                            }
+
+                            if (isset($table['index'])) {
+                                foreach ($table['index'] as $index) {
+                                    $index_data = [];
+
+                                    foreach ($index['key'] as $key) {
+                                        $index_data[] = "`" . $key . "`";
+                                    }
+
+                                    $sql .= " KEY `" . $index['name'] . "` (" . implode(",", $index_data) . "),\n";
+                                }
+                            }
+
+                            $sql = rtrim($sql, ",\n") . "\n";
+                            $sql .= ") ENGINE=" . $table['engine'] . " CHARSET=" . $table['charset'] . " COLLATE=" . $table['collate'] . ";\n";
+
+                            $this->db->query($sql);
+                        }
+                    }
+                }
+
+                $seo_urls = [];
+
+                // product_id
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'product_id',
+                    'value'       => 47,
+                    'keyword'     => 'hp-lp3065',
+                    'sort_order'  => 1
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'product_id',
+                    'value'       => 48,
+                    'keyword'     => 'ipod-classic',
+                    'sort_order'  => 1
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'product_id',
+                    'value'       => 28,
+                    'keyword'     => 'htc-touch-hd',
+                    'sort_order'  => 1
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'product_id',
+                    'value'       => 43,
+                    'keyword'     => 'macbook',
+                    'sort_order'  => 1
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'product_id',
+                    'value'       => 44,
+                    'keyword'     => 'macbook-air',
+                    'sort_order'  => 1
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'product_id',
+                    'value'       => 45,
+                    'keyword'     => 'macbook-pro',
+                    'sort_order'  => 1
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'product_id',
+                    'value'       => 30,
+                    'keyword'     => 'canon-eos-5d',
+                    'sort_order'  => 1
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'product_id',
+                    'value'       => 31,
+                    'keyword'     => 'nikon-d300',
+                    'sort_order'  => 1
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'product_id',
+                    'value'       => 29,
+                    'keyword'     => 'palm-treo-pro',
+                    'sort_order'  => 1
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'product_id',
+                    'value'       => 35,
+                    'keyword'     => 'product-8',
+                    'sort_order'  => 1
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'product_id',
+                    'value'       => 49,
+                    'keyword'     => 'samsung-galaxy-tab-10-1',
+                    'sort_order'  => 1
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'product_id',
+                    'value'       => 33,
+                    'keyword'     => 'samsung-syncmaster-941bw',
+                    'sort_order'  => 1
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'product_id',
+                    'value'       => 46,
+                    'keyword'     => 'sony-vaio',
+                    'sort_order'  => 1
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'product_id',
+                    'value'       => 41,
+                    'keyword'     => 'imac',
+                    'sort_order'  => 1
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'product_id',
+                    'value'       => 40,
+                    'keyword'     => 'iphone',
+                    'sort_order'  => 1
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'product_id',
+                    'value'       => 36,
+                    'keyword'     => 'ipod-nano',
+                    'sort_order'  => 1
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'product_id',
+                    'value'       => 34,
+                    'keyword'     => 'ipod-shuffle',
+                    'sort_order'  => 1
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'product_id',
+                    'value'       => 32,
+                    'keyword'     => 'ipod-touch',
+                    'sort_order'  => 1
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'product_id',
+                    'value'       => 50,
+                    'keyword'     => 'apple-4',
+                    'sort_order'  => 1
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'product_id',
+                    'value'       => 42,
+                    'keyword'     => 'apple-cinema',
+                    'sort_order'  => 1
+                ];
+
+                // manufacturer_id
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'manufacturer_id',
+                    'value'       => 5,
+                    'keyword'     => 'htc',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'manufacturer_id',
+                    'value'       => 7,
+                    'keyword'     => 'hewlett-packard',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'manufacturer_id',
+                    'value'       => 6,
+                    'keyword'     => 'palm',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'manufacturer_id',
+                    'value'       => 10,
+                    'keyword'     => 'sony',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'manufacturer_id',
+                    'value'       => 9,
+                    'keyword'     => 'canon',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'manufacturer_id',
+                    'value'       => 8,
+                    'keyword'     => 'apple',
+                    'sort_order'  => 0
+                ];
+
+                // path
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => 30,
+                    'keyword'     => 'printer',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => '20_27',
+                    'keyword'     => 'desktops/mac',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => '20_26',
+                    'keyword'     => 'desktops/pc',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => 25,
+                    'keyword'     => 'component',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => '25_29',
+                    'keyword'     => 'component/mouse',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => 33,
+                    'keyword'     => 'cameras',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => '25_28',
+                    'keyword'     => 'component/monitor',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => '25_28_35',
+                    'keyword'     => 'component/monitor/test-1',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => '25_28_36',
+                    'keyword'     => 'component/monitor/test-2',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => '25_30',
+                    'keyword'     => 'component/printers',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => '25_31',
+                    'keyword'     => 'component/scanners',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => '25_32',
+                    'keyword'     => 'component/web-camera',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => 20,
+                    'keyword'     => 'desktops',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => 18,
+                    'keyword'     => 'laptop-notebook',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => '18_46',
+                    'keyword'     => 'laptop-notebook/macs',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => '18_45',
+                    'keyword'     => 'laptop-notebook/windows',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => 34,
+                    'keyword'     => 'mp3-players',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => '34_43',
+                    'keyword'     => 'mp3-players/test-11',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => '34_44',
+                    'keyword'     => 'mp3-players/test-12',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => '34_47',
+                    'keyword'     => 'mp3-players/test-15',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => '34_48',
+                    'keyword'     => 'mp3-players/test-16',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => '34_49',
+                    'keyword'     => 'mp3-players/test-17',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => '34_50',
+                    'keyword'     => 'mp3-players/test-18',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => '34_51',
+                    'keyword'     => 'mp3-players/test-19',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => '34_52',
+                    'keyword'     => 'mp3-players/test-20',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => '34_52_58',
+                    'keyword'     => 'mp3-players/test-20/test-25',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => '34_53',
+                    'keyword'     => 'mp3-players/test-21',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => '34_54',
+                    'keyword'     => 'mp3-players/test-22',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => '34_55',
+                    'keyword'     => 'mp3-players/test-23',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => '34_56',
+                    'keyword'     => 'mp3-players/test-24',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => '34_38',
+                    'keyword'     => 'mp3-players/test-4',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => '34_37',
+                    'keyword'     => 'mp3-players/test-5',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => '34_39',
+                    'keyword'     => 'mp3-players/test-6',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => '34_40',
+                    'keyword'     => 'mp3-players/test-7',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => '34_41',
+                    'keyword'     => 'mp3-players/test-8',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => '34_42',
+                    'keyword'     => 'mp3-players/test-9',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => 24,
+                    'keyword'     => 'smartphone',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => 17,
+                    'keyword'     => 'software',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'path',
+                    'value'       => 57,
+                    'keyword'     => 'tablet',
+                    'sort_order'  => 0
+                ];
+
+                // information_id
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'information_id',
+                    'value'       => 1,
+                    'keyword'     => 'about-us',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'information_id',
+                    'value'       => 2,
+                    'keyword'     => 'terms',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'information_id',
+                    'value'       => 4,
+                    'keyword'     => 'delivery',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'information_id',
+                    'value'       => 3,
+                    'keyword'     => 'privacy',
+                    'sort_order'  => 0
+                ];
+
+                // language
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'language',
+                    'value'       => 'en-gb',
+                    'keyword'     => 'en-gb',
+                    'sort_order'  => -2
+                ];
+
+                // route
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'route',
+                    'value'       => 'information/information.info',
+                    'keyword'     => 'info',
+                    'sort_order'  => 0
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'route',
+                    'value'       => 'information/information',
+                    'keyword'     => 'information',
+                    'sort_order'  => -1
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'route',
+                    'value'       => 'product/product',
+                    'keyword'     => 'product',
+                    'sort_order'  => -1
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'route',
+                    'value'       => 'product/category',
+                    'keyword'     => 'catalog',
+                    'sort_order'  => -1
+                ];
+
+                $seo_urls[] = [
+                    'store_id'    => 0,
+                    'language_id' => 1,
+                    'key'         => 'route',
+                    'value'       => 'product/manufacturer',
+                    'keyword'     => 'brands',
+                    'sort_order'  => -1
+                ];
+
+                foreach ($seo_urls as $seo_url) {
+                    if (!filter_var($seo_url['value'], FILTER_VALIDATE_INT)) {
+                        $value = $this->db->escape($seo_url['value']);
+                    } else {
+                        $value = (int)$seo_url['value'];
+                    }
+
+                    $this->db->query("INSERT INTO `" . DB_PREFIX . "seo_url` SET `store_id` = '" . (int)$seo_url['store_id'] . "', `language_id` = '" . (int)$seo_url['language_id'] . "', `key` = '" . $this->db->escape($seo_url['key']) . "', `value` = '" . $value . "', `keyword` = '" . $this->db->escape($seo_url['keyword']) . "', `sort_order` = '" . (int)$seo_url['sort_order'] . "'");
+                }
+            } catch (\ErrorException $exception) {
+                $json['error'] = sprintf($this->language->get('error_exception'), $exception->getCode(), $exception->getMessage(), $exception->getFile(), $exception->getLine());
+            }
+        }
+
+        // Fix https://github.com/opencart/opencart/issues/11594
+        $this->db->query("UPDATE `" . DB_PREFIX . "layout_route` SET `route` = REPLACE(`route`, '|', '.')");
+        $this->db->query("UPDATE `" . DB_PREFIX . "seo_url` SET `value` = REPLACE(`value`, '|', '.') WHERE `key` = 'route'");
+        $this->db->query("UPDATE `" . DB_PREFIX . "event` SET `trigger` = REPLACE(`trigger`, '|', '.'), `action` = REPLACE(`action`, '|', '.')");
+        $this->db->query("UPDATE `" . DB_PREFIX . "banner_image` SET `link` = REPLACE(`link`, '|', '.')");
+
+        if (!$json) {
+            $json['success'] = $this->language->get('text_success');
+
+            $url = '';
+
+            if (isset($this->request->get['admin'])) {
+                $url .= '&admin=' . $this->request->get['admin'];
+            }
+
+            $json['redirect'] = $this->url->link('install/step_4', $url, true);
+        }
+
+        $this->response->addHeader('Content-Type: application/json');
+        $this->response->setOutput(json_encode($json));
+    }
 }

--- a/upload/install/controller/upgrade/upgrade_9.php
+++ b/upload/install/controller/upgrade/upgrade_9.php
@@ -747,6 +747,12 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                 foreach ($seo_urls as $seo_url) {
                     $value = preg_replace('/[^a-zA-Z0-9_|\/\.]/', '', str_replace('|', '.', $seo_url['value']));
 
+                    if (!filter_var($value, FILTER_VALIDATE_INT)) {
+                        $value = $this->db->escape($value);
+                    } else {
+                        $value = (int)$value;
+                    }
+
                     $this->db->query("INSERT INTO `" . DB_PREFIX . "seo_url` SET `store_id` = '" . (int)$seo_url['store_id'] . "', `language_id` = '" . (int)$seo_url['language_id'] . "', `key` = '" . $this->db->escape($seo_url['key']) . "', `value` = '" . $value . "', `keyword` = '" . $this->db->escape($seo_url['keyword']) . "', `sort_order` = '" . (int)$seo_url['sort_order'] . "'");
                 }
             } catch (\ErrorException $exception) {

--- a/upload/install/controller/upgrade/upgrade_9.php
+++ b/upload/install/controller/upgrade/upgrade_9.php
@@ -5,6 +5,758 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
 		$this->load->language('upgrade/upgrade');
 
 		$json = [];
+		
+		// Fix: https://github.com/opencart/opencart/issues/11971
+		// Previous SEO URL from OC v3.x releases
+		$query = $this->db->query("SELECT * FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = '" . DB_DATABASE . "' AND TABLE_NAME = '" . DB_PREFIX . "seo_url' AND COLUMN_NAME = 'sort_order'");
+
+		if (!$query->num_rows) {
+			$this->db->query("DROP TABLE IF EXISTS `" . DB_PREFIX . "seo_url`");
+
+			// It makes mass changes to the DB by creating tables that are not in the current db, changes the charset and DB engine to the SQL schema.
+			try {
+				// Structure
+				$this->load->helper('db_schema');
+
+				$tables = oc_db_schema();
+
+				foreach ($tables as $table) {
+					if ($table['name'] == 'seo_url') {
+						$table_query = $this->db->query("SELECT * FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = '" . DB_DATABASE . "' AND TABLE_NAME = '" . DB_PREFIX . $table['name'] . "'");
+
+						if (!$table_query->num_rows) {
+							$sql = "CREATE TABLE `" . DB_PREFIX . $table['name'] . "` (" . "\n";
+
+							foreach ($table['field'] as $field) {
+								$sql .= "  `" . $field['name'] . "` " . $field['type'] . (!empty($field['not_null']) ? " NOT NULL" : "") . (isset($field['default']) ? " DEFAULT '" . $this->db->escape($field['default']) . "'" : "") . (!empty($field['auto_increment']) ? " AUTO_INCREMENT" : "") . ",\n";
+							}
+
+							if (isset($table['primary'])) {
+								$primary_data = [];
+
+								foreach ($table['primary'] as $primary) {
+									$primary_data[] = "`" . $primary . "`";
+								}
+
+								$sql .= " PRIMARY KEY (" . implode(",", $primary_data) . "),\n";
+							}
+
+							if (isset($table['index'])) {
+								foreach ($table['index'] as $index) {
+									$index_data = [];
+
+									foreach ($index['key'] as $key) {
+										$index_data[] = "`" . $key . "`";
+									}
+
+									$sql .= " KEY `" . $index['name'] . "` (" . implode(",", $index_data) . "),\n";
+								}
+							}
+
+							$sql = rtrim($sql, ",\n") . "\n";
+							$sql .= ") ENGINE=" . $table['engine'] . " CHARSET=" . $table['charset'] . " COLLATE=" . $table['collate'] . ";\n";
+
+							$this->db->query($sql);
+						}
+					}
+				}
+
+				$seo_urls = [];
+
+				// product_id
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'product_id',
+					'value'       => 47,
+					'keyword'     => 'hp-lp3065',
+					'sort_order'  => 1
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'product_id',
+					'value'       => 48,
+					'keyword'     => 'ipod-classic',
+					'sort_order'  => 1
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'product_id',
+					'value'       => 28,
+					'keyword'     => 'htc-touch-hd',
+					'sort_order'  => 1
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'product_id',
+					'value'       => 43,
+					'keyword'     => 'macbook',
+					'sort_order'  => 1
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'product_id',
+					'value'       => 44,
+					'keyword'     => 'macbook-air',
+					'sort_order'  => 1
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'product_id',
+					'value'       => 45,
+					'keyword'     => 'macbook-pro',
+					'sort_order'  => 1
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'product_id',
+					'value'       => 30,
+					'keyword'     => 'canon-eos-5d',
+					'sort_order'  => 1
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'product_id',
+					'value'       => 31,
+					'keyword'     => 'nikon-d300',
+					'sort_order'  => 1
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'product_id',
+					'value'       => 29,
+					'keyword'     => 'palm-treo-pro',
+					'sort_order'  => 1
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'product_id',
+					'value'       => 35,
+					'keyword'     => 'product-8',
+					'sort_order'  => 1
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'product_id',
+					'value'       => 49,
+					'keyword'     => 'samsung-galaxy-tab-10-1',
+					'sort_order'  => 1
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'product_id',
+					'value'       => 33,
+					'keyword'     => 'samsung-syncmaster-941bw',
+					'sort_order'  => 1
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'product_id',
+					'value'       => 46,
+					'keyword'     => 'sony-vaio',
+					'sort_order'  => 1
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'product_id',
+					'value'       => 41,
+					'keyword'     => 'imac',
+					'sort_order'  => 1
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'product_id',
+					'value'       => 40,
+					'keyword'     => 'iphone',
+					'sort_order'  => 1
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'product_id',
+					'value'       => 36,
+					'keyword'     => 'ipod-nano',
+					'sort_order'  => 1
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'product_id',
+					'value'       => 34,
+					'keyword'     => 'ipod-shuffle',
+					'sort_order'  => 1
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'product_id',
+					'value'       => 32,
+					'keyword'     => 'ipod-touch',
+					'sort_order'  => 1
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'product_id',
+					'value'       => 50,
+					'keyword'     => 'apple-4',
+					'sort_order'  => 1
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'product_id',
+					'value'       => 42,
+					'keyword'     => 'apple-cinema',
+					'sort_order'  => 1
+				];
+
+				// manufacturer_id
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'manufacturer_id',
+					'value'       => 5,
+					'keyword'     => 'htc',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'manufacturer_id',
+					'value'       => 7,
+					'keyword'     => 'hewlett-packard',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'manufacturer_id',
+					'value'       => 6,
+					'keyword'     => 'palm',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'manufacturer_id',
+					'value'       => 10,
+					'keyword'     => 'sony',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'manufacturer_id',
+					'value'       => 9,
+					'keyword'     => 'canon',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'manufacturer_id',
+					'value'       => 8,
+					'keyword'     => 'apple',
+					'sort_order'  => 0
+				];
+
+				// path
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => 30,
+					'keyword'     => 'printer',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => '20_27',
+					'keyword'     => 'desktops/mac',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => '20_26',
+					'keyword'     => 'desktops/pc',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => 25,
+					'keyword'     => 'component',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => '25_29',
+					'keyword'     => 'component/mouse',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => 33,
+					'keyword'     => 'cameras',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => '25_28',
+					'keyword'     => 'component/monitor',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => '25_28_35',
+					'keyword'     => 'component/monitor/test-1',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => '25_28_36',
+					'keyword'     => 'component/monitor/test-2',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => '25_30',
+					'keyword'     => 'component/printers',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => '25_31',
+					'keyword'     => 'component/scanners',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => '25_32',
+					'keyword'     => 'component/web-camera',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => 20,
+					'keyword'     => 'desktops',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => 18,
+					'keyword'     => 'laptop-notebook',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => '18_46',
+					'keyword'     => 'laptop-notebook/macs',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => '18_45',
+					'keyword'     => 'laptop-notebook/windows',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => 34,
+					'keyword'     => 'mp3-players',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => '34_43',
+					'keyword'     => 'mp3-players/test-11',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => '34_44',
+					'keyword'     => 'mp3-players/test-12',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => '34_47',
+					'keyword'     => 'mp3-players/test-15',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => '34_48',
+					'keyword'     => 'mp3-players/test-16',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => '34_49',
+					'keyword'     => 'mp3-players/test-17',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => '34_50',
+					'keyword'     => 'mp3-players/test-18',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => '34_51',
+					'keyword'     => 'mp3-players/test-19',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => '34_52',
+					'keyword'     => 'mp3-players/test-20',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => '34_52_58',
+					'keyword'     => 'mp3-players/test-20/test-25',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => '34_53',
+					'keyword'     => 'mp3-players/test-21',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => '34_54',
+					'keyword'     => 'mp3-players/test-22',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => '34_55',
+					'keyword'     => 'mp3-players/test-23',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => '34_56',
+					'keyword'     => 'mp3-players/test-24',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => '34_38',
+					'keyword'     => 'mp3-players/test-4',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => '34_37',
+					'keyword'     => 'mp3-players/test-5',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => '34_39',
+					'keyword'     => 'mp3-players/test-6',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => '34_40',
+					'keyword'     => 'mp3-players/test-7',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => '34_41',
+					'keyword'     => 'mp3-players/test-8',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => '34_42',
+					'keyword'     => 'mp3-players/test-9',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => 24,
+					'keyword'     => 'smartphone',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => 17,
+					'keyword'     => 'software',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'path',
+					'value'       => 57,
+					'keyword'     => 'tablet',
+					'sort_order'  => 0
+				];
+
+				// information_id
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'information_id',
+					'value'       => 1,
+					'keyword'     => 'about-us',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'information_id',
+					'value'       => 2,
+					'keyword'     => 'terms',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'information_id',
+					'value'       => 4,
+					'keyword'     => 'delivery',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'information_id',
+					'value'       => 3,
+					'keyword'     => 'privacy',
+					'sort_order'  => 0
+				];
+
+				// language
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'language',
+					'value'       => 'en-gb',
+					'keyword'     => 'en-gb',
+					'sort_order'  => -2
+				];
+
+				// route
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'route',
+					'value'       => 'information/information.info',
+					'keyword'     => 'info',
+					'sort_order'  => 0
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'route',
+					'value'       => 'information/information',
+					'keyword'     => 'information',
+					'sort_order'  => -1
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'route',
+					'value'       => 'product/product',
+					'keyword'     => 'product',
+					'sort_order'  => -1
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'route',
+					'value'       => 'product/category',
+					'keyword'     => 'catalog',
+					'sort_order'  => -1
+				];
+
+				$seo_urls[] = [
+					'store_id'    => 0,
+					'language_id' => 1,
+					'key'         => 'route',
+					'value'       => 'product/manufacturer',
+					'keyword'     => 'brands',
+					'sort_order'  => -1
+				];
+
+				foreach ($seo_urls as $seo_url) {
+					if (!filter_var($seo_url['value'], FILTER_VALIDATE_INT)) {
+						$value = $this->db->escape($seo_url['value']);
+					} else {
+						$value = (int)$seo_url['value'];
+					}
+
+					$this->db->query("INSERT INTO `" . DB_PREFIX . "seo_url` SET `store_id` = '" . (int)$seo_url['store_id'] . "', `language_id` = '" . (int)$seo_url['language_id'] . "', `key` = '" . $this->db->escape($seo_url['key']) . "', `value` = '" . $value . "', `keyword` = '" . $this->db->escape($seo_url['keyword']) . "', `sort_order` = '" . (int)$seo_url['sort_order'] . "'");
+				}
+			} catch (\ErrorException $exception) {
+				$json['error'] = sprintf($this->language->get('error_exception'), $exception->getCode(), $exception->getMessage(), $exception->getFile(), $exception->getLine());
+			}
+		}
 
 		// Fix https://github.com/opencart/opencart/issues/11594
 		$this->db->query("UPDATE `" . DB_PREFIX . "layout_route` SET `route` = REPLACE(`route`, '|', '.')");

--- a/upload/install/controller/upgrade/upgrade_9.php
+++ b/upload/install/controller/upgrade/upgrade_9.php
@@ -746,14 +746,10 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
 
                 foreach ($seo_urls as $seo_url) {
                     $value = preg_replace('/[^a-zA-Z0-9_|\/\.]/', '', str_replace('|', '.', $seo_url['value']));
-
-                    if (!filter_var($value, FILTER_VALIDATE_INT)) {
-                        $value = $this->db->escape($value);
-                    } else {
-                        $value = (int)$value;
+                    
+                    if ($value) {
+                        $this->db->query("INSERT INTO `" . DB_PREFIX . "seo_url` SET `store_id` = '" . (int)$seo_url['store_id'] . "', `language_id` = '" . (int)$seo_url['language_id'] . "', `key` = '" . $this->db->escape($seo_url['key']) . "', `value` = '" . (!filter_var($value, FILTER_VALIDATE_INT) ? $value : (int)$value) . "', `keyword` = '" . $this->db->escape($seo_url['keyword']) . "', `sort_order` = '" . (int)$seo_url['sort_order'] . "'");
                     }
-
-                    $this->db->query("INSERT INTO `" . DB_PREFIX . "seo_url` SET `store_id` = '" . (int)$seo_url['store_id'] . "', `language_id` = '" . (int)$seo_url['language_id'] . "', `key` = '" . $this->db->escape($seo_url['key']) . "', `value` = '" . $value . "', `keyword` = '" . $this->db->escape($seo_url['keyword']) . "', `sort_order` = '" . (int)$seo_url['sort_order'] . "'");
                 }
             } catch (\ErrorException $exception) {
                 $json['error'] = sprintf($this->language->get('error_exception'), $exception->getCode(), $exception->getMessage(), $exception->getFile(), $exception->getLine());

--- a/upload/install/controller/upgrade/upgrade_9.php
+++ b/upload/install/controller/upgrade/upgrade_9.php
@@ -745,11 +745,7 @@ class Upgrade9 extends \Opencart\System\Engine\Controller {
                 ];
 
                 foreach ($seo_urls as $seo_url) {
-                    if (!filter_var($seo_url['value'], FILTER_VALIDATE_INT)) {
-                        $value = $this->db->escape($seo_url['value']);
-                    } else {
-                        $value = (int)$seo_url['value'];
-                    }
+                    $value = preg_replace('/[^a-zA-Z0-9_|\/\.]/', '', str_replace('|', '.', $seo_url['value']));
 
                     $this->db->query("INSERT INTO `" . DB_PREFIX . "seo_url` SET `store_id` = '" . (int)$seo_url['store_id'] . "', `language_id` = '" . (int)$seo_url['language_id'] . "', `key` = '" . $this->db->escape($seo_url['key']) . "', `value` = '" . $value . "', `keyword` = '" . $this->db->escape($seo_url['keyword']) . "', `sort_order` = '" . (int)$seo_url['sort_order'] . "'");
                 }


### PR DESCRIPTION
Since new database fields are involved, prior versions than OC 4 will not succeed to manage their SEOs in their admin panel. Therefore, since the database fields have been recreated by design between these two versions, we need to handle these fields and new values. No else statement is necessary to replace: '|' to: '.' since the server can already take care of it whether these criteria are found or not.