### PR TITLE
Correct placment of opening braces

### DIFF
--- a/upload/admin/controller/sale/voucher.php
+++ b/upload/admin/controller/sale/voucher.php
@@ -321,7 +321,7 @@ class Voucher extends \Opencart\System\Engine\Controller {
 		if ($voucher_info) {
 			if (!isset($this->request->post['voucher_id'])) {
 				$json['error']['warning'] = $this->language->get('error_exists');
-			} elseif ($voucher_info['voucher_id'] != (int)$this->request->post['voucher_id'])  {
+			} elseif ($voucher_info['voucher_id'] != (int)$this->request->post['voucher_id']) {
 				$json['error']['warning'] = $this->language->get('error_exists');
 			}
 		}

--- a/upload/cron.php
+++ b/upload/cron.php
@@ -82,7 +82,7 @@ set_error_handler(function(string $code, string $message, string $file, string $
 });
 
 // Exception Handler
-set_exception_handler(function(\Throwable $e) use ($log, $config): void  {
+set_exception_handler(function(\Throwable $e) use ($log, $config): void {
 	if ($config->get('error_log')) {
 		$log->write(get_class($e) . ':  ' . $e->getMessage() . ' in ' . $e->getFile() . ' on line ' . $e->getLine());
 	}

--- a/upload/system/framework.php
+++ b/upload/system/framework.php
@@ -65,7 +65,7 @@ set_error_handler(function(string $code, string $message, string $file, string $
 });
 
 // Exception Handler
-set_exception_handler(function(\Throwable $e) use ($log, $config): void  {
+set_exception_handler(function(\Throwable $e) use ($log, $config): void {
 	if ($config->get('error_log')) {
 		$log->write($e->getMessage() . ': in ' . $e->getFile() . ' on line ' . $e->getLine());
 	}

--- a/upload/system/library/db/pgsql.php
+++ b/upload/system/library/db/pgsql.php
@@ -87,7 +87,7 @@ class PgSQL {
      *
      * @return string
      */
-	public function escape(string $value): string  {
+	public function escape(string $value): string {
 		return pg_escape_string($this->connection, $value);
 	}
 

--- a/upload/system/library/session/redis.php
+++ b/upload/system/library/session/redis.php
@@ -14,7 +14,7 @@ class Redis {
      *
      * @param object $registry
      */
-	public function __construct(\Opencart\System\Engine\Registry $registry)	{
+	public function __construct(\Opencart\System\Engine\Registry $registry) {
 		$this->config = $registry->get('config');
 
 		try {
@@ -33,7 +33,7 @@ class Redis {
      *
      * @return array
      */
-	public function read(string $session_id): array	{
+	public function read(string $session_id): array {
         $data = $this->redis->get($this->prefix . $session_id);
         
         if (is_null($data) || empty($data)) {


### PR DESCRIPTION
This fixes all instances of where the opening braces have not been positioned correctly. This was done using php-cs-fixer's braces_position rule. Once all oustanding PR regarding code formatting have been merged this process can be automated.