### PR TITLE
[master] json_decode $order_info['custom_field'] twice

### DIFF
--- a/upload/admin/controller/sale/order.php
+++ b/upload/admin/controller/sale/order.php
@@ -613,7 +613,7 @@ class Order extends \Opencart\System\Engine\Controller {
 		}
 
 		if (!empty($order_info)) {
-			$data['account_custom_field'] = json_decode($order_info['custom_field'], true);
+			$data['account_custom_field'] = $order_info['custom_field'];
 		} else {
 			$data['account_custom_field'] = [];
 		}


### PR DESCRIPTION
Resolve an error.

To reproduce:
- Plane new installation with current files from server master branch
- Create new order
- Go to admin panel and try to view the order

Error obtained:
TypeError:  json_decode(): Argument #1 ($json) must be of type string, array given
File: .../admin/controller/sale/order.php
Line: 616

Reason:
It is already decoded in model getOrder