### PR TITLE
Fix MySQL SSL issue (#12765)

### DIFF
--- a/upload/install/cli_cloud.php
+++ b/upload/install/cli_cloud.php
@@ -181,9 +181,9 @@ class CliCloud extends \Opencart\System\Engine\Controller {
 		$db_hostname = getenv('DB_HOSTNAME', true);
 		$db_username = getenv('DB_USERNAME', true);
 		$db_password = getenv('DB_PASSWORD', true);
-		$db_ssl_key  = getenv('DB_SSL_KEY', true);
-		$db_ssl_cert = getenv('DB_SSL_CERT', true);
-		$db_ssl_ca   = getenv('DB_SSL_CA', true);
+		$db_ssl_key  = getenv('DB_SSL_KEY', true) ?: '';
+		$db_ssl_cert = getenv('DB_SSL_CERT', true) ?: '';
+		$db_ssl_ca   = getenv('DB_SSL_CA', true) ?: '';
 		$db_database = getenv('DB_DATABASE', true);
 		$db_port     = getenv('DB_PORT', true);
 		$db_prefix   = getenv('DB_PREFIX', true);

--- a/upload/install/cli_install.php
+++ b/upload/install/cli_install.php
@@ -17,6 +17,10 @@
 //                               --db_database opencart
 //								 --db_port     3306
 //                               --db_prefix   oc_
+// Optional Args
+//                               --db_ssl_key  ''
+//                               --db_ssl_cert ''
+//                               --db_ssl_ca   ''
 //
 // Example:
 //
@@ -119,7 +123,10 @@ class CliInstall extends \Opencart\System\Engine\Controller {
 			'db_hostname' => 'localhost',
 			'db_password' => '',
 			'db_port'     => '3306',
-			'db_prefix'   => 'oc_'
+			'db_prefix'   => 'oc_',
+			'db_ssl_key'  => '',
+			'db_ssl_cert' => '',
+			'db_ssl_ca'   => ''
 		];
 
 		// Turn args into an array
@@ -395,16 +402,22 @@ class CliInstall extends \Opencart\System\Engine\Controller {
 		$output .= 'define(\'DB_PREFIX\', \'' . addslashes($option['db_prefix']) . '\');' . "\n";
 		$output .= 'define(\'DB_PORT\', \'' . addslashes($option['db_port']) . '\');' . "\n";
 		
-		if ((isset($option['db_ssl_key']) && $option['db_ssl_key'] !== '')) {
+		if (isset($option['db_ssl_key']) && $option['db_ssl_key'] !== '') {
 			$output .= 'define(\'DB_SSL_KEY\', \'' . addslashes($option['db_ssl_key']) . '\');' . "\n";
+		} else {
+			$output .= 'define(\'DB_SSL_KEY\', \'\');' . "\n";
 		}
 		
-		if ((isset($option['db_ssl_cert']) && $option['db_ssl_cert'] !== '')) {
+		if (isset($option['db_ssl_cert']) && $option['db_ssl_cert'] !== '') {
 			$output .= 'define(\'DB_SSL_CERT\', \'' . addslashes($option['db_ssl_cert']) . '\');' . "\n";
+		} else {
+			$output .= 'define(\'DB_SSL_CERT\', \'\');' . "\n";
 		}
 		
-		if ((isset($option['db_ssl_ca']) && $option['db_ssl_ca'] !== '')) {
+		if (isset($option['db_ssl_ca']) && $option['db_ssl_ca'] !== '') {
 			$output .= 'define(\'DB_SSL_CA\', \'' . addslashes($option['db_ssl_ca']) . '\');' . "\n";
+		} else {
+			$output .= 'define(\'DB_SSL_CA\', \'\');' . "\n";
 		}
 		
 		$file = fopen(DIR_OPENCART . 'config.php', 'w');
@@ -448,16 +461,22 @@ class CliInstall extends \Opencart\System\Engine\Controller {
 		$output .= 'define(\'DB_PREFIX\', \'' . addslashes($option['db_prefix']) . '\');' . "\n";
 		$output .= 'define(\'DB_PORT\', \'' . addslashes($option['db_port']) . '\');' . "\n\n";
 		
-		if ((isset($option['db_ssl_key']) && $option['db_ssl_key'] !== '')) {
+		if (isset($option['db_ssl_key']) && $option['db_ssl_key'] !== '') {
 			$output .= 'define(\'DB_SSL_KEY\', \'' . addslashes($option['db_ssl_key']) . '\');' . "\n";
+		} else {
+			$output .= 'define(\'DB_SSL_KEY\', \'\');' . "\n";
 		}
 		
-		if ((isset($option['db_ssl_cert']) && $option['db_ssl_cert'] !== '')) {
+		if (isset($option['db_ssl_cert']) && $option['db_ssl_cert'] !== '') {
 			$output .= 'define(\'DB_SSL_CERT\', \'' . addslashes($option['db_ssl_cert']) . '\');' . "\n";
+		} else {
+			$output .= 'define(\'DB_SSL_CERT\', \'\');' . "\n";
 		}
 		
-		if ((isset($option['db_ssl_ca']) && $option['db_ssl_ca'] !== '')) {
+		if (isset($option['db_ssl_ca']) && $option['db_ssl_ca'] !== '') {
 			$output .= 'define(\'DB_SSL_CA\', \'' . addslashes($option['db_ssl_ca']) . '\');' . "\n";
+		} else {
+			$output .= 'define(\'DB_SSL_CA\', \'\');' . "\n";
 		}
 
 		$output .= '// OpenCart API' . "\n";

--- a/upload/install/controller/upgrade/upgrade_1.php
+++ b/upload/install/controller/upgrade/upgrade_1.php
@@ -293,9 +293,9 @@ class Upgrade1 extends \Opencart\System\Engine\Controller {
 			$output .= 'define(\'DB_USERNAME\', \'' . DB_USERNAME . '\');' . "\n";
 			$output .= 'define(\'DB_PASSWORD\', \'' . DB_PASSWORD . '\');' . "\n";
 			$output .= 'define(\'DB_DATABASE\', \'' . DB_DATABASE . '\');' . "\n";
-			$output .= 'define(\'DB_SSL_KEY\', \'' . DB_SSL_KEY . '\');' . "\n";
-			$output .= 'define(\'DB_SSL_CERT\', \'' . DB_SSL_CERT . '\');' . "\n";
-			$output .= 'define(\'DB_SSL_CA\', \'' . DB_SSL_CA . '\');' . "\n";
+			$output .= 'define(\'DB_SSL_KEY\', \'' . (defined('DB_SSL_KEY') ? DB_SSL_KEY : '') . '\');' . "\n";
+			$output .= 'define(\'DB_SSL_CERT\', \'' . (defined('DB_SSL_CERT') ? DB_SSL_CERT : '') . '\');' . "\n";
+			$output .= 'define(\'DB_SSL_CA\', \'' . (defined('DB_SSL_CA') ? DB_SSL_CA : '') . '\');' . "\n";
 
 			if (defined('DB_PORT')) {
 				$output .= 'define(\'DB_PORT\', \'' . DB_PORT . '\');' . "\n";

--- a/upload/system/config/admin.php
+++ b/upload/system/config/admin.php
@@ -8,9 +8,9 @@ $_['db_engine']         = DB_DRIVER; // mysqli, pdo or pgsql
 $_['db_hostname']       = DB_HOSTNAME;
 $_['db_username']       = DB_USERNAME;
 $_['db_password']       = DB_PASSWORD;
-//$_['db_ssl_key']        = DB_SSL_KEY;
-//$_['db_ssl_cert']       = DB_SSL_CERT;
-//$_['db_ssl_ca']         = DB_SSL_CA;
+$_['db_ssl_key']        = DB_SSL_KEY;
+$_['db_ssl_cert']       = DB_SSL_CERT;
+$_['db_ssl_ca']         = DB_SSL_CA;
 $_['db_database']       = DB_DATABASE;
 $_['db_port']           = DB_PORT;
 

--- a/upload/system/config/catalog.php
+++ b/upload/system/config/catalog.php
@@ -10,9 +10,9 @@ $_['db_username']        = DB_USERNAME;
 $_['db_password']        = DB_PASSWORD;
 $_['db_database']        = DB_DATABASE;
 $_['db_port']            = DB_PORT;
-//$_['db_ssl_key']         = DB_SSL_KEY;
-//$_['db_ssl_cert']        = DB_SSL_CERT;
-//$_['db_ssl_ca']          = DB_SSL_CA;
+$_['db_ssl_key']         = DB_SSL_KEY;
+$_['db_ssl_cert']        = DB_SSL_CERT;
+$_['db_ssl_ca']          = DB_SSL_CA;
 
 // Session
 $_['session_autostart']  = false;

--- a/upload/system/library/db/mysqli.php
+++ b/upload/system/library/db/mysqli.php
@@ -25,48 +25,42 @@ class MySQLi {
 			$port = '3306';
 		}
 
-		if ($ssl_key) {
-			$temp_ssl_key_file = tempnam(sys_get_temp_dir(), 'mysqli_key_');
-
-			$handle = fopen($temp_ssl_key_file, 'w');
-
-			fwrite($handle, $ssl_key);
-
-			fclose($handle);
-		}
-		
-		if ($ssl_cert) {
-			$temp_ssl_cert_file = tempnam(sys_get_temp_dir(), 'mysqli_cert_');
-
-			$handle = fopen($temp_ssl_cert_file, 'w');
-
-			fwrite($handle, $ssl_cert);
-
-			fclose($handle);
-		}
-		
-		if ($ssl_ca) {
-			$temp_ssl_ca_file = tempnam(sys_get_temp_dir(), 'mysqli_ca_');
-
-			$handle = fopen($temp_ssl_ca_file, 'w');
-
-			fwrite($handle,'-----BEGIN CERTIFICATE-----' . PHP_EOL . $ssl_ca . PHP_EOL . '-----END CERTIFICATE-----');
-
-			fclose($handle);
-		}	
-
 		try {			
-			$this->connection =  mysqli_init();
-			$this->connection->ssl_set($temp_ssl_key_file, $temp_ssl_cert_file, $temp_ssl_ca_file, null, null);
+			$this->connection =  mysqli_init();			
+			if (!empty($ssl_key) || !empty($ssl_cert) || !empty($ssl_ca)) {
+				$temp_ssl_key_file  = null;
+				$temp_ssl_cert_file = null;
+				$temp_ssl_ca_file   = null;
 
-			if ($temp_ssl_cert_file || $temp_ssl_key_file || $temp_ssl_ca_file) {
+				if ($ssl_key) {
+					$temp_ssl_key_file = tempnam(sys_get_temp_dir(), 'mysqli_key_');
+					$handle = fopen($temp_ssl_key_file, 'w');
+					fwrite($handle,'-----BEGIN CERTIFICATE-----' . PHP_EOL . $ssl_key . PHP_EOL . '-----END CERTIFICATE-----');
+					fclose($handle);
+				}
+				
+				if ($ssl_cert) {
+					$temp_ssl_cert_file = tempnam(sys_get_temp_dir(), 'mysqli_cert_');
+					$handle = fopen($temp_ssl_cert_file, 'w');
+					fwrite($handle,'-----BEGIN CERTIFICATE-----' . PHP_EOL . $ssl_cert . PHP_EOL . '-----END CERTIFICATE-----');
+					fclose($handle);
+				}
+				
+				if ($ssl_ca) {
+					$temp_ssl_ca_file = tempnam(sys_get_temp_dir(), 'mysqli_ca_');
+					$handle = fopen($temp_ssl_ca_file, 'w');
+					fwrite($handle,'-----BEGIN CERTIFICATE-----' . PHP_EOL . $ssl_ca . PHP_EOL . '-----END CERTIFICATE-----');
+					fclose($handle);
+				}
+
+				$this->connection->ssl_set($temp_ssl_key_file ?: null, $temp_ssl_cert_file ?: null, $temp_ssl_ca_file ?: null, null, null);				
 				$this->connection->real_connect($hostname, $username, $password, $database, $port, null, MYSQLI_CLIENT_SSL);
 			} else {
 				$this->connection->real_connect($hostname, $username, $password, $database, $port, null);
 			}
-
+			
 			$this->connection->set_charset('utf8mb4');
-
+			
 			$this->query("SET SESSION sql_mode = 'NO_ZERO_IN_DATE,NO_ENGINE_SUBSTITUTION'");
 			$this->query("SET FOREIGN_KEY_CHECKS = 0");
 


### PR DESCRIPTION
This commit addresses the following issues:
- Fixed a bug affecting CLI installation
- Fixed a bug affecting Cloud installation
- Fixed a bug affecting Upgrades
- Fixed a bug about saved cert
- Corrected a wrong variable name
- Fixed formatting problems in the code

If you encounter any issues with the DB_SSL_* keys, please consider adding the following lines to your development configuration files (config.php and admin/config.php):

```php
define('DB_SSL_KEY', '');
define('DB_SSL_CERT', '');
define('DB_SSL_CA', '');
```
These additions will help ensure proper handling of SSL keys for your database connections.
