### PR TITLE
PHP 8 - null parameter

### DIFF
--- a/upload/system/engine/action.php
+++ b/upload/system/engine/action.php
@@ -62,7 +62,7 @@ class Action {
 		}
 
 		$file  = DIR_APPLICATION . 'controller/' . $this->route . '.php';	
-		$class = 'Controller' . preg_replace('/[^a-zA-Z0-9]/', '', $this->route);
+		$class = 'Controller' . preg_replace('/[^a-zA-Z0-9]/', '', (string)$this->route);
 		
 		// Initialize the class
 		if (is_file($file)) {


### PR DESCRIPTION
Fix error on PHP 8:
PHP Unknown:  preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /system/engine/action.php on line 65