### PR TITLE
Bug fix when trying to change banner image

### DIFF
--- a/upload/admin/view/template/design/banner_form.twig
+++ b/upload/admin/view/template/design/banner_form.twig
@@ -71,7 +71,7 @@
                             <div class="card">
 
                               <img src="{{ banner_image.thumb }}" alt="" title="" id="thumb-image-{{ language.language_id }}-{{ image_row }}" data-oc-placeholder="{{ placeholder }}" class="card-img-top"/>
-                              <input type="hidden" name="banner_image[{{ language.language_id }}][{{ image_row }}][image]" value="{{ banner_image.image }}" id="input-image-{{ language.language_id }}-{{ image_row }}"/>
+                              <input type="hidden" name="banner_image[{{ language.language_id }}][{{ image_row }}][image]" value="{{ banner_image.image }}" id="input-image-{{ language.language_id }}-{{ image_row }}-image"/>
                               <div class="card-body">
                                 <button type="button" data-oc-toggle="image" data-oc-target="#input-image-{{ language.language_id }}-{{ image_row }}-image" data-oc-thumb="#thumb-image-{{ language.language_id }}-{{ image_row }}" class="btn btn-primary btn-sm btn-block"><i class="fa-solid fa-pencil"></i> {{ button_edit }}</button>
                                 <button type="button" data-oc-toggle="clear" data-oc-target="#input-image-{{ language.language_id }}-{{ image_row }}-image" data-oc-thumb="#thumb-image-{{ language.language_id }}-{{ image_row }}" class="btn btn-warning btn-sm btn-block"><i class="fa-regular fa-trash-can"></i> {{ button_clear }}</button>


### PR DESCRIPTION
Editing a banner doesn't actually attach the new image on Opencart 4.0.1.1.

Steps to reproduce:
Go to Design > Banners > Add New, give it a name and add an image or more, then save.
Now go back and click edit banner, pick any image and click on the edit button, pick an image from the popup image manager and save the banner.

When you refresh the page, the new image was not attached as expected.
This pull request solves this issue occurring on Opencart 4.0.1.1.