### PR TITLE
need leading space to prevent appending to link

### DIFF
--- a/upload/catalog/language/en-gb/mail/forgotten.php
+++ b/upload/catalog/language/en-gb/mail/forgotten.php
@@ -3,4 +3,4 @@
 $_['text_subject']  = '%s - Password reset request';
 $_['text_greeting'] = 'A new password was requested for %s customer account.';
 $_['text_change']   = 'To reset your password click on the link below:';
-$_['text_ip']       = 'The IP used to make this request was:';
+$_['text_ip']       = ' The IP used to make this request was:';


### PR DESCRIPTION
Without a leading space before "the" the word "The" ends up getting appended to the reset link resulting in users clicking on it and getting an "invalid reset link" message.