### PR TITLE
Correct catalog store return value when locked

### DIFF
--- a/upload/extension/opencart/catalog/controller/module/store.php
+++ b/upload/extension/opencart/catalog/controller/module/store.php
@@ -44,6 +44,8 @@ class Store extends \Opencart\System\Engine\Controller {
 			}
 
 			return $this->load->view('extension/opencart/module/store', $data);
+		} else {
+			return '';
 		}
 	}
 }


### PR DESCRIPTION
This one sort of goes all the way back to https://github.com/opencart/opencart/commit/60827089ecea70dc599f830e0f4f87cabc0113d3 but probably didn't become a real issue before the return types where added in 4.0.0