### PR TITLE
Remove blank line after class decleration

### DIFF
--- a/upload/admin/controller/event/language.php
+++ b/upload/admin/controller/event/language.php
@@ -6,7 +6,6 @@ namespace Opencart\Admin\Controller\Event;
  * @package Opencart\Admin\Controller\Event
  */
 class Language extends \Opencart\System\Engine\Controller {
-
 	/**
 	 * Dump all the language vars into the template.
 	 *

--- a/upload/admin/controller/localisation/return_action.php
+++ b/upload/admin/controller/localisation/return_action.php
@@ -6,7 +6,6 @@ namespace Opencart\Admin\Controller\Localisation;
  * @package Opencart\Admin\Controller\Localisation
  */
 class ReturnAction extends \Opencart\System\Engine\Controller {
-
 	/**
 	 * @return void
 	 */


### PR DESCRIPTION
This was done using php-cs-fixer's no_blank_lines_after_class_opening rule. Once all outstanding PR regarding code formatting have been merged future changes can be checked for issues in GitHub action and developers can run the tool locally to fix any formatting issues with there code.