### PR TITLE
empty instruction on the default extensions causes a bad time

### DIFF
--- a/upload/extension/opencart/install.json
+++ b/upload/extension/opencart/install.json
@@ -2,6 +2,5 @@
   "name": "OpenCart Default Extensions",
   "version": "1.0",
   "author": "OpenCart Ltd",
-  "link": "https://www.opencart.com",
-  "instruction": "",
+  "link": "https://www.opencart.com"
 }


### PR DESCRIPTION
With an empty instruction, the extension parser has a bad time with the install.json and never loads. There needs to be another update to the opencart.ocmod as well, but I'm not sure what the policy is for outsiders proposing changes on zip files. When trying to upload the opencart.ocmod.zip, the error_install message is returned (Warning: Could not find install.json) 