### PR TITLE
Removed Euro requirement

### DIFF
--- a/upload/extension/opencart/admin/language/en-gb/currency/fixer.php
+++ b/upload/extension/opencart/admin/language/en-gb/currency/fixer.php
@@ -7,7 +7,6 @@ $_['text_extension']   = 'Extensions';
 $_['text_success']     = 'Success: You have modified fixer currency rates!';
 $_['text_edit']        = 'Edit Fixer';
 $_['text_signup']      = 'Fixer.io is a currency conversion service <a href="https://fixer.io/" target="_blank" class="alert-link">signup here</a>.';
-$_['text_support']     = 'This extension Requires at EUR currency to be available currency option.';
 
 // Entry
 $_['entry_api']        = 'API Access Key';

--- a/upload/extension/opencart/admin/view/template/currency/fixer.twig
+++ b/upload/extension/opencart/admin/view/template/currency/fixer.twig
@@ -14,7 +14,6 @@
 		</div>
 	</div>
 	<div class="container-fluid">
-		<div class="alert alert-warning"><i class="fa-solid fa-circle-exclamation"></i> {{ text_support }}</div>
 		<div class="card">
 			<div class="card-header"><i class="fa-solid fa-pencil"></i> {{ text_edit }}</div>
 			<div class="card-body">


### PR DESCRIPTION
The Fixer module in the settings has an incorrect warning that this service requires the Euro currency.
In fact, the Fixer does not require this and the warning should be removed.