### PR TITLE
404 page recognition fix

### DIFF
--- a/upload/catalog/controller/startup/seo_url.php
+++ b/upload/catalog/controller/startup/seo_url.php
@@ -32,6 +32,16 @@ class SeoUrl extends \Opencart\System\Engine\Controller {
 						$this->request->get[$seo_url_info['key']] = html_entity_decode($seo_url_info['value'], ENT_QUOTES, 'UTF-8');
 					}
 				}
+
+				if (!isset($this->request->get['route']) && count($parts) == 1 && isset($this->request->get['language'])) {
+					$this->request->get['route'] = $this->config->get('action_default');
+				}
+			} elseif (!isset($this->request->get['route'])) {
+				$this->request->get['route'] = $this->config->get('action_default');
+			}
+
+			if (!isset($this->request->get['route'])) {
+				$this->request->get['route'] = $this->config->get('action_error');
 			}
 		}
 	}


### PR DESCRIPTION
Fix issue #12228 

Test cases to check the code changes:

1. https://domain.com => Home Page
2. https://domain.com/en-gb => Home Page
3. https://domain.com/index.php?route=checkout/cart.add&language=en-gb => Add Product to Cart
4. https://domain.com/en-gb?route=common/cart.removeProduct => Remove Product from Cart
5. https://domain.com/404qwerty or any page which is not exist => 404 Page