### PR TITLE
Removed trial_remaining field - catalog/controller/cron/subscription.php file

### DIFF
--- a/upload/catalog/controller/cron/subscription.php
+++ b/upload/catalog/controller/cron/subscription.php
@@ -61,7 +61,7 @@ class Subscription extends \Opencart\System\Engine\Controller {
                                             $subscription_info = $this->model_account_subscription->getSubscription($subscription['subscription_id']);
 
                                             if ($subscription_info) {
-                                                $this->model_account_subscription->addTransaction($subscription['subscription_id'], $subscription['order_id'], $this->language->get('text_success'), $amount, $subscription_info['type'], $subscription_info['payment_method'], $subscription_info['payment_code']);
+                                                $this->model_account_subscription->addTransaction($subscription['subscription_id'], $subscription['order_id'], $subscription_info['transaction_id'], $this->language->get('text_success'), $amount, $subscription_info['type'], $subscription_info['payment_method'], $subscription_info['payment_code'], date('Y-m-d H:i:s'));
                                             }
                                         }
                                     }

--- a/upload/catalog/controller/cron/subscription.php
+++ b/upload/catalog/controller/cron/subscription.php
@@ -37,7 +37,7 @@ class Subscription extends \Opencart\System\Engine\Controller {
 
                             // Transaction
                             if ($this->config->get('config_subscription_active_status_id') == $subscription_status_id) {
-                                if ($result['trial_duration'] > 0) {
+                                if ($result['trial_status'] && $result['trial_duration'] > 0) {
                                     $date_next = date('Y-m-d', strtotime('+' . $result['trial_cycle'] . ' ' . $result['trial_frequency']));
                                 } elseif ($result['duration'] > 0) {
                                     $date_next = date('Y-m-d', strtotime('+' . $result['cycle'] . ' ' . $result['frequency']));

--- a/upload/catalog/controller/cron/subscription.php
+++ b/upload/catalog/controller/cron/subscription.php
@@ -16,9 +16,9 @@ class Subscription extends \Opencart\System\Engine\Controller {
 
         if ($results) {
             foreach ($results as $result) {
-                if ($result['trial_status'] && (!$result['trial_duration'] || $result['trial_remaining'])) {
+                if ($result['trial_status'] && $result['trial_duration'] > 0) {
                     $amount = $result['trial_price'];
-                } elseif (!$result['duration'] || $result['remaining']) {
+                } elseif ($result['duration'] > 0) {
                     $amount = $result['price'];
                 }
 
@@ -37,9 +37,9 @@ class Subscription extends \Opencart\System\Engine\Controller {
 
                             // Transaction
                             if ($this->config->get('config_subscription_active_status_id') == $subscription_status_id) {
-                                if ($result['trial_duration'] && $result['trial_remaining']) {
+                                if ($result['trial_duration'] > 0) {
                                     $date_next = date('Y-m-d', strtotime('+' . $result['trial_cycle'] . ' ' . $result['trial_frequency']));
-                                } elseif ($result['duration'] && $result['remaining']) {
+                                } elseif ($result['duration'] > 0) {
                                     $date_next = date('Y-m-d', strtotime('+' . $result['cycle'] . ' ' . $result['frequency']));
                                 }
 
@@ -87,21 +87,6 @@ class Subscription extends \Opencart\System\Engine\Controller {
                 // History
                 if ($result['subscription_status_id'] != $subscription_status_id) {
                     $this->model_checkout_subscription->addHistory($result['subscription_id'], $subscription_status_id, 'payment extension ' . $result['payment_code'] . ' could not be loaded', true);
-                }
-
-                // Success
-                if ($this->config->get('config_subscription_active_status_id') == $subscription_status_id) {
-                    // Trial
-                    if ($result['trial_status'] && (!$result['trial_duration'] || $result['trial_remaining'])) {
-                        if ($result['trial_duration'] && $result['trial_remaining']) {
-                            $this->model_account_subscription->editTrialRemaining($result['subscription_id'], $result['trial_remaining'] - 1);
-                        }
-                    } elseif (!$result['duration'] || $result['remaining']) {
-                        // Subscription
-                        if ($result['duration'] && $result['remaining']) {
-                            $this->model_account_subscription->editRemaining($result['subscription_id'], $result['remaining'] - 1);
-                        }
-                    }
                 }
             }
         }


### PR DESCRIPTION
Does not exist on the database. As per this commit solution: https://github.com/opencart/opencart/pull/11994/commits/9b2e9af7ce0b65309491ecffdfe78969fb7541fe , the $remaining value must only be passed within the addSubscriptionTransaction() method in order for an extension to take care of the rest with the specified value of 0 when promotional features are involved. Therefore, since the cron/subscription controller is unable to identify the trial_remaining and remaining field, the cron cycle will never complete without this fix.

Furthermore, the trial_duration and duration fields do need to be above 0 since the trial_duration in the admin subscription plans validate method is already verified. Therefore, validating a trial_duration and a duration of a value 0 to return a trial amount or a full subscription's amount would not return the expected results, since the amount must be validated to a maximum extent of a year, not as an unlimited value as, again, the admin subscription plans already validates the trial_duraiton field on anyhow.