### PR TITLE
Validation fixed for the custom fields in register.php and shipping_a…

### DIFF
--- a/upload/catalog/controller/checkout/register.php
+++ b/upload/catalog/controller/checkout/register.php
@@ -344,8 +344,8 @@ class Register extends \Opencart\System\Engine\Controller {
 				// Custom field validation
 				foreach ($custom_fields as $custom_field) {
 					if ($custom_field['location'] == 'address') {
-						if ($custom_field['required'] && empty($this->request->post['shipping_custom_field'][$custom_field['location']][$custom_field['custom_field_id']])) {
-							$json['error']['shipping_custom_field_' . $custom_field['custom_field_id']] = sprintf($this->language->get('error_custom_field'), $custom_field['name']);
+						if ($custom_field['required'] && empty($this->request->post['custom_field'][$custom_field['location']][$custom_field['custom_field_id']])) {
+							$json['error']['custom_field_' . $custom_field['custom_field_id']] = sprintf($this->language->get('error_custom_field'), $custom_field['name']);
 						} elseif (($custom_field['type'] == 'text') && !empty($custom_field['validation']) && !preg_match(html_entity_decode($custom_field['validation'], ENT_QUOTES, 'UTF-8'), $this->request->post['shipping_custom_field'][$custom_field['location']][$custom_field['custom_field_id']])) {
 							$json['error']['shipping_custom_field_' . $custom_field['custom_field_id']] = sprintf($this->language->get('error_regex'), $custom_field['name']);
 						}

--- a/upload/catalog/controller/checkout/shipping_address.php
+++ b/upload/catalog/controller/checkout/shipping_address.php
@@ -142,7 +142,7 @@ class ShippingAddress extends \Opencart\System\Engine\Controller {
 
 			foreach ($custom_fields as $custom_field) {
 				if ($custom_field['location'] == 'address') {
-					if ($custom_field['required'] && empty($this->request->post['custom_field'][$custom_field['custom_field_id']])) {
+					if ($custom_field['required'] && empty($this->request->post['custom_field'][$custom_field['location']][$custom_field['custom_field_id']])) {
 						$json['error']['shipping_custom_field_' . $custom_field['custom_field_id']] = sprintf($this->language->get('error_custom_field'), $custom_field['name']);
 					} elseif (($custom_field['type'] == 'text') && !empty($custom_field['validation']) && !preg_match(html_entity_decode($custom_field['validation'], ENT_QUOTES, 'UTF-8'), $this->request->post['custom_field'][$custom_field['custom_field_id']])) {
 						$json['error']['shipping_custom_field_' . $custom_field['custom_field_id']] = sprintf($this->language->get('error_regex'), $custom_field['name']);


### PR DESCRIPTION
fixing the bug where checking if the post request doesn't contain a custom_field always returns true in register.php and shipping_address.php https://github.com/opencart/opencart/issues/12217

in the register.php

`if ($custom_field['required'] && empty($this->request->post['shipping_custom_field'][$custom_field['location']][$custom_field['custom_field_id']])) {
							var_dump($this->request->post);
							$json['error']['shipping_custom_field_' . $custom_field['custom_field_id']] = sprintf($this->language->get('error_custom_field'), $custom_field['name']);
						}`
the if statement will always be true because it depends on a  `post['shipping_custom_field']` which is not sent by the client 

![image](https://user-images.githubusercontent.com/51481220/226891704-f79888a7-e183-4f1a-95a3-e94a4a194b01.png)
here the field is not empty yet the server returns that it is required 


![image](https://user-images.githubusercontent.com/51481220/226893267-f865815e-c817-4f6f-a119-0d3ea2307b34.png)

using the var_dumb() method to see what the post request looks like, I found out that there's no such as ['shipping_custom_field'] in the body of the post request which explains why the server thinks the field is always empty so replaced the request->post['shipping_custom_field'] with request->post['custom_field'] 



In shipping_address.php 
the same problem in register.php, the server sent a message saying the custom field is required even though it has input. 

The problem occurs when trying to add a new shipping address while having a custom_field in the form.
This happens because the validation if statement
  `if ($custom_field['location'] == 'address') {
					if ($custom_field['required'] && empty($this->request->post['custom_field'][$custom_field['custom_field_id']])) {
						$json['error']['shipping_custom_field_' . $custom_field['custom_field_id']] = sprintf($this->language->get('error_custom_field'), $custom_field['name']);
					}`
checks if the post['custom_field'][$custom_field['custom_field_id']] is empty which will always be empty because the post request look like this 
![image](https://user-images.githubusercontent.com/51481220/226900669-795b5680-2009-4214-8374-c67e8b0f05a9.png)

replacing 
`					if ($custom_field['required'] && empty($this->request->post['custom_field'][$custom_field['custom_field_id']])) {
`
with 
`					if ($custom_field['required'] && empty($this->request->post['custom_field'][$custom_field['location']][$custom_field['custom_field_id']])) {
`
fixed the issue 