### PR TITLE
Change page location on admin product filter

### DIFF
--- a/upload/admin/view/template/catalog/product.twig
+++ b/upload/admin/view/template/catalog/product.twig
@@ -100,6 +100,10 @@ $('#button-filter').on('click', function () {
         url += '&filter_status=' + filter_status;
     }
 
+    var new_url = 'index.php?route=catalog/product&user_token={{ user_token }}' + url;
+
+    window.history.pushState({}, null, new_url);
+
     $('#product').load('index.php?route=catalog/product.list&user_token={{ user_token }}' + url);
 });
 


### PR DESCRIPTION
The new AJAX filter breaks page location and browser behavior.

If you refresh a page or click browser Back button you will loose current product filter.

pushState changes current location address and adds it to browser history.

This should be done for all filtered admin lists like products, reviews, customers, customer approvals, seo urls, orders

![image](https://github.com/opencart/opencart/assets/6297070/8ddb6542-cc83-4d18-8a0e-fa3aa89056da)

