### PR TITLE
Improve flexbox to show button groups in product thumb

### DIFF
--- a/upload/catalog/view/stylesheet/stylesheet.css
+++ b/upload/catalog/view/stylesheet/stylesheet.css
@@ -533,7 +533,6 @@ footer h5 {
 }
 .product-thumb {
   border: 1px solid #ddd;
-  margin-bottom: 15px;
 }
 .product-thumb h4 {
   font-weight: bold;
@@ -548,12 +547,17 @@ footer h5 {
 .product-thumb .description {
   padding: 15px;
 }
-.product-thumb .button-group {
+.product-buttons {
+  border-left: 1px solid #ddd;
+  border-bottom: 1px solid #ddd;
+  border-right: 1px solid #ddd;
+  margin-bottom: 15px;
+}
+.product-buttons .button-group {
   display: flex;
-  border-top: 1px solid #ddd;
   background-color: #eee;
 }
-.product-thumb .button-group button {
+.product-buttons .button-group button {
   flex: 33%;
   border-radius: 0;
   display: inline-block;
@@ -565,13 +569,13 @@ footer h5 {
   text-align: center;
   text-transform: uppercase;
 }
-.product-thumb .button-group button:hover {
+.product-buttons .button-group button:hover {
   color: #444;
   background-color: #ddd;
   text-decoration: none;
   cursor: pointer;
 }
-.product-thumb .button-group button + button {
+.product-buttons .button-group button + button {
   border-left: 1px solid #ddd;
 }
 @media (min-width: 960px) {
@@ -587,7 +591,7 @@ footer h5 {
     flex: 75%;
     position: relative;
   }
-  .product-list .product-thumb .button-group {
+  .product-list .product-buttons .button-group {
     position: absolute;
     bottom: 0px;
     width: 100%;

--- a/upload/catalog/view/template/product/thumb.twig
+++ b/upload/catalog/view/template/product/thumb.twig
@@ -1,5 +1,5 @@
-<form method="post" data-oc-toggle="ajax" data-oc-load="{{ cart }}" data-oc-target="#header-cart">
-  <div class="product-thumb">
+<form method="post" data-oc-toggle="ajax" data-oc-load="{{ cart }}" data-oc-target="#header-cart" class="d-flex flex-column h-100">
+  <div class="product-thumb flex-fill">
     <div class="image"><a href="{{ href }}"><img src="{{ thumb }}" alt="{{ name }}" title="{{ name }}" class="img-fluid"/></a></div>
     <div class="content">
       <div class="description">
@@ -29,13 +29,15 @@
           </div>
         {% endif %}
       </div>
+    </div>
+    <input type="hidden" name="product_id" value="{{ product_id }}"/>
+    <input type="hidden" name="quantity" value="{{ minimum }}"/>
+  </div>
+  <div class="product-buttons">
       <div class="button-group">
         <button type="submit" formaction="{{ add_to_cart }}" data-bs-toggle="tooltip" title="{{ button_cart }}"><i class="fa-solid fa-shopping-cart"></i></button>
         <button type="submit" formaction="{{ add_to_wishlist }}" data-bs-toggle="tooltip" title="{{ button_wishlist }}"><i class="fa-solid fa-heart"></i></button>
         <button type="submit" formaction="{{ add_to_compare }}" data-bs-toggle="tooltip" title="{{ button_compare }}"><i class="fa-solid fa-arrow-right-arrow-left"></i></button>
       </div>
-    </div>
-    <input type="hidden" name="product_id" value="{{ product_id }}"/>
-    <input type="hidden" name="quantity" value="{{ minimum }}"/>
   </div>
 </form>


### PR DESCRIPTION
This PR adjusts the layout of `upload/catalog/view/template/product/thumb.twig`. In previous Opencart releases the product-thumb is cut off when it's content is over. Which this adjustment it will be equally sized across the entire store.

Examples:

Featured Old: 
![image](https://github.com/opencart/opencart/assets/32510006/220b4648-0300-4922-a720-aeb156e57fd6)


Featured New:
![image](https://github.com/opencart/opencart/assets/32510006/ba62d145-e020-4f40-b428-fb260cfa61b6)

Categories Old:
![image](https://github.com/opencart/opencart/assets/32510006/0e0a8472-09b6-4469-9c52-db0e8015009d)

Categories New:
![image](https://github.com/opencart/opencart/assets/32510006/edf3c801-d0b2-4b27-85e0-8a551bf9e3c2)
