### PR TITLE
Update admin/controller/sale/order.php to fix Fraud Order Tab issue

### DIFF
--- a/upload/admin/controller/sale/order.php
+++ b/upload/admin/controller/sale/order.php
@@ -1181,7 +1181,7 @@ class Order extends \Opencart\System\Engine\Controller {
 
 				if (!$output instanceof \Exception) {
 					$data['tabs'][] = [
-						'code'    => $output,
+						'code'    => $extension['extension'],
 						'title'   => $this->language->get('extension_heading_title'),
 						'content' => $output
 					];


### PR DESCRIPTION
This PR is to fix the Fraud Order Tab naming issue to use the Fraud Extension name instead of the output.

Screenshot of the issue:
![image](https://github.com/opencart/opencart/assets/19896915/c81fdf2b-c3d2-4915-ad06-8508f997c1b1)

Screenshot of the order details page after the fixes:
![image](https://github.com/opencart/opencart/assets/19896915/4e9bf3b4-b4bb-45ee-b29a-950f2dca1f6b)
