### PR TITLE
Fix incorrect indentation in base

### DIFF
--- a/upload/install/cli_install.php
+++ b/upload/install/cli_install.php
@@ -95,8 +95,8 @@ set_error_handler(function($code, $message, $file, $line, array $errcontext) {
  */
 class CliInstall extends \Opencart\System\Engine\Controller {
 	/**
-     * @return void
-     */
+	 * @return void
+	 */
 	public function index(): void {
 		if (isset($this->request->server['argv'])) {
 			$argv = $this->request->server['argv'];

--- a/upload/install/controller/upgrade/upgrade_5.php
+++ b/upload/install/controller/upgrade/upgrade_5.php
@@ -257,7 +257,7 @@ class Upgrade5 extends \Opencart\System\Engine\Controller {
 			$this->db->query("DELETE FROM `" . DB_PREFIX . "event` WHERE `action` = 'extension/extension/promotion.getList'");
 			
 			// Rename subscription to mail_subscription
-            $this->db->query("UPDATE `" . DB_PREFIX . "event` SET `code` = 'mail_subscription' WHERE `code` = 'subscription'");
+			$this->db->query("UPDATE `" . DB_PREFIX . "event` SET `code` = 'mail_subscription' WHERE `code` = 'subscription'");
 		} catch (\ErrorException $exception) {
 			$json['error'] = sprintf($this->language->get('error_exception'), $exception->getCode(), $exception->getMessage(), $exception->getFile(), $exception->getLine());
 		}

--- a/upload/install/controller/upgrade/upgrade_8.php
+++ b/upload/install/controller/upgrade/upgrade_8.php
@@ -131,11 +131,11 @@ class Upgrade8 extends \Opencart\System\Engine\Controller {
 			}
 			
 			// Addresses
-            $query = $this->db->query("SELECT * FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = '" . DB_DATABASE . "' AND TABLE_NAME = '" . DB_PREFIX . "address' AND COLUMN_NAME = 'default'");
+			$query = $this->db->query("SELECT * FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = '" . DB_DATABASE . "' AND TABLE_NAME = '" . DB_PREFIX . "address' AND COLUMN_NAME = 'default'");
 
-            if (!$query->num_rows) {
-                $this->db->query("ALTER TABLE `" . DB_PREFIX . "address` ADD COLUMN `default` tinyint(1) NOT NULL AFTER `custom_field`");
-            }
+			if (!$query->num_rows) {
+				$this->db->query("ALTER TABLE `" . DB_PREFIX . "address` ADD COLUMN `default` tinyint(1) NOT NULL AFTER `custom_field`");
+			}
 
 			// Drop Fields
 			$remove = [];

--- a/upload/system/config/admin.php
+++ b/upload/system/config/admin.php
@@ -63,7 +63,7 @@ $_['action_event']       = [
 	'language/*/before' => [
 		0 => 'event/modification.language'
 	],
-    'language/*/after' => [
-        0 => 'startup/language.after'
-    ]
+	'language/*/after' => [
+		0 => 'startup/language.after'
+	]
 ];

--- a/upload/system/engine/controller.php
+++ b/upload/system/engine/controller.php
@@ -28,12 +28,12 @@ class Controller {
 	}
 
 	/**
-     * __get
-     *
-     * @param string $key
-     *
-     * @return object
-     */
+	 * __get
+	 *
+	 * @param string $key
+	 *
+	 * @return object
+	 */
 	public function __get(string $key): object {
 		if ($this->registry->has($key)) {
 			return $this->registry->get($key);
@@ -43,13 +43,13 @@ class Controller {
 	}
 
 	/**
-     * __set
-     *
-     * @param string $key
-     * @param object $value
-     *
-     * @return void
-     */
+	 * __set
+	 *
+	 * @param string $key
+	 * @param object $value
+	 *
+	 * @return void
+	 */
 	public function __set(string $key, object $value): void {
 		$this->registry->set($key, $value);
 	}

--- a/upload/system/engine/event.php
+++ b/upload/system/engine/event.php
@@ -23,23 +23,23 @@ class Event {
 	protected array $data = [];
 	
 	/**
-     * Constructor
-     *
-     * @param object $route
-     */
+	 * Constructor
+	 *
+	 * @param object $route
+	 */
 	public function __construct(\Opencart\System\Engine\Registry $registry) {
 		$this->registry = $registry;
 	}
 	
 	/**
-     * Register
-     *
-     * @param string $trigger
-     * @param object $action
-     * @param int	 $priority
-     *
-     * @return void
-     */
+	 * Register
+	 *
+	 * @param string $trigger
+	 * @param object $action
+	 * @param int	 $priority
+	 *
+	 * @return void
+	 */
 	public function register(string $trigger, \Opencart\System\Engine\Action $action, int $priority = 0): void {
 		$this->data[] = [
 			'trigger'  => $trigger,
@@ -57,13 +57,13 @@ class Event {
 	}
 	
 	/**
-     * Trigger
-     *
-     * @param string $event
-     * @param array	 $args
-     *
-     * @return mixed
-     */
+	 * Trigger
+	 *
+	 * @param string $event
+	 * @param array	 $args
+	 *
+	 * @return mixed
+	 */
 	public function trigger(string $event, array $args = []) {
 		foreach ($this->data as $value) {
 			if (preg_match('/^' . str_replace(['\*', '\?'], ['.*', '.'], preg_quote($value['trigger'], '/')) . '/', $event)) {
@@ -75,13 +75,13 @@ class Event {
 	}
 	
 	/**
-     * Unregister
-     *
-     * @param string $trigger
-     * @param string $route
-     *
-     * @return void
-     */
+	 * Unregister
+	 *
+	 * @param string $trigger
+	 * @param string $route
+	 *
+	 * @return void
+	 */
 	public function unregister(string $trigger, string $route): void {
 		foreach ($this->data as $key => $value) {
 			if ($trigger == $value['trigger'] && $value['action']->getId() == $route) {
@@ -91,12 +91,12 @@ class Event {
 	}
 	
 	/**
-     * Clear
-     *
-     * @param string $trigger
-     *
-     * @return void
-     */
+	 * Clear
+	 *
+	 * @param string $trigger
+	 *
+	 * @return void
+	 */
 	public function clear(string $trigger): void {
 		foreach ($this->data as $key => $value) {
 			if ($trigger == $value['trigger']) {

--- a/upload/system/engine/factory.php
+++ b/upload/system/engine/factory.php
@@ -71,13 +71,13 @@ class Factory {
 	}
 
 	/**
-     * Library
-     *
-     * @param string $route
-     * @param array  $args
-     *
-     * @return object
-     */
+	 * Library
+	 *
+	 * @param string $route
+	 * @param array  $args
+	 *
+	 * @return object
+	 */
 	public function library(string $route, array $args): object {
 		// Sanitize the call
 		$route = preg_replace('/[^a-zA-Z0-9_\/]/', '', $route);

--- a/upload/system/engine/loader.php
+++ b/upload/system/engine/loader.php
@@ -19,51 +19,51 @@ class Loader {
 	protected $registry;
 
 	/**
-     * Constructor
-     *
-     * @param object $registry
-     */
+	 * Constructor
+	 *
+	 * @param object $registry
+	 */
 	public function __construct(\Opencart\System\Engine\Registry $registry) {
 		$this->registry = $registry;
 	}
 
 	/**
-     * __get
-     *
-     * https://www.php.net/manual/en/language.oop5.overloading.php#object.get
-     *
-     * @param string $key
-     *
-     * @return object
-     */
+	 * __get
+	 *
+	 * https://www.php.net/manual/en/language.oop5.overloading.php#object.get
+	 *
+	 * @param string $key
+	 *
+	 * @return object
+	 */
 	public function __get(string $key): object {
 		return $this->registry->get($key);
 	}
 
 	/**
-     * __set
-     *
-     * https://www.php.net/manual/en/language.oop5.overloading.php#object.set
-     *
-     * @param string $key
-     * @param object $value
-     *
-     * @return void
-     */
+	 * __set
+	 *
+	 * https://www.php.net/manual/en/language.oop5.overloading.php#object.set
+	 *
+	 * @param string $key
+	 * @param object $value
+	 *
+	 * @return void
+	 */
 	public function __set(string $key, object $value): void {
 		$this->registry->set($key, $value);
 	}
 
 	/**
-     * Controller
-     *
-     * https://wiki.php.net/rfc/variadics
-     *
-     * @param string $route
-     * @param mixed  $args
-     *
-     * @return mixed
-     */
+	 * Controller
+	 *
+	 * https://wiki.php.net/rfc/variadics
+	 *
+	 * @param string $route
+	 * @param mixed  $args
+	 *
+	 * @return mixed
+	 */
 	public function controller(string $route, ...$args) {
 		// Sanitize the call
 		$route = preg_replace('/[^a-zA-Z0-9_|\/\.]/', '', str_replace('|', '.', $route));
@@ -96,12 +96,12 @@ class Loader {
 	}
 
 	/**
-     * Model
+	 * Model
 	 *
-     * @param string $route
-     *
-     * @return void
-     */
+	 * @param string $route
+	 *
+	 * @return void
+	 */
 	public function model(string $route): void {
 		// Sanitize the call
 		$route = preg_replace('/[^a-zA-Z0-9_\/]/', '', $route);
@@ -170,16 +170,16 @@ class Loader {
 	}
 
 	/**
-     * View
-     *
-     * Loads the template file and generates the html code.
-     *
-     * @param string $route
-     * @param array  $data
-     * @param string $code
-     *
-     * @return string
-     */
+	 * View
+	 *
+	 * Loads the template file and generates the html code.
+	 *
+	 * @param string $route
+	 * @param array  $data
+	 * @param string $code
+	 *
+	 * @return string
+	 */
 	public function view(string $route, array $data = [], string $code = ''): string {
 		// Sanitize the call
 		$route = preg_replace('/[^a-zA-Z0-9_\/]/', '', $route);
@@ -203,14 +203,14 @@ class Loader {
 	}
 
 	/**
-     * Language
-     *
-     * @param string $route
-     * @param string $prefix
-     * @param string $code
-     *
-     * @return array
-     */
+	 * Language
+	 *
+	 * @param string $route
+	 * @param string $prefix
+	 * @param string $code
+	 *
+	 * @return array
+	 */
 	public function language(string $route, string $prefix = '', string $code = ''): array {
 		// Sanitize the call
 		$route = preg_replace('/[^a-zA-Z0-9_\-\/]/', '', $route);
@@ -256,12 +256,12 @@ class Loader {
 	}
 
 	/**
-     * Config
-     *
-     * @param string $route
-     *
-     * @return array
-     */
+	 * Config
+	 *
+	 * @param string $route
+	 *
+	 * @return array
+	 */
 	public function config(string $route): array {
 		// Sanitize the call
 		$route = preg_replace('/[^a-zA-Z0-9_\-\/]/', '', $route);
@@ -280,12 +280,12 @@ class Loader {
 	}
 
 	/**
-     * Helper
-     *
-     * @param string $route
-     *
-     * @return void
-     */
+	 * Helper
+	 *
+	 * @param string $route
+	 *
+	 * @return void
+	 */
 	public function helper(string $route): void {
 		$route = preg_replace('/[^a-zA-Z0-9_\/]/', '', $route);
 

--- a/upload/system/engine/model.php
+++ b/upload/system/engine/model.php
@@ -32,12 +32,12 @@ class Model {
 	}
 
 	/**
-     * __get
-     *
-     * @param string $key
-     *
-     * @return object
-     */
+	 * __get
+	 *
+	 * @param string $key
+	 *
+	 * @return object
+	 */
 	public function __get(string $key): object {
 		if ($this->registry->has($key)) {
 			return $this->registry->get($key);
@@ -47,26 +47,26 @@ class Model {
 	}
 
 	/**
-     * __set
-     *
-     * @param string $key
-     * @param string $value
-     *
-     * @return void
-     */
+	 * __set
+	 *
+	 * @param string $key
+	 * @param string $value
+	 *
+	 * @return void
+	 */
 	public function __set(string $key, object $value): void {
 		$this->registry->set($key, $value);
 	}
 
 	/**
-     * __isset
-     *
-     * https://www.php.net/manual/en/language.oop5.overloading.php#object.set
-     *
-     * @param string $key
-     *
-     * @return bool
-     */
+	 * __isset
+	 *
+	 * https://www.php.net/manual/en/language.oop5.overloading.php#object.set
+	 *
+	 * @param string $key
+	 *
+	 * @return bool
+	 */
 	public function __isset(string $key): bool {
 		return $this->registry->has($key);
 	}

--- a/upload/system/engine/registry.php
+++ b/upload/system/engine/registry.php
@@ -79,24 +79,24 @@ class Registry {
 	}
 
 	/**
-     * Get
-     *
-     * @param string $key
-     *
-     * @return ?object
-     */
+	 * Get
+	 *
+	 * @param string $key
+	 *
+	 * @return ?object
+	 */
 	public function get(string $key): ?object {
 		return isset($this->data[$key]) ? $this->data[$key] : null;
 	}
 
-    /**
-     * Set
-     *
-     * @param string $key
-     * @param object $value
-     *
-     * @return void
-     */
+	/**
+	 * Set
+	 *
+	 * @param string $key
+	 * @param object $value
+	 *
+	 * @return void
+	 */
 	public function set(string $key, object $value): void {
 		$this->data[$key] = $value;
 	}
@@ -113,14 +113,14 @@ class Registry {
 	}
 
 	/**
-     * Unset
-     *
-     * Unsets registry value by key.
-     *
-     * @param string $key
-     *
-     * @return void
-     */
+	 * Unset
+	 *
+	 * Unsets registry value by key.
+	 *
+	 * @param string $key
+	 *
+	 * @return void
+	 */
 	public function unset(string $key): void {
 		unset($this->data[$key]);
 	}


### PR DESCRIPTION
This was done using php-cs-fixer's indentation_type rule. Once all outstanding PR regarding code formatting have been merged future changes can be checked for issues in GitHub action and developers can run the tool locally to fix any formatting issues with there code.