### PR TITLE
Sticky admin filters

### DIFF
--- a/upload/admin/view/stylesheet/stylesheet.css
+++ b/upload/admin/view/stylesheet/stylesheet.css
@@ -31,7 +31,7 @@ a {
     width: 100%;
     position: relative;
     background: #f6f6f6;
-    overflow: hidden;
+    overflow: clip;
 }
 
 .container-fluid {
@@ -852,4 +852,20 @@ div.required .col-form-label:not(span):before, td.required:before {
 
 td {
     position: relative;
+}
+
+.filter-sticky {
+    position: -webkit-sticky;
+    position: sticky;
+    top: calc(var(--bs-gutter-x) / 1);
+    bottom: calc(var(--bs-gutter-x) / 1);
+    max-height: calc(100vh - (var(--bs-gutter-x) * 2));
+    overflow-y: auto;
+    z-index: 100;
+}
+
+@media screen and (max-width: 992px) {
+    .filter-sticky {
+        position: unset;
+    }
 }

--- a/upload/admin/view/template/catalog/product.twig
+++ b/upload/admin/view/template/catalog/product.twig
@@ -19,7 +19,7 @@
   <div class="container-fluid">
     <div class="row">
       <div id="filter-product" class="col-lg-3 col-md-12 order-lg-last d-none d-lg-block mb-3">
-        <div class="card">
+        <div class="card filter-sticky">
           <div class="card-header"><i class="fa-solid fa-filter"></i> {{ text_filter }}</div>
           <div class="card-body">
             <div class="mb-3">

--- a/upload/admin/view/template/catalog/review.twig
+++ b/upload/admin/view/template/catalog/review.twig
@@ -19,7 +19,7 @@
   <div class="container-fluid">
     <div class="row">
       <div id="filter-review" class="col-lg-3 col-md-12 order-lg-last d-none d-lg-block mb-3">
-        <div class="card">
+        <div class="card filter-sticky">
           <div class="card-header"><i class="fa-solid fa-filter"></i> {{ text_filter }}</div>
           <div class="card-body">
             <div class="mb-3">

--- a/upload/admin/view/template/cms/comment.twig
+++ b/upload/admin/view/template/cms/comment.twig
@@ -18,7 +18,7 @@
   <div class="container-fluid">
     <div class="row">
       <div id="filter-comment" class="col-lg-3 col-md-12 order-lg-last d-none d-lg-block mb-3">
-        <div class="card">
+        <div class="card filter-sticky">
           <div class="card-header"><i class="fa fa-filter"></i> {{ text_filter }}</div>
           <div class="card-body">
             <div class="mb-3">

--- a/upload/admin/view/template/customer/customer.twig
+++ b/upload/admin/view/template/customer/customer.twig
@@ -18,7 +18,7 @@
   <div class="container-fluid">
     <div class="row">
       <div id="filter-customer" class="col-lg-3 col-md-12 order-lg-last d-none d-lg-block mb-3">
-        <div class="card">
+        <div class="card filter-sticky">
           <div class="card-header"><i class="fa-solid fa-filter"></i> {{ text_filter }}</div>
           <div class="card-body">
             <div class="mb-3">

--- a/upload/admin/view/template/customer/customer_approval.twig
+++ b/upload/admin/view/template/customer/customer_approval.twig
@@ -18,7 +18,7 @@
   <div class="container-fluid">
     <div class="row">
       <div id="filter-customer" class="col-lg-3 col-md-12 order-lg-last d-none d-lg-block mb-3">
-        <div class="card">
+        <div class="card filter-sticky">
           <div class="card-header"><i class="fa-solid fa-filter"></i> {{ text_filter }}</div>
           <div class="card-body">
             <div class="mb-3">

--- a/upload/admin/view/template/customer/gdpr.twig
+++ b/upload/admin/view/template/customer/gdpr.twig
@@ -20,7 +20,7 @@
     <div class="alert alert-warning"><i class="fa-solid fa-info-circle"></i> {{ text_info }}</div>
     <div class="row">
       <div id="filter-gdpr" class="col-lg-3 col-md-12 order-lg-last d-none d-lg-block mb-3">
-        <div class="card">
+        <div class="card filter-sticky">
           <div class="card-header"><i class="fa-solid fa-filter"></i> {{ text_filter }}</div>
           <div class="card-body">
             <div class="mb-3">

--- a/upload/admin/view/template/design/seo_url.twig
+++ b/upload/admin/view/template/design/seo_url.twig
@@ -18,7 +18,7 @@
   <div class="container-fluid">
     <div class="row">
       <div id="filter-seo" class="col-lg-3 col-md-12 order-lg-last d-none d-lg-block mb-3">
-        <div class="card">
+        <div class="card filter-sticky">
           <div class="card-header"><i class="fa-solid fa-filter"></i> {{ text_filter }}</div>
           <div class="card-body">
             <div class="mb-3">

--- a/upload/admin/view/template/localisation/country.twig
+++ b/upload/admin/view/template/localisation/country.twig
@@ -18,7 +18,7 @@
   <div class="container-fluid">
     <div class="row">
       <div id="filter-country" class="col-lg-3 col-md-12 order-lg-last d-none d-lg-block mb-3">
-        <div class="card">
+        <div class="card filter-sticky">
           <div class="card-header"><i class="fa-solid fa-filter"></i> {{ text_filter }}</div>
           <div class="card-body">
             <div class="mb-3">

--- a/upload/admin/view/template/localisation/zone.twig
+++ b/upload/admin/view/template/localisation/zone.twig
@@ -18,7 +18,7 @@
 	<div class="container-fluid">
 		<div class="row">
 			<div id="filter-zone" class="col-lg-3 col-md-12 order-lg-last d-none d-lg-block mb-3">
-				<div class="card">
+				<div class="card filter-sticky">
 					<div class="card-header"><i class="fa-solid fa-filter"></i> {{ text_filter }}</div>
 					<div class="card-body">
 						<div class="mb-3">

--- a/upload/admin/view/template/marketing/affiliate.twig
+++ b/upload/admin/view/template/marketing/affiliate.twig
@@ -28,7 +28,7 @@
   <div class="container-fluid">
     <div class="row">
       <div id="filter-affiliate" class="col-lg-3 col-md-12 order-lg-last d-none d-lg-block mb-3">
-        <div class="card">
+        <div class="card filter-sticky">
           <div class="card-header"><i class="fa-solid fa-filter"></i> {{ text_filter }}</div>
           <div class="card-body">
             <div class="mb-3">

--- a/upload/admin/view/template/marketing/marketing.twig
+++ b/upload/admin/view/template/marketing/marketing.twig
@@ -20,7 +20,7 @@
   <div class="container-fluid">
     <div class="row">
       <div id="filter-marketing" class="col-lg-3 col-md-12 order-lg-last d-none d-lg-block mb-3">
-        <div class="card">
+        <div class="card filter-sticky">
           <div class="card-header"><i class="fa-solid fa-filter"></i> {{ text_filter }}</div>
           <div class="card-body">
             <div class="mb-3">

--- a/upload/admin/view/template/report/online.twig
+++ b/upload/admin/view/template/report/online.twig
@@ -16,7 +16,7 @@
   <div class="container-fluid">
     <div class="row">
       <div id="filter-online" class="col-lg-3 col-md-12 order-lg-last d-none d-lg-block mb-3">
-        <div class="card">
+        <div class="card filter-sticky">
           <div class="card-header"><i class="fa-solid fa-filter"></i> {{ text_filter }}</div>
           <div class="card-body">
             <div class="mb-3">

--- a/upload/admin/view/template/sale/order.twig
+++ b/upload/admin/view/template/sale/order.twig
@@ -20,7 +20,7 @@
   <div class="container-fluid">
     <div class="row">
       <div id="filter-order" class="col-lg-3 col-md-12 order-lg-last d-none d-lg-block mb-3">
-        <div class="card">
+        <div class="card filter-sticky">
           <div class="card-header"><i class="fa-solid fa-filter"></i> {{ text_filter }}</div>
           <div class="card-body">
             <div class="mb-3">

--- a/upload/admin/view/template/sale/returns.twig
+++ b/upload/admin/view/template/sale/returns.twig
@@ -18,7 +18,7 @@
   <div class="container-fluid">
     <div class="row">
       <div id="filter-return" class="col-lg-3 col-md-12 order-lg-last d-none d-lg-block mb-3">
-        <div class="card">
+        <div class="card filter-sticky">
           <div class="card-header"><i class="fa-solid fa-filter"></i> {{ text_filter }}</div>
           <div class="card-body">
             <div class="mb-3">

--- a/upload/admin/view/template/sale/subscription.twig
+++ b/upload/admin/view/template/sale/subscription.twig
@@ -16,7 +16,7 @@
   <div class="container-fluid">
     <div class="row">
       <div id="filter-subscription" class="col-lg-3 col-md-12 order-lg-last d-none d-lg-block mb-3">
-        <div class="card">
+        <div class="card filter-sticky">
           <div class="card-header"><i class="fa-solid fa-filter"></i> {{ text_filter }}</div>
           <div class="card-body">
             <div class="mb-3">

--- a/upload/admin/view/template/tool/upload.twig
+++ b/upload/admin/view/template/tool/upload.twig
@@ -17,7 +17,7 @@
   <div class="container-fluid">
     <div class="row">
       <div id="filter-upload" class="col-lg-3 col-md-12 order-lg-last d-none d-lg-block mb-3">
-        <div class="card">
+        <div class="card filter-sticky">
           <div class="card-header"><i class="fa-solid fa-filter"></i> {{ text_filter }}</div>
           <div class="card-body">
             <div class="mb-3">


### PR DESCRIPTION
Make right filter sticky when scrolling a page.
Very useful if you have set more then 10 items per page in admin area.
Also lists look more aesthetically pleasing now without empty space in the right column.

![image](https://github.com/opencart/opencart/assets/6297070/67260ace-03b7-4c11-8343-6be2d124f192)
