### PR TITLE
[master] HTTP_CATALOG not defined error

### DIFF
--- a/upload/catalog/controller/mail/order.php
+++ b/upload/catalog/controller/mail/order.php
@@ -318,7 +318,11 @@ class Order extends \Opencart\System\Engine\Controller {
 			$store_url = $store_info['url'];
 		} else {
 			$store_name = html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8');
-			$store_url = HTTP_CATALOG;
+			if (!defined('HTTP_CATALOG')) {
+				$store_url = HTTP_SERVER;
+			} else {
+				$store_url = HTTP_CATALOG;
+			}
 		}
 
 		$this->load->model('localisation/language');


### PR DESCRIPTION
HTTP_CATALOG not defined error

- Plane new master install on real server
- Go to Settings, select the store, go to Mail tab, select mail function
- Go to frontend of the site and try to create order
- Go to error log and see the error

One side comment: Why after plane install no mail method is selected by default?