### PR TITLE
Fix missing $order_info in subscription cron

### DIFF
--- a/upload/catalog/controller/cron/subscription.php
+++ b/upload/catalog/controller/cron/subscription.php
@@ -35,6 +35,8 @@ class Subscription extends \Opencart\System\Engine\Controller {
 		$results = $this->model_checkout_subscription->getSubscriptions($filter_data);
 
 		foreach ($results as $result) {
+			$order_info = $this->model_checkout_order->getOrder($result['order_id']);
+
 			if (($result['trial_status'] && $result['trial_remaining']) || ($result['duration'] && $result['remaining'])) {
 				$error = '';
 


### PR DESCRIPTION
This was introduced with https://github.com/opencart/opencart/commit/66fa3b1693f4b91fc1cd4c3505addc3b8322f27d