### PR TITLE
Fix getting product info in subscription data

### DIFF
--- a/upload/admin/controller/sale/subscription.php
+++ b/upload/admin/controller/sale/subscription.php
@@ -658,9 +658,8 @@ class Subscription extends \Opencart\System\Engine\Controller {
 
 		// Product data
 		if (!empty($subscription_info)) {
-			//$this->load->model('sale/order');
-			//getSubscriptionByOrderProductId
-		//	$product_info = $this->model_sale_order->getProductByOrderProductId($subscription_info['order_id'], $subscription_info['order_product_id']);
+			$this->load->model('sale/order');
+			$product_info = $this->model_sale_order->getProductByOrderProductId($subscription_info['order_id'], $subscription_info['order_product_id']);
 		}
 
 		if (!empty($product_info['name'])) {


### PR DESCRIPTION
This code was commented out in https://github.com/opencart/opencart/commit/66fa3b1693f4b91fc1cd4c3505addc3b8322f27d which causes subsequent conditions to fail as $product_info hasn't been populated. No clear reason is given to I'm assuming this was just a left over from local debugging.