### PR TITLE
Fix syntax error in marketplace

### DIFF
--- a/upload/admin/controller/marketplace/installer.php
+++ b/upload/admin/controller/marketplace/installer.php
@@ -496,7 +496,7 @@ class Installer extends \Opencart\System\Engine\Controller {
 
 				if ($xml) {
 					try {
-						$dom = new DOMDocument('1.0', 'UTF-8');
+						$dom = new \DOMDocument('1.0', 'UTF-8');
 						$dom->loadXml($xml);
 
 						$name = $dom->getElementsByTagName('name')->item(0);
@@ -569,7 +569,7 @@ class Installer extends \Opencart\System\Engine\Controller {
 
 							$this->model_setting_modification->addModification($modification_data);
 						}
-					} catch (Exception $exception) {
+					} catch (\Exception $exception) {
 						$json['error'] = sprintf($this->language->get('error_exception'), $exception->getCode(), $exception->getMessage(), $exception->getFile(), $exception->getLine());
 					}
 				}

--- a/upload/admin/controller/marketplace/modification.php
+++ b/upload/admin/controller/marketplace/modification.php
@@ -255,7 +255,7 @@ class Modification extends \Opencart\System\Engine\Controller {
 					continue;
 				}
 
-				$dom = new DOMDocument('1.0', 'UTF-8');
+				$dom = new \DOMDocument('1.0', 'UTF-8');
 				$dom->preserveWhiteSpace = false;
 				$dom->loadXml($xml);
 
@@ -513,7 +513,7 @@ class Modification extends \Opencart\System\Engine\Controller {
 			}
 
 			// Log
-			$ocmod = new Log('ocmod.log');
+			$ocmod = new \Opencart\System\Library\Log('ocmod.log');
 			$ocmod->write(implode("\n", $log));
 
 			// Write all modification files


### PR DESCRIPTION
This commit broke the syntax of the install file and also isn't properly giving the name space for two classes: https://github.com/opencart/opencart/commit/50b13de22dfb2781c834f08600ceeacbe3bf8fa8) broke somethings.

A similar issue was also introduced in this commit, which has also been fixed here as it affects the marketplace controllers: https://github.com/opencart/opencart/commit/0da669409629a3aca01aefe40c49765b34eb9491

I was actually just looking at the code to see what level of analyzers you run on it, nooks like there is none. Are you open to introducing some to automatically catch errors like this?

**Update:** Looks like the syntax error has now been fixed in https://github.com/opencart/opencart/commit/3591578ad725c0216c823276041e1c13642519a9, but the name space issues remains, the PR has been updated to only address that now.