### PR TITLE
Add missing error property

### DIFF
--- a/upload/admin/controller/extension/dashboard.php
+++ b/upload/admin/controller/extension/dashboard.php
@@ -7,6 +7,11 @@ namespace Opencart\Admin\Controller\Extension;
  */
 class Dashboard extends \Opencart\System\Engine\Controller {
 	/**
+	 * @var array
+	 */
+	private array $error = [];
+
+	/**
 	 * @return void
 	 */
 	public function index(): void {

--- a/upload/admin/controller/extension/feed.php
+++ b/upload/admin/controller/extension/feed.php
@@ -7,6 +7,11 @@ namespace Opencart\Admin\Controller\Extension;
  */
 class Feed extends \Opencart\System\Engine\Controller {
 	/**
+	 * @var array
+	 */
+	private array $error = [];
+
+	/**
 	 * @return void
 	 */
 	public function index(): void {


### PR DESCRIPTION
The property was removed in https://github.com/opencart/opencart/commit/992411d0eedb937cfb58249ce35ea98c9e6180aa but remains in use in the validation function.