### PR TITLE
Check that code passes for supported versions of PHP

### DIFF
--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -1,0 +1,40 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: ['7.4', '8.0', '8.1', '8.2']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: Lint
+        run: |
+          error=0
+          for file in $(find upload -type f -name "*.php" ! -path 'upload/system/storage/vendor/*'); do
+            php -l -n $file | grep -v "No syntax errors detected" && error=1
+          done
+          if [ $error -eq 1 ]; then
+            echo "Syntax errors were found."
+            exit 1
+          else
+            echo "No syntax errors were detected."
+          fi

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%208.0-8892BF.svg?style=flat-square)](https://php.net/)
+[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%207.4-8892BF.svg?style=flat-square)](https://php.net/)
 [![GitHub release](https://img.shields.io/github/v/release/opencart/opencart)](https://github.com/opencart/opencart)
 
 OpenCart is a free open source ecommerce platform for online merchants. OpenCart provides a professional and reliable foundation from which to build a successful online store.


### PR DESCRIPTION
This adds a GitHub action that checks to see if the code can be parsed by all the supported versions of PHP (7.4, 8.0, 8.1, and 8.2).

An example of what this looks like in a Pull Request:
![image](https://github.com/opencart/opencart/assets/204594/ecae8b48-7a25-4385-a981-c57f19aa98b2)

This should help with the review process as developers get instant feedback of potential issues with there code.

Clicking details next to the failing test will also give you details regarding the errors that where found in various files.

Also it updates to badge in the read me to say that `PHP >= 7.4` rather then `PHP >= 8.0` to better clarify things.

![image](https://github.com/opencart/opencart/assets/204594/720144a7-ea7d-404f-9d53-d1fb376b2d3d)
