### PR TITLE
Fix invalid regex in admin function

### DIFF
--- a/upload/admin/controller/common/security.php
+++ b/upload/admin/controller/common/security.php
@@ -290,7 +290,7 @@ class Security extends \Opencart\System\Engine\Controller {
 		}
 
 		if (isset($this->request->get['name'])) {
-			$name = preg_replace('[^a-zA-z0-9]', '', basename(html_entity_decode(trim((string)$this->request->get['name']), ENT_QUOTES, 'UTF-8')));
+			$name = preg_replace('/[^a-zA-Z0-9]/', '', basename(html_entity_decode(trim((string)$this->request->get['name']), ENT_QUOTES, 'UTF-8')));
 		} else {
 			$name = 'admin';
 		}


### PR DESCRIPTION
The string was missing the pattern delimiters meaning the regex didn't really do anything. This issue was introduced in https://github.com/opencart/opencart/commit/9b1b3d23a9dc4a5de119b42a8d06c0e0ea0f0115