### PR TITLE
conflict fix for mysql ssl connection

### DIFF
--- a/upload/system/config/admin.php
+++ b/upload/system/config/admin.php
@@ -8,9 +8,9 @@ $_['db_engine']         = DB_DRIVER; // mysqli, pdo or pgsql
 $_['db_hostname']       = DB_HOSTNAME;
 $_['db_username']       = DB_USERNAME;
 $_['db_password']       = DB_PASSWORD;
-//$_['db_ssl_key']        = DB_SSL_KEY;
-//$_['db_ssl_cert']       = DB_SSL_CERT;
-//$_['db_ssl_ca']         = DB_SSL_CA;
+$_['db_ssl_key']        = DB_SSL_KEY;
+$_['db_ssl_cert']       = DB_SSL_CERT;
+$_['db_ssl_ca']         = DB_SSL_CA;
 $_['db_database']       = DB_DATABASE;
 $_['db_port']           = DB_PORT;
 

--- a/upload/system/config/catalog.php
+++ b/upload/system/config/catalog.php
@@ -10,9 +10,9 @@ $_['db_username']        = DB_USERNAME;
 $_['db_password']        = DB_PASSWORD;
 $_['db_database']        = DB_DATABASE;
 $_['db_port']            = DB_PORT;
-//$_['db_ssl_key']         = DB_SSL_KEY;
-//$_['db_ssl_cert']        = DB_SSL_CERT;
-//$_['db_ssl_ca']          = DB_SSL_CA;
+$_['db_ssl_key']         = DB_SSL_KEY;
+$_['db_ssl_cert']        = DB_SSL_CERT;
+$_['db_ssl_ca']          = DB_SSL_CA;
 
 // Session
 $_['session_autostart']  = false;

--- a/upload/system/library/db/mysqli.php
+++ b/upload/system/library/db/mysqli.php
@@ -24,13 +24,16 @@ class MySQLi {
 		if (!$port) {
 			$port = '3306';
 		}
+		$tempSSLKeyFile = null;
+		$tempSSLCertFile = null;
+		$tempSSLCaFile = null;
 
 		if ($ssl_key) {
 			$temp_ssl_key_file = tempnam(sys_get_temp_dir(), 'mysqli_key_');
 
 			$handle = fopen($temp_ssl_key_file, 'w');
 
-			fwrite($handle, $ssl_key);
+			fwrite($handle,'-----BEGIN CERTIFICATE-----' . PHP_EOL . $ssl_key . PHP_EOL . '-----END CERTIFICATE-----');
 
 			fclose($handle);
 		}
@@ -40,8 +43,8 @@ class MySQLi {
 
 			$handle = fopen($temp_ssl_cert_file, 'w');
 
-			fwrite($handle, $ssl_cert);
-
+			fwrite($handle,'-----BEGIN CERTIFICATE-----' . PHP_EOL . $ssl_cert . PHP_EOL . '-----END CERTIFICATE-----');
+			
 			fclose($handle);
 		}
 		
@@ -57,9 +60,9 @@ class MySQLi {
 
 		try {			
 			$this->connection =  mysqli_init();
-			$this->connection->ssl_set($temp_ssl_key_file, $temp_ssl_cert_file, $temp_ssl_ca_file, null, null);
 
 			if ($temp_ssl_cert_file || $temp_ssl_key_file || $temp_ssl_ca_file) {
+				$this->connection->ssl_set($temp_ssl_key_file, $temp_ssl_cert_file, $temp_ssl_ca_file, null, null);
 				$this->connection->real_connect($hostname, $username, $password, $database, $port, null, MYSQLI_CLIENT_SSL);
 			} else {
 				$this->connection->real_connect($hostname, $username, $password, $database, $port, null);


### PR DESCRIPTION
conflict fix for the following link
https://github.com/opencart/opencart/commit/56f257e024d4ee54f6e8b9ec8b776a1ab082c67a#comments

If you encounter any issues with the DB_SSL_* keys, please consider adding the following lines to your development configuration files (config.php and admin/config.php):

```php
define('DB_SSL_KEY', '');
define('DB_SSL_CERT', '');
define('DB_SSL_CA', '');
```
These additions will help ensure proper handling of SSL keys for your database connections.