### PR TITLE
Fix header cart not updating issue (#12874 and #12875)

### DIFF
--- a/upload/catalog/view/javascript/common.js
+++ b/upload/catalog/view/javascript/common.js
@@ -355,11 +355,13 @@ $(document).on('submit', 'form', function (e) {
                     $('#alert').prepend('<div class="alert alert-success alert-dismissible"><i class="fa-solid fa-circle-check"></i> ' + json['success'] + ' <button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>');
 
                     // Refresh
-                    var url = $(form).attr('data-oc-load');
-                    var target = $(form).attr('data-oc-target');
+                    const url = $(form).attr('data-oc-load').split(',');
+                    const target = $(form).attr('data-oc-target').split(',');
 
-                    if (url !== undefined && target !== undefined) {
-                        $(target).load(url);
+                    for (let i = 0; i < url.length; i ++) {
+                        if (url[i] !== undefined && target[i] !== undefined) {
+                            $(target[i]).load(url[i]);
+                        }
                     }
                 }
 

--- a/upload/extension/opencart/catalog/controller/total/coupon.php
+++ b/upload/extension/opencart/catalog/controller/total/coupon.php
@@ -15,6 +15,7 @@ class Coupon extends \Opencart\System\Engine\Controller {
 
 			$data['save'] = $this->url->link('extension/opencart/total/coupon.save', 'language=' . $this->config->get('config_language'), true);
 			$data['list'] = $this->url->link('checkout/cart.list', 'language=' . $this->config->get('config_language'), true);
+			$data['header_cart'] = $this->url->link('common/cart.info', 'language=' . $this->config->get('config_language'), true);
 
 			if (isset($this->session->data['coupon'])) {
 				$data['coupon'] = $this->session->data['coupon'];

--- a/upload/extension/opencart/catalog/controller/total/reward.php
+++ b/upload/extension/opencart/catalog/controller/total/reward.php
@@ -30,6 +30,7 @@ class Reward extends \Opencart\System\Engine\Controller {
 
 				$data['save'] = $this->url->link('extension/opencart/total/reward.save', 'language=' . $this->config->get('config_language'), true);
 				$data['list'] = $this->url->link('checkout/cart.list', 'language=' . $this->config->get('config_language'), true);
+				$data['header_cart'] = $this->url->link('common/cart.info', 'language=' . $this->config->get('config_language'), true);
 
 				if (isset($this->session->data['reward'])) {
 					$data['reward'] = $this->session->data['reward'];

--- a/upload/extension/opencart/catalog/controller/total/voucher.php
+++ b/upload/extension/opencart/catalog/controller/total/voucher.php
@@ -15,6 +15,7 @@ class Voucher extends \Opencart\System\Engine\Controller {
 
 			$data['save'] = $this->url->link('extension/opencart/total/voucher.save', 'language=' . $this->config->get('config_language'), true);
 			$data['list'] = $this->url->link('checkout/cart.list', 'language=' . $this->config->get('config_language'), true);
+			$data['header_cart'] = $this->url->link('common/cart.info', 'language=' . $this->config->get('config_language'), true);
 
 			if (isset($this->session->data['voucher'])) {
 				$data['voucher'] = $this->session->data['voucher'];

--- a/upload/extension/opencart/catalog/view/template/total/coupon.twig
+++ b/upload/extension/opencart/catalog/view/template/total/coupon.twig
@@ -2,7 +2,7 @@
   <h2 class="accordion-header"><button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#collapse-coupon">{{ heading_title }}</button></h2>
   <div id="collapse-coupon" class="accordion-collapse collapse" data-bs-parent="#accordion">
     <div class="accordion-body">
-      <form id="form-coupon" action="{{ save }}" method="post" data-oc-toggle="ajax" data-oc-load="{{ list }}" data-oc-target="#shopping-cart">
+      <form id="form-coupon" action="{{ save }}" method="post" data-oc-toggle="ajax" data-oc-load="{{ list ~ ',' ~ header_cart }}" data-oc-target="#shopping-cart,#header-cart">
         <div class="row mb-3">
           <label for="input-coupon" class="col-md-4 col-form-label">{{ entry_coupon }}</label>
           <div class="col-md-8">

--- a/upload/extension/opencart/catalog/view/template/total/reward.twig
+++ b/upload/extension/opencart/catalog/view/template/total/reward.twig
@@ -2,7 +2,7 @@
   <h2 class="accordion-header"><button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#collapse-reward">{{ heading_title }}</button></h2>
   <div id="collapse-reward" class="accordion-collapse collapse" data-bs-parent="#accordion">
     <div class="accordion-body">
-      <form id="form-reward" action="{{ save }}" method="post" data-oc-toggle="ajax" data-oc-load="{{ list }}" data-oc-target="#shopping-cart">
+      <form id="form-reward" action="{{ save }}" method="post" data-oc-toggle="ajax" data-oc-load="{{ list ~ ',' ~ header_cart }}" data-oc-target="#shopping-cart,#header-cart">
         <div class="row mb-3">
           <label for="input-reward" class="col-md-4 col-form-label">{{ entry_reward }}</label>
           <div class="col-md-8">

--- a/upload/extension/opencart/catalog/view/template/total/shipping.twig
+++ b/upload/extension/opencart/catalog/view/template/total/shipping.twig
@@ -150,7 +150,9 @@
               if (json['success']) {
                   $('#alert').prepend('<div class="alert alert-success alert-dismissible"><i class="fa-solid fa-circle-exclamation"></i> ' + json['success'] + ' <button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>');
 
-                  $('#shopping-cart').load('index.php?route=checkout/cart.list&language={{ language }}');
+                  $('#shopping-cart').load('index.php?route=checkout/cart.list&language={{ language }}', {}, function () {
+                      $('#header-cart').load('index.php?route=common/cart.info&language={{ language }}');
+                  });
 
                   $('#modal-shipping').modal('hide');
               }

--- a/upload/extension/opencart/catalog/view/template/total/voucher.twig
+++ b/upload/extension/opencart/catalog/view/template/total/voucher.twig
@@ -2,7 +2,7 @@
   <h2 class="accordion-header"><button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#collapse-voucher">{{ heading_title }}</button></h2>
   <div id="collapse-voucher" class="accordion-collapse collapse" data-bs-parent="#accordion">
     <div class="accordion-body">
-      <form id="form-voucher" action="{{ save }}" method="post" data-oc-toggle="ajax" data-oc-load="{{ list }}" data-oc-target="#shopping-cart">
+      <form id="form-voucher" action="{{ save }}" method="post" data-oc-toggle="ajax" data-oc-load="{{ list ~ ',' ~ header_cart }}" data-oc-target="#shopping-cart,#header-cart">
 
         <div class="row mb-3">
           <label for="input-voucher" class="col-md-4 col-form-label">{{ entry_voucher }}</label>


### PR DESCRIPTION
Reference to issue #12874 and #12875 

This commit addresses the following issues:

- Estimate Shipping & Taxes at Cart page does not update header cart
- Use Coupon Code at Cart page does not update header cart
- Use Gift Certificate at Cart page does not update header cart
- Use Reward Points at Cart page does not update header cart
