### PR TITLE
Fix: #12718

### DIFF
--- a/upload/catalog/controller/product/category.php
+++ b/upload/catalog/controller/product/category.php
@@ -49,6 +49,7 @@ class Category extends \Opencart\System\Engine\Controller {
 		}
 
 		$parts = explode('_', $path);
+		$parts1 = explode('_', $path);
 
 		$category_id = (int)array_pop($parts);
 
@@ -84,7 +85,7 @@ class Category extends \Opencart\System\Engine\Controller {
 
 			$path = '';
 
-			foreach ($parts as $path_id) {
+			foreach ($parts1 as $path_id) {
 				if (!$path) {
 					$path = (int)$path_id;
 				} else {


### PR DESCRIPTION
Fix  issue : #12718

The application was not able to render the sub category descriptions, the issue was arising because of an error in the code where `upload/catalog/controller/product/category.php`  where in the code `$parts = explode('_', $path);` was actually splitting the path but by using `array_pop($parts)` method we were only able to fetch the first part of the path and the second part of the path was being removed.

In the current commit i just added another variable `$parts1` which just does the same operation as `$parts` and i am passing it to the for loop for validation and now it seemed to be working, i have tested it as for my knowledge. Except `category.php` file i haven't altered any other files. 

This is my first contribution till day, i hope i did it right. 
Thanks.