### PR TITLE
Extension Installer. The last installed extension should be the first…

### DIFF
--- a/upload/admin/controller/marketplace/installer.php
+++ b/upload/admin/controller/marketplace/installer.php
@@ -60,13 +60,13 @@ class Installer extends \Opencart\System\Engine\Controller {
 		if (isset($this->request->get['sort'])) {
 			$sort = $this->request->get['sort'];
 		} else {
-			$sort = 'name';
+			$sort = 'date_added';
 		}
 
 		if (isset($this->request->get['order'])) {
 			$order = $this->request->get['order'];
 		} else {
-			$order = 'ASC';
+			$order = 'DESC';
 		}
 
 		if (isset($this->request->get['page'])) {


### PR DESCRIPTION
Extension Installer. The last installed extension should be the first in the list.

If we have multiple pages of installed extensions, then each new installed extension should be searched on the pagination. We need to set default sort by date_added, and not by the name of the extension.