### PR TITLE
optimized zone delete query

### DIFF
--- a/upload/admin/controller/localisation/zone.php
+++ b/upload/admin/controller/localisation/zone.php
@@ -402,9 +402,7 @@ class Zone extends \Opencart\System\Engine\Controller {
 		if (!$json) {
 			$this->load->model('localisation/zone');
 
-			foreach ($selected as $zone_id) {
-				$this->model_localisation_zone->deleteZone($zone_id);
-			}
+			$this->model_localisation_zone->deleteZone($selected);
 
 			$json['success'] = $this->language->get('text_success');
 		}

--- a/upload/admin/model/localisation/zone.php
+++ b/upload/admin/model/localisation/zone.php
@@ -15,8 +15,13 @@ class Zone extends \Opencart\System\Engine\Model {
 		$this->cache->delete('zone');
 	}
 
-	public function deleteZone(int $zone_id): void {
-		$this->db->query("DELETE FROM `" . DB_PREFIX . "zone` WHERE `zone_id` = '" . (int)$zone_id . "'");
+	public function deleteZone(int|array $zone_id): void {
+		if (is_array($zone_id)) {
+			$zoneIds = array_filter($zone_id, 'is_numeric');
+			$this->db->query("DELETE FROM `" . DB_PREFIX . "zone` WHERE `zone_id` in (" . implode(",", $zoneIds) . ")");
+		} else {
+			$this->db->query("DELETE FROM `" . DB_PREFIX . "zone` WHERE `zone_id` = '" . (int)$zone_id . "'");
+		}
 
 		$this->cache->delete('zone');
 	}


### PR DESCRIPTION
Optimized zone delete query
Now the delete zone may accept either int or array as $zone_id. 
On deletion of multiple zones at a time will result in database efficiency and will also be compatible for other extensions.