### PR TITLE
Redirect to cart page after reorder

### DIFF
--- a/upload/catalog/controller/account/order.php
+++ b/upload/catalog/controller/account/order.php
@@ -432,6 +432,6 @@ class Order extends \Opencart\System\Engine\Controller {
 			}
 		}
 
-		$this->response->redirect($this->url->link('account/order.info', 'language=' . $this->config->get('config_language') . '&customer_token=' . $this->session->data['customer_token'] . '&order_id=' . $order_id));
+		$this->response->redirect($this->url->link('checkout/cart', 'language=' . $this->config->get('config_language')));
 	}
 }


### PR DESCRIPTION
we have a case, when we wanted to use "reorder" button outside the order info page, in that case, problem is, customer was redirecting to order info page after reorder. so to make reorder work from anywhere, we should redirect customer to cart page.