### PR TITLE
Update common/cart.twig

### DIFF
--- a/upload/catalog/view/stylesheet/stylesheet.css
+++ b/upload/catalog/view/stylesheet/stylesheet.css
@@ -232,28 +232,55 @@ footer a {
 #header-cart .dropdown-menu {
   background: #eee;
   z-index: 1001;
-  min-width: 100%;
 }
-#header-cart .dropdown-menu table {
-  margin-bottom: 10px;
+.dropdown-menu-cart {
+  min-width: min(100vw, 500px) !important;
 }
-#header-cart .dropdown-menu li {
-  min-width: 427px;
-  padding: 0 10px;
+
+.cart-products {
+  display: flex;
+  flex-wrap: wrap;
+  padding: .5rem;
+  gap: 1em;
 }
-#header-cart .dropdown-menu li p {
-  margin: 20px 0;
+
+.cart-product {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 1fr 2fr 1fr 1fr 1fr;
+  gap: .5rem;
+  align-items: center;
 }
-@media (max-width: 478px) {
-  #header-cart .dropdown-menu {
-    width: 100%;
-  }
-  #header-cart .dropdown-menu li > div {
-    min-width: 100%;
-  }
+
+.cart-product-action {
+  text-align: right;
 }
-#header-cart .table-striped > tbody > tr:nth-of-type(odd) {
-  background-color: #f9f9f9;
+
+.cart-totals {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: .5rem;
+}
+.cart-total {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 3fr 1fr;
+}
+
+.cart-total-title {
+  font-weight: bold; 
+  text-align: right;
+}
+
+.cart-total-text {
+  text-align: right;
+}
+
+.cart-buttons {
+  width: 100%;
+  display: flex;
+  justify-content: end;
 }
 /* menu */
 #menu {

--- a/upload/catalog/view/template/common/cart.twig
+++ b/upload/catalog/view/template/common/cart.twig
@@ -1,14 +1,17 @@
 <div class="dropdown d-grid">
   <button type="button" data-bs-toggle="dropdown" class="btn btn-lg btn-inverse btn-block dropdown-toggle"><i class="fa-solid fa-cart-shopping"></i> {{ text_items }}</button>
-  <ul class="dropdown-menu dropdown-menu-right" style="width: 500px;">
+  <div class="dropdown-menu dropdown-menu-right dropdown-menu-cart">
     {% if products or vouchers %}
-      <li>
-        <table class="table table-sm table-striped">
-
+      <div class="cart-products">
           {% for product in products %}
-            <tr>
-              <td class="text-center">{% if product.thumb %}<a href="{{ product.href }}"><img src="{{ product.thumb }}" alt="{{ product.name }}" title="{{ product.name }}" class="img-thumbnail"/></a>{% endif %}</td>
-              <td class="text-start"><a href="{{ product.href }}">{{ product.name }}</a>
+            <div class="cart-product">
+              <div class="cart-product-image">
+                {% if product.thumb %}
+                  <a href="{{ product.href }}"><img src="{{ product.thumb }}" alt="{{ product.name }}" title="{{ product.name }}" class="img-thumbnail"/></a>
+                {% endif %}
+              </div>
+              <div class="cart-product-name">
+                <a href="{{ product.href }}">{{ product.name }}</a>
                 {% if product.option %}
                   {% for option in product.option %}
                     <br/>
@@ -23,50 +26,35 @@
                   <br/>
                   <small> - {{ text_subscription }}: {{ product.subscription }}</small>
                 {% endif %}
-              </td>
-              <td class="text-end">x {{ product.quantity }}</td>
-              <td class="text-end">{{ product.total }}</td>
-              <td class="text-end">
+              </div>
+              <div class="cart-product-quantity">x {{ product.quantity }}</div>
+              <div class="cart-product-total">{{ product.total }}</div>
+              <div class="cart-product-action">
                 <form action="{{ product_remove }}" method="post" data-oc-toggle="ajax" data-oc-load="{{ list }}" data-oc-target="#header-cart">
                   <input type="hidden" name="key" value="{{ product.cart_id }}">
                   <button type="submit" data-bs-toggle="tooltip" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-circle-xmark"></i></button>
                 </form>
-              </td>
-            </tr>
+              </div>
+            </div>
           {% endfor %}
-
-          {% for voucher in vouchers %}
-            <tr>
-              <td class="text-center"></td>
-              <td class="text-start">{{ voucher.description }}</td>
-              <td class="text-end">x&nbsp;1</td>
-              <td class="text-end">{{ voucher.amount }}</td>
-              <td class="text-end">
-                <form action="{{ voucher_remove }}" method="post" data-oc-toggle="ajax" data-oc-load="{{ list }}" data-oc-target="#header-cart">
-                  <input type="hidden" name="key" value="{{ voucher.key }}"/>
-                  <button type="submit" data-bs-toggle="tooltip" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-circle-xmark"></i></button>
-                </form>
-              </td>
-            </tr>
-          {% endfor %}
-
-        </table>
-        <div>
-          <table class="table table-sm table-bordered">
+      
+          <div class="cart-totals">
             {% for total in totals %}
-              <tr>
-                <td class="text-end"><strong>{{ total.title }}</strong></td>
-                <td class="text-end">{{ total.text }}</td>
-              </tr>
+              <div class="cart-total">
+                <div class="cart-total-title">{{ total.title }}</div>
+                <div class="cart-total-text">{{ total.text }}</div>
+              </div>
             {% endfor %}
-          </table>
-          <p class="text-end"><a href="{{ cart }}"><strong><i class="fa-solid fa-cart-shopping"></i> {{ text_cart }}</strong></a>&nbsp;&nbsp;&nbsp;<a href="{{ checkout }}"><strong><i class="fa-solid fa-share"></i> {{ text_checkout }}</strong></a></p>
-        </div>
-      </li>
+          </div>
+          
+          <div class="cart-buttons">
+            <a class="btn btn-default" href="{{ cart }}"><strong><i class="fa-solid fa-cart-shopping"></i> {{ text_cart }}</strong></a>
+            <a class="btn btn-success" href="{{ checkout }}"><strong><i class="fa-solid fa-share"></i> {{ text_checkout }}</strong></a>
+          </div>
+    
+      </div>
     {% else %}
-      <li>
-        <p class="text-center">{{ text_no_results }}</p>
-      </li>
+      <p class="text-center">{{ text_no_results }}</p>
     {% endif %}
-  </ul>
+  </div>
 </div>


### PR DESCRIPTION
This PR updates the `common/cart.twig` and the `stylesheet.css` to improve the looks and compatibility of the cart. It also fixes #12345 

I've replaced the old tabled structured UI with new flex/grid approach. In addition all containers have unique class names to allow for easy customization.

The old template featured another section:
```twig
{% for voucher in vouchers %}
  <tr>
    <td class="text-center"></td>
    <td class="text-start">{{ voucher.description }}</td>
    <td class="text-end">x&nbsp;1</td>
    <td class="text-end">{{ voucher.amount }}</td>
    <td class="text-end">
      <form action="{{ voucher_remove }}" method="post" data-oc-toggle="ajax" data-oc-load="{{ list }}" data-oc-target="#header-cart">
        <input type="hidden" name="key" value="{{ voucher.key }}"/>
        <button type="submit" data-bs-toggle="tooltip" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-circle-xmark"></i></button>
      </form>
    </td>
  </tr>
    </div>
  </div>
{% endfor %}
```

But OC4 doesn't display the vouchers here anymore, only in the totals. So I removed it from this PR. If it's a mistake that vouchers are not visible here, feel free to add it back.

I didn't touch the scss file since I'm not familiar with scss. So this file still needs to be updated.

This code is tested on mobile, tablet and desktop PCs.


Fell free to tell me if something doesn't work and I will fix it :)

Examples:

Desktop example:
![grafik](https://github.com/opencart/opencart/assets/32510006/79c118a5-1db1-4752-a526-fc103e7c4b9b)


Tablet example:
![grafik](https://github.com/opencart/opencart/assets/32510006/28d9944f-903e-4209-a2af-2bd87f5c4811)


Mobile example:
![grafik](https://github.com/opencart/opencart/assets/32510006/e0f54588-54d1-4da3-92cf-6e904c0f2e5e)

 


