### PR TITLE
Fixed PHP 7.4 warning for mail library

### DIFF
--- a/upload/system/library/mail.php
+++ b/upload/system/library/mail.php
@@ -36,11 +36,11 @@ class Mail {
 	/**
      * setTo
      *
-     * @param	string	$to
+     * @param	string|array	$to
 	 *
 	 * @return  void
      */
-	public function setTo(string|array $to): void {
+	public function setTo($to): void {
 		$this->option['to'] = $to;
 	}
 


### PR DESCRIPTION
PHP 7.4 does not support union type but we can add it to the phpdoc instead.