### PR TITLE
&amp; in url

### DIFF
--- a/upload/system/library/url.php
+++ b/upload/system/library/url.php
@@ -57,7 +57,7 @@ class Url {
 
 		if ($args) {
 			if (is_array($args)) {
-				$url .= '&' . http_build_query($args);
+				$url .= '&' . http_build_query($args, '', '&amp;');
 			} else {
 				$url .= '&' . trim($args, '&');
 			}


### PR DESCRIPTION
without this change, it will be like this:

```
$this->url->link('extension/my/module', ['param1' => '1', 'param2' => '2']);

site.ru/index.php/?route=extension/my/module&amp;param1=1&param2=2
```

with the change so:

`site.ru/index.php/?route=extension/my/module&amp;param1=1&amp;param2=2`

it is necessary either to replace the ampersand everywhere, or nowhere

for example sitemap.xml (and in general, the xml format) does not accept ampersand. `Accepts only &amp;`