### PR TITLE
Fix incorrect indentation in catalog

### DIFF
--- a/upload/catalog/controller/account/returns.php
+++ b/upload/catalog/controller/account/returns.php
@@ -172,7 +172,7 @@ class Returns extends \Opencart\System\Engine\Controller {
 				];
 			}
 
-		    $data['continue'] = $this->url->link('account/returns', 'language=' . $this->config->get('config_language') . $url . '&customer_token=' . $this->session->data['customer_token']);
+			$data['continue'] = $this->url->link('account/returns', 'language=' . $this->config->get('config_language') . $url . '&customer_token=' . $this->session->data['customer_token']);
 			$data['column_left'] = $this->load->controller('common/column_left');
 			$data['column_right'] = $this->load->controller('common/column_right');
 			$data['content_top'] = $this->load->controller('common/content_top');

--- a/upload/catalog/controller/api/account/login.php
+++ b/upload/catalog/controller/api/account/login.php
@@ -30,7 +30,7 @@ class Login extends \Opencart\System\Engine\Controller {
 	 * curl_setopt($curl, CURLOPT_POSTFIELDS, $request_data);
 	 *
 	 * $response = curl_exec($curl);
- 	 *
+	 *
 	 * $status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 	 *
 	 * curl_close($curl);

--- a/upload/catalog/controller/cms/comment.php
+++ b/upload/catalog/controller/cms/comment.php
@@ -273,8 +273,8 @@ class Comment extends \Opencart\System\Engine\Controller {
 	/*
 	 * Add
 	 *
-     * @return void
-     */
+	 * @return void
+	 */
 	public function add(): void {
 		$this->load->language('cms/comment');
 

--- a/upload/catalog/controller/product/category.php
+++ b/upload/catalog/controller/product/category.php
@@ -410,17 +410,17 @@ class Category extends \Opencart\System\Engine\Controller {
 
 			// http://googlewebmastercentral.blogspot.com/2011/09/pagination-with-relnext-and-relprev.html
 			if ($page == 1) {
-			    $this->document->addLink($this->url->link('product/category', 'language=' . $this->config->get('config_language') . '&path=' . $this->request->get['path']), 'canonical');
+				$this->document->addLink($this->url->link('product/category', 'language=' . $this->config->get('config_language') . '&path=' . $this->request->get['path']), 'canonical');
 			} else {
 				$this->document->addLink($this->url->link('product/category', 'language=' . $this->config->get('config_language') . '&path=' . $this->request->get['path'] . '&page='. $page), 'canonical');
 			}
 
 			if ($page > 1) {
-			    $this->document->addLink($this->url->link('product/category', 'language=' . $this->config->get('config_language') . '&path=' . $this->request->get['path'] . (($page - 2) ? '&page='. ($page - 1) : '')), 'prev');
+				$this->document->addLink($this->url->link('product/category', 'language=' . $this->config->get('config_language') . '&path=' . $this->request->get['path'] . (($page - 2) ? '&page='. ($page - 1) : '')), 'prev');
 			}
 
 			if ($limit && ceil($product_total / $limit) > $page) {
-			    $this->document->addLink($this->url->link('product/category', 'language=' . $this->config->get('config_language') . '&path=' . $this->request->get['path'] . '&page='. ($page + 1)), 'next');
+				$this->document->addLink($this->url->link('product/category', 'language=' . $this->config->get('config_language') . '&path=' . $this->request->get['path'] . '&page='. ($page + 1)), 'next');
 			}
 
 			$data['sort'] = $sort;

--- a/upload/catalog/controller/product/manufacturer.php
+++ b/upload/catalog/controller/product/manufacturer.php
@@ -323,7 +323,7 @@ class Manufacturer extends \Opencart\System\Engine\Controller {
 
 			// http://googlewebmastercentral.blogspot.com/2011/09/pagination-with-relnext-and-relprev.html
 			if ($page == 1) {
-			    $this->document->addLink($this->url->link('product/manufacturer.info', 'language=' . $this->config->get('config_language') . '&manufacturer_id=' . $this->request->get['manufacturer_id']), 'canonical');
+				$this->document->addLink($this->url->link('product/manufacturer.info', 'language=' . $this->config->get('config_language') . '&manufacturer_id=' . $this->request->get['manufacturer_id']), 'canonical');
 			} else {
 				$this->document->addLink($this->url->link('product/manufacturer.info', 'language=' . $this->config->get('config_language') . '&manufacturer_id=' . $this->request->get['manufacturer_id'] . '&page=' . $page), 'canonical');
 			}

--- a/upload/catalog/controller/product/special.php
+++ b/upload/catalog/controller/product/special.php
@@ -248,9 +248,9 @@ class Special extends \Opencart\System\Engine\Controller {
 
 		// http://googlewebmastercentral.blogspot.com/2011/09/pagination-with-relnext-and-relprev.html
 		if ($page == 1) {
-		    $this->document->addLink($this->url->link('product/special', 'language=' . $this->config->get('config_language')), 'canonical');
+			$this->document->addLink($this->url->link('product/special', 'language=' . $this->config->get('config_language')), 'canonical');
 		} else {
-		    $this->document->addLink($this->url->link('product/special', 'language=' . $this->config->get('config_language') . '&page='. $page), 'canonical');
+			$this->document->addLink($this->url->link('product/special', 'language=' . $this->config->get('config_language') . '&page='. $page), 'canonical');
 		}
 
 		if ($page > 1) {
@@ -258,7 +258,7 @@ class Special extends \Opencart\System\Engine\Controller {
 		}
 
 		if ($limit && ceil($product_total / $limit) > $page) {
-		    $this->document->addLink($this->url->link('product/special', 'language=' . $this->config->get('config_language') . '&page='. ($page + 1)), 'next');
+			$this->document->addLink($this->url->link('product/special', 'language=' . $this->config->get('config_language') . '&page='. ($page + 1)), 'next');
 		}
 
 		$data['sort'] = $sort;

--- a/upload/catalog/model/account/subscription.php
+++ b/upload/catalog/model/account/subscription.php
@@ -67,7 +67,7 @@ class Subscription extends \Opencart\System\Engine\Model {
 		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "subscription` WHERE `customer_id` = '" . (int)$this->customer->getId() . "' AND `subscription_status_id` > '0' AND `store_id` = '" . (int)$this->config->get('config_store_id') . "' ORDER BY `subscription_id` DESC LIMIT " . (int)$start . "," . (int)$limit);
 
 		return $query->rows;
-    }
+	}
 
 	/**
 	 * @return int
@@ -80,7 +80,7 @@ class Subscription extends \Opencart\System\Engine\Model {
 		} else {
 			return 0;
 		}
-    }
+	}
 
 	/**
 	 * @param int $address_id


### PR DESCRIPTION
This was done using php-cs-fixer's indentation_type rule. Once all outstanding PR regarding code formatting have been merged future changes can be checked for issues in GitHub action and developers can run the tool locally to fix any formatting issues with there code.