### PR TITLE
Fix admin language

### DIFF
--- a/upload/admin/controller/startup/language.php
+++ b/upload/admin/controller/startup/language.php
@@ -19,7 +19,7 @@ class Language extends \Opencart\System\Engine\Controller {
 			if ($language_info['extension']) {
 				self::$extension = $language_info['extension'];
 
-				$this->language->addPath('extension/' . $language_info['extension'], DIR_EXTENSION . $language_info['extension'] . '/admin/language/');
+				$this->language->addPath(DIR_EXTENSION . $language_info['extension'] . '/admin/language/');
 			}
 
 			// Set the config language_id key

--- a/upload/system/framework.php
+++ b/upload/system/framework.php
@@ -171,7 +171,8 @@ $registry->set('template', $template);
 $template->addPath(DIR_TEMPLATE);
 
 // Language
-$language = new \Opencart\System\Library\Language($config->get('language_code'));
+$language_code =  $request->get['language'] ?? $config->get('language_code');
+$language = new \Opencart\System\Library\Language($language_code);
 $registry->set('language', $language);
 $language->addPath(DIR_LANGUAGE);
 $loader->language('default');

--- a/upload/system/framework.php
+++ b/upload/system/framework.php
@@ -171,11 +171,11 @@ $registry->set('template', $template);
 $template->addPath(DIR_TEMPLATE);
 
 // Language
-$language_code =  $request->get['language'] ?? $config->get('language_code');
+// Get is for front-end, cookie for admin, config for default
+$language_code =  $request->get['language'] ?? $request->cookie['language'] ?? $config->get('language_code');
 $language = new \Opencart\System\Library\Language($language_code);
 $registry->set('language', $language);
 $language->addPath(DIR_LANGUAGE);
-$loader->language('default');
 
 // Url
 $registry->set('url', new \Opencart\System\Library\Url($config->get('site_url')));


### PR DESCRIPTION
This PR fixes that the language of the Administration cannot be changed.

We are doing it by setting the language code in the framework itself. Since there are three different ways of getting the language code, we'll need to check for each of them indiviudally.

```php
$language_code =  $request->get['language'] ?? $request->cookie['language'] ?? $config->get('language_code');
```

`$request->get['language']` is being used in the front-end. The backend uses a cookie `$request->cookie['language']` when neither of these is specified it falls back to the default which is `$config->get('language_code')`

@danielkerr btw. what's the point of providing the language in the frontend by URL? What's wrong about a language cookie here?

Fixes: #12290 
Related to: #12353 