### PR TITLE
Fix getTotalArticles() not accepting the given filter

### DIFF
--- a/upload/catalog/model/cms/article.php
+++ b/upload/catalog/model/cms/article.php
@@ -103,7 +103,7 @@ class Article extends \Opencart\System\Engine\Model {
 	/**
 	 * @return int
 	 */
-	public function getTotalArticles(): int {
+	public function getTotalArticles(array $data = []): int {
 		$sql = "SELECT COUNT(*) AS `total` FROM `" . DB_PREFIX . "article` `a` LEFT JOIN `" . DB_PREFIX . "article_description` `ad` ON (`a`.`article_id` = `ad`.`article_id`) LEFT JOIN `" . DB_PREFIX . "article_to_store` `a2s` ON (`a`.`article_id` = `a2s`.`article_id`) WHERE `ad`.`language_id` = '" . (int)$this->config->get('config_language_id') . "' AND `a2s`.`store_id` = '" . (int)$this->config->get('config_store_id') . "'";
 
 		if (!empty($data['filter_search'])) {


### PR DESCRIPTION
This one appears to have been an issue since the functions introduction in https://github.com/opencart/opencart/commit/aaae7efc3b83da5b550e17a88c1dd84df781191f