### PR TITLE
Fix Zone list - status always "Enabled"

### DIFF
--- a/upload/admin/model/localisation/zone.php
+++ b/upload/admin/model/localisation/zone.php
@@ -59,7 +59,7 @@ class Zone extends \Opencart\System\Engine\Model {
 	 * @return array
 	 */
 	public function getZones(array $data = []): array {
-		$sql = "SELECT *, z.`name`, c.`name` AS country FROM `" . DB_PREFIX . "zone` z LEFT JOIN `" . DB_PREFIX . "country` c ON (z.`country_id` = c.`country_id`)";
+		$sql = "SELECT *, z.`name`, z.`status`, c.`name` AS country FROM `" . DB_PREFIX . "zone` z LEFT JOIN `" . DB_PREFIX . "country` c ON (z.`country_id` = c.`country_id`)";
 
 		$implode = [];
 


### PR DESCRIPTION
Even if the zone status is 'Disabled', the zone list still shows the status 'Enabled'