### PR TITLE
Fixed PHP 7.4 warning for apcu

### DIFF
--- a/upload/system/library/cache/apcu.php
+++ b/upload/system/library/cache/apcu.php
@@ -44,7 +44,7 @@ class Apcu {
 	 * 
 	 * @return	 void
      */
-	public function set(string $key, array|string|null $value, int $expire = 0): void {
+	public function set(string $key, $value, int $expire = 0): void {
 		if (!$expire) {
 			$expire = $this->expire;
 		}


### PR DESCRIPTION
PHP 7.4 does not support union types, but we still have it in the phpdoc above