### PR TITLE
Removed trial_remaining field - admin/model/sale/subscription.php file

### DIFF
--- a/upload/admin/model/sale/subscription.php
+++ b/upload/admin/model/sale/subscription.php
@@ -12,6 +12,14 @@ class Subscription extends \Opencart\System\Engine\Model {
 	public function editSubscriptionPlan(int $subscription_id, int $subscription_plan_id): void {
 		$this->db->query("UPDATE `" . DB_PREFIX . "subscription` SET `subscription_plan_id` = '" . (int)$subscription_plan_id . "' WHERE `subscription_id` = '" . (int)$subscription_id . "'");
 	}
+	
+	public function editRemaining(int $subscription_id, int $remaining): void {
+		$this->db->query("UPDATE `" . DB_PREFIX . "subscription` SET `remaining` = '" .  (int)$remaining .  "' WHERE `subscription_id` = '" . (int)$subscription_id . "'");
+	}
+
+	public function editTrialRemaining(int $subscription_id, int $trial_remaining): void {
+		$this->db->query("UPDATE `" . DB_PREFIX . "subscription` SET `trial_remaining` = '" .  (int)$trial_remaining .  "' WHERE `subscription_id` = '" . (int)$subscription_id . "'");
+	}
 
 	public function editDateNext(int $subscription_id, string $date_next): void {
 		$this->db->query("UPDATE `" . DB_PREFIX . "subscription` SET `date_next` = '" . $this->db->escape($date_next) . "' WHERE `subscription_id` = '" . (int)$subscription_id . "'");

--- a/upload/admin/model/sale/subscription.php
+++ b/upload/admin/model/sale/subscription.php
@@ -13,14 +13,6 @@ class Subscription extends \Opencart\System\Engine\Model {
 		$this->db->query("UPDATE `" . DB_PREFIX . "subscription` SET `subscription_plan_id` = '" . (int)$subscription_plan_id . "' WHERE `subscription_id` = '" . (int)$subscription_id . "'");
 	}
 
-	public function editRemaining(int $subscription_id, int $remaining): void {
-		$this->db->query("UPDATE `" . DB_PREFIX . "subscription` SET `remaining` = '" .  (int)$remaining .  "' WHERE `subscription_id` = '" . (int)$subscription_id . "'");
-	}
-
-	public function editTrialRemaining(int $subscription_id, int $trial_remaining): void {
-		$this->db->query("UPDATE `" . DB_PREFIX . "subscription` SET `trial_remaining` = '" .  (int)$trial_remaining .  "' WHERE `subscription_id` = '" . (int)$subscription_id . "'");
-	}
-
 	public function editDateNext(int $subscription_id, string $date_next): void {
 		$this->db->query("UPDATE `" . DB_PREFIX . "subscription` SET `date_next` = '" . $this->db->escape($date_next) . "' WHERE `subscription_id` = '" . (int)$subscription_id . "'");
 	}

--- a/upload/admin/model/sale/subscription.php
+++ b/upload/admin/model/sale/subscription.php
@@ -6,7 +6,7 @@ class Subscription extends \Opencart\System\Engine\Model {
 	}
 
 	public function editPaymentMethod(int $subscription_id, int $customer_payment_id): void {
-		$this->db->query("UPDATE `" . DB_PREFIX . "subscription` SET `customer_payment_id ` = '" . (int)$customer_payment_id . "' WHERE `subscription_id` = '" . (int)$subscription_id . "'");
+		$this->db->query("UPDATE `" . DB_PREFIX . "subscription` SET `customer_payment_id` = '" . (int)$customer_payment_id . "' WHERE `subscription_id` = '" . (int)$subscription_id . "'");
 	}
 	
 	public function editSubscriptionPlan(int $subscription_id, int $subscription_plan_id): void {


### PR DESCRIPTION
Does not exist on the database. The remaining event must be used by transactions in order for an extension to make the next move as per this detailed explanation: https://github.com/opencart/opencart/pull/12003#issue-1456937274 .