### PR TITLE
Check if encryption negotiation failed

### DIFF
--- a/upload/system/library/mail/smtp.php
+++ b/upload/system/library/mail/smtp.php
@@ -126,14 +126,16 @@ class Smtp extends \stdClass {
 
 				$this->handleReply($handle, 220, 'Error: STARTTLS not accepted from server!');
 
-				stream_socket_enable_crypto($handle, true, STREAM_CRYPTO_METHOD_TLS_CLIENT);
-			}
+				if (stream_socket_enable_crypto($handle, true, STREAM_CRYPTO_METHOD_TLS_CLIENT) !== true) {
+					throw new \Exception('Error: TLS could not be established!');
+				}
 
-			if (!empty($this->smtp_username) && !empty($this->smtp_password)) {
 				fputs($handle, 'EHLO ' . getenv('SERVER_NAME') . "\r\n");
 
 				$this->handleReply($handle, 250, 'Error: EHLO not accepted from server!');
+			}
 
+			if (!empty($this->smtp_username) && !empty($this->smtp_password)) {
 				fputs($handle, 'AUTH LOGIN' . "\r\n");
 
 				$this->handleReply($handle, 334, 'Error: AUTH LOGIN not accepted from server!');


### PR DESCRIPTION
If stream_socket_enable_crypto failed to negotiation encryption SMTP credentials could be sent unencrypted. Added a check to prevent this.

Also fixed the duplicate EHLO when STARTTLS isn't sent.