### PR TITLE
fix #12465 Removed unused event

### DIFF
--- a/upload/system/config/admin.php
+++ b/upload/system/config/admin.php
@@ -55,7 +55,6 @@ $_['action_event']       = [
 		999 => 'event/language'
 	],
     'language/*/after' => [
-        0 => 'startup/language.after',
-        1 => 'event/translation'
+        0 => 'startup/language.after'
     ]
 ];


### PR DESCRIPTION
A small addition to my PR #12465
Since the translation event is not used on the admin side, it must be removed from the configuration.