### PR TITLE
Clear cart data on update

### DIFF
--- a/upload/system/library/cart/cart.php
+++ b/upload/system/library/cart/cart.php
@@ -379,6 +379,9 @@ class Cart {
 			$this->db->query("UPDATE `" . DB_PREFIX . "cart` SET `quantity` = (`quantity` + " . (int)$quantity . ") WHERE `api_id` = '" . (isset($this->session->data['api_id']) ? (int)$this->session->data['api_id'] : 0) . "' AND `customer_id` = '" . (int)$this->customer->getId() . "' AND `session_id` = '" . $this->db->escape($this->session->getId()) . "' AND `product_id` = '" . (int)$product_id . "' AND `subscription_plan_id` = '" . (int)$subscription_plan_id . "' AND `option` = '" . $this->db->escape(json_encode($option)) . "'");
 		}
 
+		// Clear cart data
+		$this->data = [];
+
 		// Populate the cart data
 		$this->data = $this->getProducts();
 	}
@@ -393,6 +396,9 @@ class Cart {
      */
 	public function update(int $cart_id, int $quantity): void {
 		$this->db->query("UPDATE `" . DB_PREFIX . "cart` SET `quantity` = '" . (int)$quantity . "' WHERE `cart_id` = '" . (int)$cart_id . "' AND `api_id` = '" . (isset($this->session->data['api_id']) ? (int)$this->session->data['api_id'] : 0) . "' AND `customer_id` = '" . (int)$this->customer->getId() . "' AND `session_id` = '" . $this->db->escape($this->session->getId()) . "'");
+
+		// Clear cart data
+		$this->data = [];
 
 		// Populate the cart data
 		$this->data = $this->getProducts();


### PR DESCRIPTION
https://github.com/opencart/opencart/blob/1be6112ad2a522ac9f3d6fa36c8888173b82175c/upload/system/library/cart/cart.php#L398
Basically this line means `$this->data = $this->data;` and it has no sense without clearing `data` property.

If you try to `add/update` cart and then call `getProducts` in one request you cannot see your updates cause results are returned from outdated `data` property.