### PR TITLE
Fix leftover from Twig 2.4 to 3.0 migrating

### DIFF
--- a/upload/system/library/template/twig.php
+++ b/upload/system/library/template/twig.php
@@ -116,7 +116,7 @@ class Twig {
 			$twig = new \Twig\Environment($loader, $config);
 
 			return $twig->render($file, $data);
-		} catch (Twig_Error_Syntax $e) {
+		} catch (\Twig\Error\SyntaxError $e) {
 			throw new \Exception('Error: Could not load template ' . $filename . '!');
 		}
 	}


### PR DESCRIPTION
This line was not properly updated when the system was updated from Twig 2.4 to 3.0: https://github.com/opencart/opencart/commit/ba5509e986cf4c05e9df8e0111b5839bfdb3582c