### PR TITLE
Fix bad array push

### DIFF
--- a/upload/admin/model/sale/subscription.php
+++ b/upload/admin/model/sale/subscription.php
@@ -194,19 +194,19 @@ class Subscription extends \Opencart\System\Engine\Model {
 		$implode = [];
 
 		if (!empty($data['filter_subscription_id'])) {
-			$implode[] .= "`s`.`subscription_id` = '" . (int)$data['filter_subscription_id'] . "'";
+			$implode[] = "`s`.`subscription_id` = '" . (int)$data['filter_subscription_id'] . "'";
 		}
 
 		if (!empty($data['filter_order_id'])) {
-			$implode[] .= "`s`.`order_id` = '" . (int)$data['filter_order_id'] . "'";
+			$implode[] = "`s`.`order_id` = '" . (int)$data['filter_order_id'] . "'";
 		}
 
 		if (!empty($data['filter_customer'])) {
-			$implode[] .= "LCASE(CONCAT(`o`.`firstname`, ' ', `o`.`lastname`)) LIKE '" . $this->db->escape(oc_strtolower($data['filter_customer']) . '%') . "'";
+			$implode[] = "LCASE(CONCAT(`o`.`firstname`, ' ', `o`.`lastname`)) LIKE '" . $this->db->escape(oc_strtolower($data['filter_customer']) . '%') . "'";
 		}
 
 		if (!empty($data['filter_subscription_status_id'])) {
-			$implode[] .= "`s`.`subscription_status_id` = '" . (int)$data['filter_subscription_status_id'] . "'";
+			$implode[] = "`s`.`subscription_status_id` = '" . (int)$data['filter_subscription_status_id'] . "'";
 		}
 
 		if (!empty($data['filter_date_from'])) {


### PR DESCRIPTION
You cannot append to a new element on an array.

This one can be traced all the way back to the release of 2.2 when it was changed from a string to and array: https://github.com/opencart/opencart/commit/9e0b04f153b8803cfc8d98bf9b351a0dda5ed5e6