### PR TITLE
Added missing removal fields in upgrade/upgrade_8

### DIFF
--- a/upload/install/controller/upgrade/upgrade_8.php
+++ b/upload/install/controller/upgrade/upgrade_8.php
@@ -213,6 +213,76 @@ class Upgrade8 extends \Opencart\System\Engine\Controller {
 				'field' => 'status'
 			];
 
+			$remove[] = [
+				'table' => 'customer',
+				'field' => 'wishlist'
+			];
+
+			$remove[] = [
+				'table' => 'customer',
+				'field' => 'address_id'
+			];
+
+			$remove[] = [
+				'table' => 'product',
+				'field' => 'viewed'
+			];
+
+			$remove[] = [
+				'table' => 'seo_url',
+				'field' => 'query'
+			];
+
+			$remove[] = [
+				'table' => 'country',
+				'field' => 'address_format'
+			];
+
+			$remove[] = [
+				'table' => 'cart',
+				'field' => 'recurring_id'
+			];
+
+			$remove[] = [
+				'table' => 'subscription_plan',
+				'field' => 'trial_price'
+			];
+
+			$remove[] = [
+				'table' => 'subscription_plan',
+				'field' => 'price'
+			];
+
+			$remove[] = [
+				'table' => 'subscription_plan_description',
+				'field' => 'description'
+			];
+
+			$remove[] = [
+				'table' => 'theme',
+				'field' => 'theme'
+			];
+
+			$remove[] = [
+				'table' => 'subscription',
+				'field' => 'customer_payment_id'
+			];
+
+			$remove[] = [
+				'table' => 'subscription',
+				'field' => 'description'
+			];
+
+			$remove[] = [
+				'table' => 'subscription',
+				'field' => 'name'
+			];
+
+			$remove[] = [
+				'table' => 'subscription',
+				'field' => 'reference'
+			];
+
 			foreach ($remove as $result) {
 				$query = $this->db->query("SELECT * FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = '" . DB_DATABASE . "' AND TABLE_NAME = '" . DB_PREFIX . $result['table'] . "' AND COLUMN_NAME = '" . $result['field'] . "'");
 


### PR DESCRIPTION
The dates have now been restored in opencart-3. In OC 4.0.2.2 release, the subscription database fields have changed since previous OC 4 releases but the previous fields for the upgrade haven't been queried for removal.

If they're not added, the database fields won't be balanced when inserting new data into the database.