### PR TITLE
Fix anti-spam validate in the Returns page

### DIFF
--- a/upload/catalog/controller/account/returns.php
+++ b/upload/catalog/controller/account/returns.php
@@ -389,7 +389,7 @@ class Returns extends \Opencart\System\Engine\Controller {
 
 			$extension_info = $this->model_setting_extension->getExtensionByCode('captcha', $this->config->get('config_captcha'));
 
-			if ($extension_info && $this->config->get('captcha_' . $this->config->get('config_captcha') . '_status') && in_array('return', (array)$this->config->get('config_captcha_page'))) {
+			if ($extension_info && $this->config->get('captcha_' . $this->config->get('config_captcha') . '_status') && in_array('returns', (array)$this->config->get('config_captcha_page'))) {
 				$captcha = $this->load->controller('extension/' . $extension_info['extension'] . '/captcha/' . $extension_info['code'] . '.validate');
 
 				if ($captcha) {


### PR DESCRIPTION
The ID in the captcha extensions search is  `returns`, not `return`. Anti-spam validation does not work on the Returns page due to this error.