### PR TITLE
CKEditor ShowBlocks alternate config

### DIFF
--- a/upload/admin/view/javascript/ckeditor/config.js
+++ b/upload/admin/view/javascript/ckeditor/config.js
@@ -22,7 +22,7 @@ CKEDITOR.editorConfig = function( config ) {
 	config.codemirror_theme = 'monokai';
 	config.toolbar = 'Custom';
 	config.allowedContent = true;
-	config.startupOutlineBlocks = true;
+	config.startupOutlineBlocks = false;
 	config.disableNativeSpellChecker = false;
 	config.browserContextMenuOnCtrl = true;
 	config.resize_enabled = true;
@@ -30,6 +30,7 @@ CKEDITOR.editorConfig = function( config ) {
 
 	config.toolbar_Custom = [
 		['Source'],
+		['ShowBlocks'],
 		['Maximize'],
 		['Bold','Italic','Underline','Strike','-','Subscript','Superscript'],
 		['NumberedList','BulletedList','-','Outdent','Indent'],


### PR DESCRIPTION
Here is an alternate ShowBlocks config.
It disables ShowBlocks by default and adds ShowBlocks toolbar switch. 
https://github.com/opencart/opencart/issues/12692

In my opinion Blocks should be always visible. It does nothing to the source code but allows you to control the HTML structure better. It's just a matter of habit.

![image](https://github.com/opencart/opencart/assets/6297070/b3f1b940-00f2-417e-a327-23aa8f3ac107)
