### PR TITLE
Fix incorrect indentation in admin

### DIFF
--- a/upload/admin/controller/common/filemanager.php
+++ b/upload/admin/controller/common/filemanager.php
@@ -87,10 +87,10 @@ class FileManager extends \Opencart\System\Engine\Controller {
 		$this->load->model('tool/image');
 
 		// Get directories and files
-        $paths = array_merge(
-            glob($directory . $filter_name . '*', GLOB_ONLYDIR),
-            glob($directory . $filter_name . '*{' . implode(',', $allowed) . '}', GLOB_BRACE)
-        );
+		$paths = array_merge(
+			glob($directory . $filter_name . '*', GLOB_ONLYDIR),
+			glob($directory . $filter_name . '*{' . implode(',', $allowed) . '}', GLOB_BRACE)
+		);
 
 		$total = count($paths);
 		$limit = 16;
@@ -98,8 +98,8 @@ class FileManager extends \Opencart\System\Engine\Controller {
 
 		if ($paths) {
 			// Split the array based on current page number and max number of items per page of 10
-            foreach (array_slice($paths, $start, $limit) as $path) {
-                $path = str_replace('\\', '/', realpath($path));
+			foreach (array_slice($paths, $start, $limit) as $path) {
+				$path = str_replace('\\', '/', realpath($path));
 
 				if (substr($path, 0, strlen($path)) == $path) {
 					$name = basename($path);

--- a/upload/admin/controller/extension/captcha.php
+++ b/upload/admin/controller/extension/captcha.php
@@ -10,7 +10,7 @@ class Captcha extends \Opencart\System\Engine\Controller {
 	 * @return void
 	 */
 	public function index(): void {
- 		$this->response->setOutput($this->getList());
+		$this->response->setOutput($this->getList());
 	}
 
 	/**

--- a/upload/admin/controller/localisation/country.php
+++ b/upload/admin/controller/localisation/country.php
@@ -340,7 +340,7 @@ class Country extends \Opencart\System\Engine\Controller {
 			$data['postcode_required'] = 0;
 		}
 
-	    if (!empty($country_info)) {
+		if (!empty($country_info)) {
 			$data['status'] = $country_info['status'];
 		} else {
 			$data['status'] = '1';

--- a/upload/admin/controller/localisation/tax_rate.php
+++ b/upload/admin/controller/localisation/tax_rate.php
@@ -216,7 +216,7 @@ class TaxRate extends \Opencart\System\Engine\Controller {
 			$data['tax_rate_id'] = 0;
 		}
 
-	    if (!empty($tax_rate_info)) {
+		if (!empty($tax_rate_info)) {
 			$data['name'] = $tax_rate_info['name'];
 		} else {
 			$data['name'] = '';

--- a/upload/admin/controller/marketplace/marketplace.php
+++ b/upload/admin/controller/marketplace/marketplace.php
@@ -729,7 +729,7 @@ class Marketplace extends \Opencart\System\Engine\Controller {
 						$download = '';
 					}
 
-			 		// Install
+					// Install
 					if ($install_info && !$install_info['status']) {
 						$install = $this->url->link('marketplace/installer.install', 'user_token=' . $this->session->data['user_token'] . '&extension_install_id=' . $install_info['extension_install_id']);
 					} else {

--- a/upload/admin/controller/sale/subscription.php
+++ b/upload/admin/controller/sale/subscription.php
@@ -769,8 +769,8 @@ class Subscription extends \Opencart\System\Engine\Controller {
 		if (!$this->user->hasPermission('modify', 'sale/subscription')) {
 			$json['error'] = $this->language->get('error_permission');
 		} elseif ($this->request->post['subscription_plan_id'] == '') {
-            $json['error'] = $this->language->get('error_subscription_plan');
-        }
+			$json['error'] = $this->language->get('error_subscription_plan');
+		}
 
 		$this->load->model('catalog/subscription_plan');
 
@@ -877,8 +877,8 @@ class Subscription extends \Opencart\System\Engine\Controller {
 		}
 
 		if (!$this->user->hasPermission('modify', 'sale/subscription')) {
-            $json['error'] = $this->language->get('error_permission');
-        }
+			$json['error'] = $this->language->get('error_permission');
+		}
 
 		// Subscription
 		$this->load->model('sale/subscription');
@@ -895,8 +895,8 @@ class Subscription extends \Opencart\System\Engine\Controller {
 		$subscription_status_info = $this->model_localisation_subscription_status->getSubscriptionStatus($this->request->post['subscription_status_id']);
 
 		if (!$subscription_status_info) {
-            $json['error'] = $this->language->get('error_subscription_status');
-        }
+			$json['error'] = $this->language->get('error_subscription_status');
+		}
 
 		if (!$json) {
 			$this->model_sale_subscription->addHistory($subscription_id, $this->request->post['subscription_status_id'], $this->request->post['comment'], $this->request->post['notify']);

--- a/upload/admin/model/catalog/attribute.php
+++ b/upload/admin/model/catalog/attribute.php
@@ -13,7 +13,7 @@ class Attribute extends \Opencart\System\Engine\Model {
 	 *
 	 *	Create a new attribute record in the database.
 	 *
-     *	@param	array	$data
+	 *	@param	array	$data
 	 *
 	 *	@return	int		returns the primary key of the new attribute record.
 	 */
@@ -34,7 +34,7 @@ class Attribute extends \Opencart\System\Engine\Model {
 	 *
 	 *	Edit attribute record in the database.
 	 *
-     *	@param	int		$attribute_id	Primary key of the attribute record to edit.
+	 *	@param	int		$attribute_id	Primary key of the attribute record to edit.
 	 *	@param	array	$data  			Array of data [
 	 * 		'attribute_group_id'
 	 * ].

--- a/upload/admin/model/catalog/attribute_group.php
+++ b/upload/admin/model/catalog/attribute_group.php
@@ -24,11 +24,11 @@ class AttributeGroup extends \Opencart\System\Engine\Model {
 	}
 
 	/**
-     * @param int   $attribute_group_id
-     * @param array $data
-     *
-     * @return void
-     */
+	 * @param int   $attribute_group_id
+	 * @param array $data
+	 *
+	 * @return void
+	 */
 	public function editAttributeGroup(int $attribute_group_id, array $data): void {
 		$this->db->query("UPDATE `" . DB_PREFIX . "attribute_group` SET `sort_order` = '" . (int)$data['sort_order'] . "' WHERE `attribute_group_id` = '" . (int)$attribute_group_id . "'");
 

--- a/upload/admin/model/customer/customer.php
+++ b/upload/admin/model/customer/customer.php
@@ -255,8 +255,8 @@ class Customer extends \Opencart\System\Engine\Model {
 
 	/**
 	 * @param int   $customer_id
-     * @param int   $address_id
-     * @param array $data
+	 * @param int   $address_id
+	 * @param array $data
 	 *
 	 * @return void
 	 */

--- a/upload/admin/model/setting/event.php
+++ b/upload/admin/model/setting/event.php
@@ -46,11 +46,11 @@ class Event extends \Opencart\System\Engine\Model {
 	}
 
 	/**
-     * @param string $code
-     * @param bool   $status
-     *
-     * @return void
-     */
+	 * @param string $code
+	 * @param bool   $status
+	 *
+	 * @return void
+	 */
 	public function editStatusByCode(string $code, bool $status): void {
 		$this->db->query("UPDATE `" . DB_PREFIX . "event` SET `status` = '" . (bool)$status . "' WHERE `code` = '" . $this->db->escape($code) . "'");
 	}


### PR DESCRIPTION
This was done using php-cs-fixer's indentation_type rule. Once all outstanding PR regarding code formatting have been merged future changes can be checked for issues in GitHub action and developers can run the tool locally to fix any formatting issues with there code.