### PR TITLE
oc_payment_example module mktime() missing day argument, causes month to be missed

### DIFF
--- a/upload/extension/oc_payment_example/catalog/controller/payment/credit_card.php
+++ b/upload/extension/oc_payment_example/catalog/controller/payment/credit_card.php
@@ -11,7 +11,7 @@ class CreditCard extends \Opencart\System\Engine\Controller {
 			$data['months'] = [];
 
 			foreach (range(1, 12) as $month) {
-				$data['months'][] = date('m', mktime(0, 0, 0, $month));
+				$data['months'][] = date('m', mktime(0, 0, 0, $month, 1));
 			}
 
 			$data['years'] = [];


### PR DESCRIPTION
Arguments not supplied to mktime are filled in by current system values:
"Any optional arguments omitted or null will be set to the current value according to the local date and time. "

If this is run when the date is eg 30th, it will skip February as there is no such date.

https://www.php.net/manual/en/function.mktime.php

https://stackoverflow.com/questions/66851868/php-mktime-shows-2-marchs-when-i-dump-foreach-month