### PR TITLE
Fixed PHP 7.4 warning for postgreSQL

### DIFF
--- a/upload/system/library/db/pgsql.php
+++ b/upload/system/library/db/pgsql.php
@@ -9,7 +9,7 @@ class PgSQL {
 	/**
 	 * @var object|resource|null
 	 */
-	private object|null $connection;
+	private $connection;
 
 	/**
 	 * Constructor
@@ -47,7 +47,7 @@ class PgSQL {
 	 *
 	 * @return   bool|object
 	 */
-	public function query(string $sql): bool|object {
+	public function query(string $sql) {
 		$resource = pg_query($this->connection, $sql);
 
 		if ($resource) {


### PR DESCRIPTION
The return type of [pg_connect() was changed](https://www.php.net/manual/en/function.pg-connect.php) in 8.1 and 7.4 does not support union type so this has to be left to the phpdoc