### PR TITLE
Correct loading of notification model

### DIFF
--- a/upload/admin/controller/startup/notification.php
+++ b/upload/admin/controller/startup/notification.php
@@ -32,11 +32,12 @@ class Notification extends \Opencart\System\Engine\Controller {
 			}
 
 			if (isset($notification['notification'])) {
+				$this->load->model('tool/notification');
 				foreach ($notification['notifications'] as $result) {
-					$notification_info = $this->model_notification->addNotification($result['notification_id']);
+					$notification_info = $this->model_tool_notification->addNotification($result['notification_id']);
 
 					if (!$notification_info) {
-						$this->model_notification->addNotification($result);
+						$this->model_tool_notification->addNotification($result);
 					}
 				}
 			}


### PR DESCRIPTION
The wrong property name was used and the model was never loaded. This looks to have been introduced in https://github.com/opencart/opencart/commit/08be346a14e107b71e6fb62d3cc42208a35f456f