### PR TITLE
Fixed admin order editor incorrect error display

### DIFF
--- a/upload/catalog/controller/api/sale/order.php
+++ b/upload/catalog/controller/api/sale/order.php
@@ -241,7 +241,7 @@ class Order extends \Opencart\System\Engine\Controller {
 
 		// Payment Method
 		if (!isset($this->session->data['payment_method'])) {
-			$json['error'] = $this->language->get('error_payment_method');
+			$json['error']['payment_method'] = $this->language->get('error_payment_method');
 		}
 
 		if (!$json) {


### PR DESCRIPTION
**Steps to check error**

1. Go to 'Admin->Sales->Order'
2. Click on 'Plus Button to add order'
3. Scroll down to 'Confirm Button and click it without selecting anything'
4. See error

**Expected behavior**
It will now display 1 line understandable error


![image](https://user-images.githubusercontent.com/49372879/234779739-c26a57fc-8218-4e8b-b973-ed3106ddbac3.png)
