### PR TITLE
Remove trailing whitespace in comments

### DIFF
--- a/upload/admin/controller/common/developer.php
+++ b/upload/admin/controller/common/developer.php
@@ -160,7 +160,7 @@ class Developer extends \Opencart\System\Engine\Controller {
 
 	/**
      * Generate new autoloader file
-     *    
+     *
      * @return void
      */
 	public function vendor(): void {

--- a/upload/admin/controller/event/statistics.php
+++ b/upload/admin/controller/event/statistics.php
@@ -15,7 +15,7 @@ class Statistics extends \Opencart\System\Engine\Controller {
 	 * @param mixed  $output
 	 *
 	 * @return void
-	 * 
+	 *
 	 * admin/model/catalog/review/addReview/after
 	 */
 	public function addReview(string &$route, array &$args, &$output): void {

--- a/upload/catalog/controller/event/debug.php
+++ b/upload/catalog/controller/event/debug.php
@@ -47,7 +47,7 @@ class Debug extends \Opencart\System\Engine\Controller {
 					'route' => $route,
 					'time'  => microtime(true) - $this->session->data['debug'][$route]
 				];
-				
+
 				$this->log->write($log_data);
 			}
 		}

--- a/upload/system/library/cache.php
+++ b/upload/system/library/cache.php
@@ -21,7 +21,7 @@ class Cache {
      *
      * @param string $adaptor The type of storage for the cache.
      * @param int    $expire  Optional parameters
-     *     
+     *
      */
 	public function __construct(string $adaptor, int $expire = 3600) {
 		$class = 'Opencart\System\Library\Cache\\' . $adaptor;

--- a/upload/system/library/cache/apcu.php
+++ b/upload/system/library/cache/apcu.php
@@ -78,7 +78,7 @@ class Apcu {
 
 	/**
      * Delete all cache
-     *     
+     *
      * @return bool
      */
 	public function flush(): bool {

--- a/upload/system/library/cache/redis.php
+++ b/upload/system/library/cache/redis.php
@@ -46,7 +46,7 @@ class Redis {
      * @param string $key
      * @param mixed  $value
      * @param int    $expire
-     * 
+     *
      * @return void
      */
 	public function set(string $key, $value, int $expire = 0): void {

--- a/upload/system/library/document.php
+++ b/upload/system/library/document.php
@@ -40,7 +40,7 @@ class Document {
      * setTitle
      *
      * @param string $title
-     * 
+     *
      * @return void
      */
 	public function setTitle(string $title): void {

--- a/upload/system/library/url.php
+++ b/upload/system/library/url.php
@@ -45,7 +45,7 @@ class Url {
 
 	/**
      * Link
-     * 
+     *
      * Generates a URL
      *
      * @param string $route


### PR DESCRIPTION
This was done using php-cs-fixer's no_trailing_whitespace_in_comment rule. Once all outstanding PR regarding code formatting have been merged future changes can be checked for issues in GitHub action and developers can run the tool locally to fix any formatting issues with there code.