### PR TITLE
Fixed PHP 7.4 warning for PDO

### DIFF
--- a/upload/system/library/db/pdo.php
+++ b/upload/system/library/db/pdo.php
@@ -9,7 +9,7 @@ class PDO {
 	/**
 	 * @var object|\PDO|null
 	 */
-	private object|null $connection;
+	private ?object $connection;
 	/**
 	 * @var array
 	 */


### PR DESCRIPTION
Union type is not supported, but we can use nullable to express the same type in 7.4 syntax