### PR TITLE
Remove unnecessary print_r statement from save method

### DIFF
--- a/upload/catalog/controller/checkout/payment_address.php
+++ b/upload/catalog/controller/checkout/payment_address.php
@@ -135,8 +135,6 @@ class PaymentAddress extends \Opencart\System\Engine\Controller {
 			}
 
 
-			print_r($this->request->post);
-
 			// Custom field validation
 			$this->load->model('account/custom_field');
 


### PR DESCRIPTION
The print_r() statement was added for debugging purposes and is not necessary for the functionality of the save() method. 