### PR TITLE
Fix the cart url in the Sitemap page

### DIFF
--- a/upload/catalog/view/template/information/sitemap.twig
+++ b/upload/catalog/view/template/information/sitemap.twig
@@ -44,7 +44,7 @@
                 <li><a href="{{ download }}">{{ text_download }}</a></li>
               </ul>
             </li>
-            <li><a href="{{ history }}">{{ text_cart }}</a></li>
+            <li><a href="{{ cart }}">{{ text_cart }}</a></li>
             <li><a href="{{ checkout }}">{{ text_checkout }}</a></li>
             <li><a href="{{ search }}">{{ text_search }}</a></li>
             <li>{{ text_information }}


### PR DESCRIPTION
Incorrect link to the Cart in the Site Map page.
I have submitted this issue before and it was closed without a fix.