### PR TITLE
Fix product controller

### DIFF
--- a/upload/catalog/controller/product/product.php
+++ b/upload/catalog/controller/product/product.php
@@ -519,6 +519,6 @@ class Product extends \Opencart\System\Engine\Controller {
 			return new \Opencart\System\Engine\Action('error/not_found');
 		}
 
-		return;
+		return null;
 	}
 }


### PR DESCRIPTION
PHP 8.2
Fatal error: A function with return type must return a value (did you mean "return null;" instead of "return;"?) in \catalog\controller\product\product.php on line 522