### PR TITLE
Add missing prefix property to redis session class

### DIFF
--- a/upload/system/library/session/redis.php
+++ b/upload/system/library/session/redis.php
@@ -8,6 +8,7 @@ namespace Opencart\System\Library\Session;
 class Redis {
 	private object $config;
 	private object $redis;
+	public string $prefix;
 	/**
 	 * Construct
 	 *


### PR DESCRIPTION
This isn't strictly causing any issues but it's best to have all utilized properties declared as that gives an opportunity to set there viability and type which can help to catch issues with the code that accesses it.

It was probably intended to be private, but I have set it to public to keep comparability with prior versions.