### PR TITLE
Remove trailing whitespace from empty lines in admin

### DIFF
--- a/upload/admin/controller/catalog/review.php
+++ b/upload/admin/controller/catalog/review.php
@@ -222,7 +222,7 @@ class Review extends \Opencart\System\Engine\Controller {
 		];
 
 		$this->load->model('catalog/review');
-		
+
 		$results = $this->model_catalog_review->getReviews($filter_data);
 
 		foreach ($results as $result) {
@@ -301,7 +301,7 @@ class Review extends \Opencart\System\Engine\Controller {
 		}
 
 		$review_total = $this->model_catalog_review->getTotalReviews($filter_data);
-		
+
 		$data['pagination'] = $this->load->controller('common/pagination', [
 			'total' => $review_total,
 			'page'  => $page,

--- a/upload/admin/controller/common/developer.php
+++ b/upload/admin/controller/common/developer.php
@@ -78,9 +78,9 @@ class Developer extends \Opencart\System\Engine\Controller {
 	 */
 	public function theme(): void {
 		$this->load->language('common/developer');
-		
+
 		$json = [];
-		
+
 		if (!$this->user->hasPermission('modify', 'common/developer')) {
 			$json['error'] = $this->language->get('error_permission');
 		}
@@ -97,16 +97,16 @@ class Developer extends \Opencart\System\Engine\Controller {
 							unlink($file);
 						}
 					}
-					
+
 					if (is_dir($directory)) {
 						rmdir($directory);
 					}
 				}
 			}
-						
+
 			$json['success'] = $this->language->get('text_theme_success');
 		}
-		
+
 		$this->response->addHeader('Content-Type: application/json');
 		$this->response->setOutput(json_encode($json));
 	}
@@ -116,9 +116,9 @@ class Developer extends \Opencart\System\Engine\Controller {
 	 */
 	public function sass(): void {
 		$this->load->language('common/developer');
-		
+
 		$json = [];
-		
+
 		if (!$this->user->hasPermission('modify', 'common/developer')) {
 			$json['error'] = $this->language->get('error_permission');
 		}
@@ -126,26 +126,26 @@ class Developer extends \Opencart\System\Engine\Controller {
 		if (!$json) {
 			// Before we delete we need to make sure there is a sass file to regenerate the css
 			$file = DIR_APPLICATION  . 'view/stylesheet/bootstrap.css';
-			
+
 			if (is_file($file) && is_file(DIR_APPLICATION . 'view/stylesheet/scss/bootstrap.scss')) {
 				unlink($file);
 			}
-			 
+
 			$files = glob(DIR_CATALOG  . 'view/theme/*/stylesheet/scss/bootstrap.scss');
-			 
+
 			foreach ($files as $file) {
 				$file = substr($file, 0, -20) . '/bootstrap.css';
-				
+
 				if (is_file($file)) {
 					unlink($file);
 				}
 			}
 
 			$files = glob(DIR_CATALOG  . 'view/theme/*/stylesheet/stylesheet.scss');
-			 
+
 			foreach ($files as $file) {
 				$file = substr($file, 0, -16) . '/stylesheet.css';
-				
+
 				if (is_file($file)) {
 					unlink($file);
 				}

--- a/upload/admin/controller/customer/customer_approval.php
+++ b/upload/admin/controller/customer/customer_approval.php
@@ -68,7 +68,7 @@ class CustomerApproval extends \Opencart\System\Engine\Controller {
 		} else {
 			$filter_email = '';
 		}
-		
+
 		if (isset($this->request->get['filter_customer_group_id'])) {
 			$filter_customer_group_id = (int)$this->request->get['filter_customer_group_id'];
 		} else {
@@ -92,7 +92,7 @@ class CustomerApproval extends \Opencart\System\Engine\Controller {
 		} else {
 			$filter_date_to = '';
 		}
-						
+
 		if (isset($this->request->get['page'])) {
 			$page = (int)$this->request->get['page'];
 		} else {
@@ -172,11 +172,11 @@ class CustomerApproval extends \Opencart\System\Engine\Controller {
 		if (isset($this->request->get['filter_email'])) {
 			$url .= '&filter_email=' . urlencode(html_entity_decode($this->request->get['filter_email'], ENT_QUOTES, 'UTF-8'));
 		}
-			
+
 		if (isset($this->request->get['filter_customer_group_id'])) {
 			$url .= '&filter_customer_group_id=' . $this->request->get['filter_customer_group_id'];
 		}
-		
+
 		if (isset($this->request->get['filter_type'])) {
 			$url .= '&filter_type=' . $this->request->get['filter_type'];
 		}
@@ -256,7 +256,7 @@ class CustomerApproval extends \Opencart\System\Engine\Controller {
 		$this->load->language('customer/customer_approval');
 
 		$json = [];
-				
+
 		if (!$this->user->hasPermission('modify', 'customer/customer_approval')) {
 			$json['error'] = $this->language->get('error_permission');
 		}
@@ -290,7 +290,7 @@ class CustomerApproval extends \Opencart\System\Engine\Controller {
 
 			$json['success'] = $this->language->get('text_success');
 		}
-		
+
 		$this->response->addHeader('Content-Type: application/json');
 		$this->response->setOutput(json_encode($json));
 	}

--- a/upload/admin/controller/design/banner.php
+++ b/upload/admin/controller/design/banner.php
@@ -246,7 +246,7 @@ class Banner extends \Opencart\System\Engine\Controller {
 					$image = '';
 					$thumb = 'no_image.png';
 				}
-				
+
 				$data['banner_images'][$language_id][] = [
 					'title'      => $value['title'],
 					'link'       => $value['link'],

--- a/upload/admin/controller/error/not_found.php
+++ b/upload/admin/controller/error/not_found.php
@@ -11,7 +11,7 @@ class NotFound extends \Opencart\System\Engine\Controller {
 	 */
 	public function index(): void {
 		$this->load->language('error/not_found');
-		
+
 		$this->document->setTitle($this->language->get('heading_title'));
 
 		$data['breadcrumbs'] = [];

--- a/upload/admin/controller/event/debug.php
+++ b/upload/admin/controller/event/debug.php
@@ -33,7 +33,7 @@ class Debug extends \Opencart\System\Engine\Controller {
 					'route' => $route,
 					'time'  => microtime() - $this->session->data['debug'][$route]
 				];
-				
+
 				$this->log->write($route);
 			}
 		}

--- a/upload/admin/controller/localisation/language.php
+++ b/upload/admin/controller/localisation/language.php
@@ -277,11 +277,11 @@ class Language extends \Opencart\System\Engine\Controller {
 		if ((oc_strlen($this->request->post['code']) < 2) || (oc_strlen($this->request->post['code']) > 5)) {
 			$json['error']['code'] = $this->language->get('error_code');
 		}
-		
+
 		if ((oc_strlen($this->request->post['locale']) < 2) || (oc_strlen($this->request->post['locale']) > 255)) {
 			$json['error']['locale'] = $this->language->get('error_locale');
 		}
-		
+
 		$language_info = $this->model_localisation_language->getLanguageByCode($this->request->post['code']);
 
 		if (!$this->request->post['language_id']) {

--- a/upload/admin/controller/localisation/location.php
+++ b/upload/admin/controller/localisation/location.php
@@ -237,7 +237,7 @@ class Location extends \Opencart\System\Engine\Controller {
 		} else {
 			$data['telephone'] = '';
 		}
-		
+
 		if (!empty($location_info)) {
 			$data['image'] = $location_info['image'];
 		} else {

--- a/upload/admin/controller/localisation/tax_class.php
+++ b/upload/admin/controller/localisation/tax_class.php
@@ -59,7 +59,7 @@ class TaxClass extends \Opencart\System\Engine\Controller {
 	 */
 	public function list(): void {
 		$this->load->language('localisation/tax_class');
-		
+
 		$this->response->setOutput($this->getList());
 	}
 

--- a/upload/admin/controller/mail/returns.php
+++ b/upload/admin/controller/mail/returns.php
@@ -58,7 +58,7 @@ class Returns extends \Opencart\System\Engine\Controller {
 				}
 
 				$this->load->model('localisation/language');
-				
+
 				$language_info = $this->model_localisation_language->getLanguage($return_info['language_id']);
 
 				if ($language_info) {

--- a/upload/admin/controller/mail/transaction.php
+++ b/upload/admin/controller/mail/transaction.php
@@ -20,7 +20,7 @@ class Transaction extends \Opencart\System\Engine\Controller {
 		} else {
 			$customer_id = 0;
 		}
-		
+
 		if (isset($args[1])) {
 			$description = $args[1];
 		} else {
@@ -32,15 +32,15 @@ class Transaction extends \Opencart\System\Engine\Controller {
 		} else {
 			$amount = 0;
 		}
-		
+
 		if (isset($args[3])) {
 			$order_id = $args[3];
 		} else {
 			$order_id = 0;
 		}
-			
+
 		$this->load->model('customer/customer');
-						
+
 		$customer_info = $this->model_customer_customer->getCustomer($customer_id);
 
 		if ($customer_info) {

--- a/upload/admin/controller/marketplace/api.php
+++ b/upload/admin/controller/marketplace/api.php
@@ -24,7 +24,7 @@ class Api extends \Opencart\System\Engine\Controller {
 		$this->load->language('marketplace/api');
 
 		$json = [];
-		
+
 		if (!$this->user->hasPermission('modify', 'marketplace/api')) {
 			$json['error']['warning'] = $this->language->get('error_permission');
 		}
@@ -39,9 +39,9 @@ class Api extends \Opencart\System\Engine\Controller {
 
 		if (!$json) {
 			$this->load->model('setting/setting');
-			
+
 			$this->model_setting_setting->editSetting('opencart', $this->request->post);
-			
+
 			$json['success'] = $this->language->get('text_success');
 		}
 

--- a/upload/admin/controller/marketplace/marketplace.php
+++ b/upload/admin/controller/marketplace/marketplace.php
@@ -517,7 +517,7 @@ class Marketplace extends \Opencart\System\Engine\Controller {
 		$data['filter_license'] = $filter_license;
 		$data['filter_member_type'] = $filter_member_type;
 		$data['filter_rating'] = $filter_rating;
-		
+
 		$data['sort'] = $sort;
 
 		$data['user_token'] = $this->session->data['user_token'];

--- a/upload/admin/controller/report/online.php
+++ b/upload/admin/controller/report/online.php
@@ -27,7 +27,7 @@ class Online extends \Opencart\System\Engine\Controller {
 		if (isset($this->request->get['page'])) {
 			$url .= '&page=' . $this->request->get['page'];
 		}
-			
+
 		$data['breadcrumbs'] = [];
 
 		$data['breadcrumbs'][] = [
@@ -47,7 +47,7 @@ class Online extends \Opencart\System\Engine\Controller {
 		$data['header'] = $this->load->controller('common/header');
 		$data['column_left'] = $this->load->controller('common/column_left');
 		$data['footer'] = $this->load->controller('common/footer');
-		
+
 		$this->response->setOutput($this->load->view('report/online', $data));
 	}
 

--- a/upload/admin/controller/report/statistics.php
+++ b/upload/admin/controller/report/statistics.php
@@ -51,11 +51,11 @@ class Statistics extends \Opencart\System\Engine\Controller {
 	 */
 	public function getList(): string {
 		$data['statistics'] = [];
-		
+
 		$this->load->model('report/statistics');
-		
+
 		$results = $this->model_report_statistics->getStatistics();
-		
+
 		foreach ($results as $result) {
 			$data['statistics'][] = [
 				'name'  => $this->language->get('text_' . $result['code']),

--- a/upload/admin/controller/sale/voucher.php
+++ b/upload/admin/controller/sale/voucher.php
@@ -120,7 +120,7 @@ class Voucher extends \Opencart\System\Engine\Controller {
 			} else {
 				$order_href = '';
 			}
-			
+
 			$data['vouchers'][] = [
 				'voucher_id' => $result['voucher_id'],
 				'code'       => $result['code'],

--- a/upload/admin/controller/startup/application.php
+++ b/upload/admin/controller/startup/application.php
@@ -34,10 +34,10 @@ class Application extends \Opencart\System\Engine\Controller {
 
 		// Weight
 		$this->registry->set('weight', new \Opencart\System\Library\Cart\Weight($this->registry));
-		
+
 		// Length
 		$this->registry->set('length', new \Opencart\System\Library\Cart\Length($this->registry));
-		
+
 		// Cart
 		$this->registry->set('cart', new \Opencart\System\Library\Cart\Cart($this->registry));
 	}

--- a/upload/admin/controller/startup/event.php
+++ b/upload/admin/controller/startup/event.php
@@ -12,9 +12,9 @@ class Event extends \Opencart\System\Engine\Controller {
 	public function index(): void {
 		// Add events from the DB
 		$this->load->model('setting/event');
-		
+
 		$results = $this->model_setting_event->getEvents();
-		
+
 		foreach ($results as $result) {
 			if ($result['status']) {
 				$part = explode('/', $result['trigger']);

--- a/upload/admin/controller/tool/log.php
+++ b/upload/admin/controller/tool/log.php
@@ -11,7 +11,7 @@ class Log extends \Opencart\System\Engine\Controller {
 	 */
 	public function index(): void {
 		$this->load->language('tool/log');
-		
+
 		$this->document->setTitle($this->language->get('heading_title'));
 
 		$data['breadcrumbs'] = [];

--- a/upload/admin/controller/tool/notification.php
+++ b/upload/admin/controller/tool/notification.php
@@ -75,7 +75,7 @@ class Notification extends \Opencart\System\Engine\Controller {
 
 		foreach ($results as $result) {
 			$second = time() - strtotime($result['date_added']);
-			
+
 			$ranges = [
 				'second' => $second,
 				'minute' => floor($second / 60),

--- a/upload/admin/model/localisation/return_reason.php
+++ b/upload/admin/model/localisation/return_reason.php
@@ -23,7 +23,7 @@ class ReturnReason extends \Opencart\System\Engine\Model {
 		}
 
 		$this->cache->delete('return_reason');
-		
+
 		return $return_reason_id;
 	}
 

--- a/upload/admin/model/tool/image.php
+++ b/upload/admin/model/tool/image.php
@@ -26,7 +26,7 @@ class Image extends \Opencart\System\Engine\Model {
 
 		if (!is_file(DIR_IMAGE . $image_new) || (filemtime(DIR_IMAGE . $image_old) > filemtime(DIR_IMAGE . $image_new))) {
 			[$width_orig, $height_orig, $image_type] = getimagesize(DIR_IMAGE . $image_old);
-				 
+
 			if (!in_array($image_type, [IMAGETYPE_PNG, IMAGETYPE_JPEG, IMAGETYPE_GIF, IMAGETYPE_WEBP])) {
 				return HTTP_CATALOG . 'image/' . $image_old;
 			}

--- a/upload/admin/model/user/user_group.php
+++ b/upload/admin/model/user/user_group.php
@@ -13,7 +13,7 @@ class UserGroup extends \Opencart\System\Engine\Model {
 	 */
 	public function addUserGroup(array $data): int {
 		$this->db->query("INSERT INTO `" . DB_PREFIX . "user_group` SET `name` = '" . $this->db->escape((string)$data['name']) . "', `permission` = '" . (isset($data['permission']) ? $this->db->escape(json_encode($data['permission'])) : '') . "'");
-	
+
 		return $this->db->getLastId();
 	}
 


### PR DESCRIPTION
This was done using php-cs-fixer's no_whitespace_in_blank_line rule. Once all outstanding PR regarding code formatting have been merged future changes can be checked for issues in GitHub action and developers can run the tool locally to fix any formatting issues with there code.