### PR TITLE
Update seo_url.php

### DIFF
--- a/upload/catalog/controller/startup/seo_url.php
+++ b/upload/catalog/controller/startup/seo_url.php
@@ -93,7 +93,7 @@ class SeoUrl extends \Opencart\System\Engine\Controller {
 		$url .= str_replace('/index.php', '', $url_info['path']);
 
 		foreach ($paths as $result) {
-			$url .= '/' . $result['keyword'];
+			if($result['keyword'])$url .= '/' . $result['keyword'];
 		}
 
 		// Rebuild the URL query


### PR DESCRIPTION
If keyword is not set:
(which is described in the admin as possible:  "Leave blank if you just want to remove the perimeter." and works) Except it still adds an  extra slash which is unnecessary
(also it should be spelling "parameter")

**update , it seems this comment is removed from master language, even though it still should work.