### PR TITLE
Fix undefined function customer.php and missing comments in history and order details payment_method.twig

### DIFF
--- a/upload/admin/controller/customer/customer.php
+++ b/upload/admin/controller/customer/customer.php
@@ -698,15 +698,15 @@ class Customer extends \Opencart\System\Engine\Controller {
 					$json['error']['address_' . $key . '_firstname'] = $this->language->get('error_firstname');
 				}
 
-				if ((\Opencart\System\oc_strlen($value['lastname']) < 1) || (\Opencart\System\oc_strlen($value['lastname']) > 32)) {
+				if ((oc_strlen($value['lastname']) < 1) || (oc_strlen($value['lastname']) > 32)) {
 					$json['error']['address_' . $key . '_lastname'] = $this->language->get('error_lastname');
 				}
 
-				if ((\Opencart\System\oc_strlen($value['address_1']) < 3) || (\Opencart\System\oc_strlen($value['address_1']) > 128)) {
+				if ((oc_strlen($value['address_1']) < 3) || (oc_strlen($value['address_1']) > 128)) {
 					$json['error']['address_' . $key . '_address_1'] = $this->language->get('error_address_1');
 				}
 
-				if ((\Opencart\System\oc_strlen($value['city']) < 2) || (\Opencart\System\oc_strlen($value['city']) > 128)) {
+				if ((oc_strlen($value['city']) < 2) || (oc_strlen($value['city']) > 128)) {
 					$json['error']['address_' . $key . '_city'] = $this->language->get('error_city');
 				}
 

--- a/upload/catalog/view/template/checkout/payment_method.twig
+++ b/upload/catalog/view/template/checkout/payment_method.twig
@@ -159,6 +159,7 @@ $('#input-comment').on('keydown', function () {
 
                     if (json['success']) {
                         $('#alert').prepend('<div class="alert alert-success alert-dismissible"><i class="fa-solid fa-circle-check"></i> ' + json['success'] + ' <button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>');
+                        $('#checkout-confirm').load('index.php?route=checkout/confirm.confirm&language={{ language }}');
                     }
 
                     window.setTimeout(function () {


### PR DESCRIPTION
When I tried to add an address to a customer, I received the following in my console:

Fix for : "<b>Error</b>: Call to undefined function Opencart\System\oc_strlen() in <b>/home/opencart/htdocs/admin/controller/customer/customer.php</b> on line <b>701</b>"

I removed "Opencart\System\" from these lines and it fixed my problem.