### PR TITLE
white display fix

### DIFF
--- a/upload/system/library/response.php
+++ b/upload/system/library/response.php
@@ -107,6 +107,10 @@ class Response {
 			return $data;
 		}
 
+		if (ob_get_contents()) {
+			return $data;
+		}
+
 		if (connection_status()) {
 			return $data;
 		}


### PR DESCRIPTION
If the output_buffering ini directive is enabled, then headers_sent() does not work, as a result, compression works and makes a white screen if something is output before compression (error, var_dump).