### PR TITLE
Remove trailing whitespace in code

### DIFF
--- a/upload/admin/controller/common/developer.php
+++ b/upload/admin/controller/common/developer.php
@@ -92,7 +92,7 @@ class Developer extends \Opencart\System\Engine\Controller {
 				foreach ($directories as $directory) {
 					$files = glob($directory . '/*');
 					
-					foreach ($files as $file) { 
+					foreach ($files as $file) {
 						if (is_file($file)) {
 							unlink($file);
 						}
@@ -152,10 +152,10 @@ class Developer extends \Opencart\System\Engine\Controller {
 			}
 
 			$json['success'] = $this->language->get('text_sass_success');
-		}	
+		}
 		
 		$this->response->addHeader('Content-Type: application/json');
-		$this->response->setOutput(json_encode($json));					
+		$this->response->setOutput(json_encode($json));
 	}
 
 	/**

--- a/upload/admin/controller/customer/customer_approval.php
+++ b/upload/admin/controller/customer/customer_approval.php
@@ -41,7 +41,7 @@ class CustomerApproval extends \Opencart\System\Engine\Controller {
 		$data['column_left'] = $this->load->controller('common/column_left');
 		$data['footer'] = $this->load->controller('common/footer');
 
-		$this->response->setOutput($this->load->view('customer/customer_approval', $data));	
+		$this->response->setOutput($this->load->view('customer/customer_approval', $data));
 	}
 
 	/**
@@ -144,7 +144,7 @@ class CustomerApproval extends \Opencart\System\Engine\Controller {
 			'limit'                    => $this->config->get('config_pagination_admin')
 		];
 
-		$this->load->model('customer/customer_approval');	
+		$this->load->model('customer/customer_approval');
 
 		$results = $this->model_customer_customer_approval->getCustomerApprovals($filter_data);
 

--- a/upload/admin/controller/event/debug.php
+++ b/upload/admin/controller/event/debug.php
@@ -37,5 +37,5 @@ class Debug extends \Opencart\System\Engine\Controller {
 				$this->log->write($route);
 			}
 		}
-	}	
+	}
 }

--- a/upload/admin/controller/mail/transaction.php
+++ b/upload/admin/controller/mail/transaction.php
@@ -25,7 +25,7 @@ class Transaction extends \Opencart\System\Engine\Controller {
 			$description = $args[1];
 		} else {
 			$description = '';
-		}		
+		}
 		
 		if (isset($args[2])) {
 			$amount = $args[2];

--- a/upload/admin/controller/marketplace/api.php
+++ b/upload/admin/controller/marketplace/api.php
@@ -12,7 +12,7 @@ class Api extends \Opencart\System\Engine\Controller {
 	public function index(): void {
 		$this->load->language('marketplace/api');
 			
-		$data['user_token'] = $this->session->data['user_token'];	
+		$data['user_token'] = $this->session->data['user_token'];
 			
 		$this->response->setOutput($this->load->view('marketplace/api', $data));
 	}
@@ -35,7 +35,7 @@ class Api extends \Opencart\System\Engine\Controller {
 
 		if (!$this->request->post['opencart_secret']) {
 			$json['error']['secret'] = $this->language->get('error_secret');
-		}		
+		}
 
 		if (!$json) {
 			$this->load->model('setting/setting');

--- a/upload/admin/controller/sale/voucher.php
+++ b/upload/admin/controller/sale/voucher.php
@@ -115,7 +115,7 @@ class Voucher extends \Opencart\System\Engine\Controller {
 		$results = $this->model_sale_voucher->getVouchers($filter_data);
 
 		foreach ($results as $result) {
-			if ($result['order_id']) {	
+			if ($result['order_id']) {
 				$order_href = $this->url->link('sale/order.info', 'user_token=' . $this->session->data['user_token'] . '&order_id=' . $result['order_id'] . $url);
 			} else {
 				$order_href = '';

--- a/upload/admin/model/catalog/attribute.php
+++ b/upload/admin/model/catalog/attribute.php
@@ -104,8 +104,8 @@ class Attribute extends \Opencart\System\Engine\Model {
 		}
 
 		$sort_data = [
-			'ad.name', 
-			'attribute_group', 
+			'ad.name',
+			'attribute_group',
 			'a.sort_order'
 		];
 

--- a/upload/catalog/controller/event/activity.php
+++ b/upload/catalog/controller/event/activity.php
@@ -80,7 +80,7 @@ class Activity extends \Opencart\System\Engine\Controller {
 	
 					$this->model_account_activity->addActivity('reset', $activity_data);
 				}
-			}	
+			}
 		}
 	}
 	
@@ -107,7 +107,7 @@ class Activity extends \Opencart\System\Engine\Controller {
 	
 				$this->model_account_activity->addActivity('login', $activity_data);
 			}
-		}	
+		}
 	}
 	
 	// catalog/model/account/customer/editCode/after
@@ -135,7 +135,7 @@ class Activity extends \Opencart\System\Engine\Controller {
 
 				$this->model_account_activity->addActivity('forgotten', $activity_data);
 			}
-		}	
+		}
 	}
 	
 	// catalog/model/account/customer/addTransaction/after
@@ -165,7 +165,7 @@ class Activity extends \Opencart\System\Engine\Controller {
 				$this->model_account_activity->addActivity('transaction', $activity_data);
 			}
 		}
-	}	
+	}
 	
 	// catalog/model/account/affiliate/addAffiliate/after
 
@@ -187,7 +187,7 @@ class Activity extends \Opencart\System\Engine\Controller {
 
 			$this->model_account_activity->addActivity('affiliate_add', $activity_data);
 		}
-	}	
+	}
 	
 	// catalog/model/account/affiliate/editAffiliate/after
 
@@ -230,7 +230,7 @@ class Activity extends \Opencart\System\Engine\Controller {
 			];
 
 			$this->model_account_activity->addActivity('address_add', $activity_data);
-		}	
+		}
 	}
 	
 	// catalog/model/account/address/editAddress/after
@@ -252,7 +252,7 @@ class Activity extends \Opencart\System\Engine\Controller {
 			];
 
 			$this->model_account_activity->addActivity('address_edit', $activity_data);
-		}	
+		}
 	}
 	
 	// catalog/model/account/address/deleteAddress/after
@@ -307,7 +307,7 @@ class Activity extends \Opencart\System\Engine\Controller {
 				$this->model_account_activity->addActivity('return_guest', $activity_data);
 			}
 		}
-	}	
+	}
 	
 	// catalog/model/checkout/order/addHistory/before
 

--- a/upload/catalog/controller/event/statistics.php
+++ b/upload/catalog/controller/event/statistics.php
@@ -17,7 +17,7 @@ class Statistics extends \Opencart\System\Engine\Controller {
 	public function addReview(string &$route, array &$args, &$output): void {
 		$this->load->model('report/statistics');
 
-		$this->model_report_statistics->addValue('review', 1);	
+		$this->model_report_statistics->addValue('review', 1);
 	}
 		
 	// catalog/model/account/returns/addReturn/after

--- a/upload/catalog/controller/event/translation.php
+++ b/upload/catalog/controller/event/translation.php
@@ -23,6 +23,6 @@ class Translation extends \Opencart\System\Engine\Controller {
 			} else {
 				$this->language->set($prefix . '_' . $result['key'], html_entity_decode($result['value'], ENT_QUOTES, 'UTF-8'));
 			}
-		}	
+		}
 	}
 }

--- a/upload/catalog/model/report/statistics.php
+++ b/upload/catalog/model/report/statistics.php
@@ -58,5 +58,5 @@ class Statistics extends \Opencart\System\Engine\Model {
 	 */
 	public function editValue(string $code, float $value): void {
 		$this->db->query("UPDATE `" . DB_PREFIX . "statistics` SET `value` = '" . (float)$value . "' WHERE `code` = '" . $this->db->escape($code) . "'");
-	}	
+	}
 }

--- a/upload/catalog/model/setting/module.php
+++ b/upload/catalog/model/setting/module.php
@@ -19,5 +19,5 @@ class Module extends \Opencart\System\Engine\Model {
 		} else {
 			return [];
 		}
-	}		
+	}
 }

--- a/upload/catalog/model/setting/setting.php
+++ b/upload/catalog/model/setting/setting.php
@@ -53,5 +53,5 @@ class Setting extends \Opencart\System\Engine\Model {
 		} else {
 			return '';
 		}
-	}	
+	}
 }

--- a/upload/extension/opencart/catalog/controller/module/category.php
+++ b/upload/extension/opencart/catalog/controller/module/category.php
@@ -30,7 +30,7 @@ class Category extends \Opencart\System\Engine\Controller {
 			$data['child_id'] = 0;
 		}
 
-		$this->load->model('catalog/category');		
+		$this->load->model('catalog/category');
 		$this->load->model('catalog/product');
 
 		$data['categories'] = [];
@@ -45,7 +45,7 @@ class Category extends \Opencart\System\Engine\Controller {
 
 				foreach ($children as $child) {
 					$filter_data = [
-						'filter_category_id'  => $child['category_id'], 
+						'filter_category_id'  => $child['category_id'],
 						'filter_sub_category' => true
 					];
 

--- a/upload/install/controller/install/step_3.php
+++ b/upload/install/controller/install/step_3.php
@@ -299,7 +299,7 @@ class Step3 extends \Opencart\System\Engine\Controller {
 			$data['db_ssl_ca'] = $this->request->post['db_ssl_ca'];
 		} else {
 			$data['db_ssl_ca'] = '';
-		}		
+		}
 
 		if (isset($this->request->post['db_database'])) {
 			$data['db_database'] = $this->request->post['db_database'];

--- a/upload/install/controller/upgrade/upgrade_8.php
+++ b/upload/install/controller/upgrade/upgrade_8.php
@@ -98,7 +98,7 @@ class Upgrade8 extends \Opencart\System\Engine\Controller {
 			if (!$query->num_rows) {
 				$this->db->query("ALTER TABLE `" . DB_PREFIX . "country` ADD COLUMN `address_format_id` int(11) NOT NULL AFTER `address_format`");
 				$this->db->query("ALTER TABLE `" . DB_PREFIX . "country` DROP COLUMN `address_format`");
-			}		
+			}
 
 			$query = $this->db->query("SELECT * FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = '" . DB_DATABASE . "' AND TABLE_NAME = '" . DB_PREFIX . "address_format'");
 

--- a/upload/system/engine/autoloader.php
+++ b/upload/system/engine/autoloader.php
@@ -34,7 +34,7 @@ class Autoloader {
 	 * @return void
 	 *
 	 * @psr-4 filename standard is stupid composer has lower case file structure than its packages have camelcase file names!
-	 */	
+	 */
 	public function register(string $namespace, string $directory, $psr4 = false): void {
 		$this->path[$namespace] = [
 			'directory' => $directory,

--- a/upload/system/engine/event.php
+++ b/upload/system/engine/event.php
@@ -53,7 +53,7 @@ class Event {
 			$sort_order[$key] = $value['priority'];
 		}
 
-		array_multisort($sort_order, SORT_ASC, $this->data);	
+		array_multisort($sort_order, SORT_ASC, $this->data);
 	}
 	
 	/**
@@ -87,7 +87,7 @@ class Event {
 			if ($trigger == $value['trigger'] && $value['action']->getId() == $route) {
 				unset($this->data[$key]);
 			}
-		}			
+		}
 	}
 	
 	/**
@@ -103,5 +103,5 @@ class Event {
 				unset($this->data[$key]);
 			}
 		}
-	}	
+	}
 }


### PR DESCRIPTION
This was done using php-cs-fixer's no_trailing_whitespace rule. Once all outstanding PR regarding code formatting have been merged future changes can be checked for issues in GitHub action and developers can run the tool locally to fix any formatting issues with there code.