### PR TITLE
Correct position of return type declaration

### DIFF
--- a/upload/admin/model/localisation/return_status.php
+++ b/upload/admin/model/localisation/return_status.php
@@ -33,7 +33,7 @@ class ReturnStatus extends \Opencart\System\Engine\Model {
 	 *
 	 * @return void
 	 */
-	public function editReturnStatus(int $return_status_id, array $data) : void {
+	public function editReturnStatus(int $return_status_id, array $data): void {
 		$this->db->query("DELETE FROM `" . DB_PREFIX . "return_status` WHERE `return_status_id` = '" . (int)$return_status_id . "'");
 
 		foreach ($data['return_status'] as $language_id => $value) {


### PR DESCRIPTION
This was done using php-cs-fixer's return_type_declaration rule. Once all outstanding PR regarding code formatting have been merged future changes can be checked for issues in GitHub action and developers can run the tool locally to fix any formatting issues with there code.