### PR TITLE
Fix misspelled property in example extension

### DIFF
--- a/upload/extension/oc_payment_example/admin/controller/payment/credit_card.php
+++ b/upload/extension/oc_payment_example/admin/controller/payment/credit_card.php
@@ -114,7 +114,7 @@ class CreditCard extends \Opencart\System\Engine\Controller {
 			$data['reports'][] = [
 				'order_id'   => $result['order_id'],
 				'card'       => $result['card'],
-				'amount'     => $this->curency->format($result['amount'], $this->config->get('config_currency')),
+				'amount'     => $this->currency->format($result['amount'], $this->config->get('config_currency')),
 				'response'   => $result['response'],
 				'status'     => $result['order_status'],
 				'date_added' => date($this->language->get('datetime_format'), strtotime($result['date_added'])),


### PR DESCRIPTION
This was introduced here when the class was added: https://github.com/opencart/opencart/commit/3df3ec018e376ec07dcc668a4fd25999a12e50b5