### PR TITLE
Fix broken language for modules in front-end

### DIFF
--- a/upload/system/framework.php
+++ b/upload/system/framework.php
@@ -171,7 +171,8 @@ $registry->set('template', $template);
 $template->addPath(DIR_TEMPLATE);
 
 // Language
-$language = new \Opencart\System\Library\Language($config->get('language_code'));
+$language_code =  $request->get['language'] ?? $config->get('language_code');
+$language = new \Opencart\System\Library\Language($language_code);
 $registry->set('language', $language);
 $language->addPath(DIR_LANGUAGE);
 $loader->language('default');


### PR DESCRIPTION
Currently added language folders for all default extensions are not beeing recognized by Opencart.

For example:
![grafik](https://github.com/opencart/opencart/assets/32510006/acec7dd2-c85d-4a7a-b1fa-3c3eb1e18f64)

As you can see, the totals for example are still in English.

This fix checks for the language code within the framework and applies it to the language so that all language files from modules will be applied. After this fix:
![grafik](https://github.com/opencart/opencart/assets/32510006/069d785d-509c-416e-bf61-f7cd84f2f21e)


When a non valid language is specified it will fall back to the default of the store.
