### PR TITLE
Correctly align array initilizations in extension

### DIFF
--- a/upload/system/helper/db_schema.php
+++ b/upload/system/helper/db_schema.php
@@ -58,8 +58,8 @@ function oc_db_schema() {
 	$tables = [];
 
 	$tables[] = [
-		'name'    => 'address',
-		'field'   => [
+		'name'  => 'address',
+		'field' => [
 			[
 				'name'           => 'address_id',
 				'type'           => 'int(11)',
@@ -126,7 +126,7 @@ function oc_db_schema() {
 				'field' => 'customer_id'
 			]
 		],
-		'index'   => [
+		'index' => [
 			[
 				'name' => 'customer_id',
 				'key'  => [
@@ -140,8 +140,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'address_format',
-		'field'   => [
+		'name'  => 'address_format',
+		'field' => [
 			[
 				'name'           => 'address_format_id',
 				'type'           => 'int(11)',
@@ -165,8 +165,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'api',
-		'field'   => [
+		'name'  => 'api',
+		'field' => [
 			[
 				'name'           => 'api_id',
 				'type'           => 'int(11)',
@@ -202,8 +202,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'api_ip',
-		'field'   => [
+		'name'  => 'api_ip',
+		'field' => [
 			[
 				'name'           => 'api_ip_id',
 				'type'           => 'int(11)',
@@ -234,8 +234,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'api_session',
-		'field'   => [
+		'name'  => 'api_session',
+		'field' => [
 			[
 				'name'           => 'api_session_id',
 				'type'           => 'int(11)',
@@ -278,8 +278,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'attribute',
-		'field'   => [
+		'name'  => 'attribute',
+		'field' => [
 			[
 				'name'           => 'attribute_id',
 				'type'           => 'int(11)',
@@ -310,8 +310,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'attribute_description',
-		'field'   => [
+		'name'  => 'attribute_description',
+		'field' => [
 			[
 				'name' => 'attribute_id',
 				'type' => 'int(11)'
@@ -347,8 +347,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'attribute_group',
-		'field'   => [
+		'name'  => 'attribute_group',
+		'field' => [
 			[
 				'name'           => 'attribute_group_id',
 				'type'           => 'int(11)',
@@ -368,8 +368,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'attribute_group_description',
-		'field'   => [
+		'name'  => 'attribute_group_description',
+		'field' => [
 			[
 				'name' => 'attribute_group_id',
 				'type' => 'int(11)'
@@ -405,8 +405,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'banner',
-		'field'   => [
+		'name'  => 'banner',
+		'field' => [
 			[
 				'name'           => 'banner_id',
 				'type'           => 'int(11)',
@@ -430,8 +430,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'banner_image',
-		'field'   => [
+		'name'  => 'banner_image',
+		'field' => [
 			[
 				'name'           => 'banner_image_id',
 				'type'           => 'int(11)',
@@ -484,8 +484,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'antispam',
-		'field'   => [
+		'name'  => 'antispam',
+		'field' => [
 			[
 				'name'           => 'antispam_id',
 				'type'           => 'int(11)',
@@ -499,7 +499,7 @@ function oc_db_schema() {
 		'primary' => [
 			'antispam_id'
 		],
-		'index'   => [
+		'index' => [
 			[
 				'name' => 'keyword',
 				'key'  => [
@@ -513,8 +513,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'article',
-		'field'   => [
+		'name'  => 'article',
+		'field' => [
 			[
 				'name'           => 'article_id',
 				'type'           => 'int(11)',
@@ -550,8 +550,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'article_comment',
-		'field'   => [
+		'name'  => 'article_comment',
+		'field' => [
 			[
 				'name'           => 'article_comment_id',
 				'type'           => 'int(11)',
@@ -609,7 +609,7 @@ function oc_db_schema() {
 				'field' => 'customer_id'
 			]
 		],
-		'index'   => [
+		'index' => [
 			[
 				'name' => 'article_id',
 				'key'  => [
@@ -629,8 +629,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'article_description',
-		'field'   => [
+		'name'  => 'article_description',
+		'field' => [
 			[
 				'name' => 'article_id',
 				'type' => 'int(11)'
@@ -679,7 +679,7 @@ function oc_db_schema() {
 				'field' => 'language_id'
 			]
 		],
-		'index'   => [
+		'index' => [
 			[
 				'name' => 'name',
 				'key'  => [
@@ -693,8 +693,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'article_rating',
-		'field'   => [
+		'name'  => 'article_rating',
+		'field' => [
 			[
 				'name'           => 'article_rating_id',
 				'type'           => 'int(11)',
@@ -756,7 +756,7 @@ function oc_db_schema() {
 				'field' => 'store_id'
 			]
 		],
-		'index'   => [
+		'index' => [
 			[
 				'name' => 'article_id',
 				'key'  => [
@@ -788,8 +788,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'article_to_layout',
-		'field'   => [
+		'name'  => 'article_to_layout',
+		'field' => [
 			[
 				'name' => 'article_id',
 				'type' => 'int(11)'
@@ -830,8 +830,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'article_to_store',
-		'field'   => [
+		'name'  => 'article_to_store',
+		'field' => [
 			[
 				'name' => 'article_id',
 				'type' => 'int(11)'
@@ -864,8 +864,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'topic',
-		'field'   => [
+		'name'  => 'topic',
+		'field' => [
 			[
 				'name'           => 'topic_id',
 				'type'           => 'int(11)',
@@ -890,8 +890,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'topic_description',
-		'field'   => [
+		'name'  => 'topic_description',
+		'field' => [
 			[
 				'name' => 'topic_id',
 				'type' => 'int(11)'
@@ -936,7 +936,7 @@ function oc_db_schema() {
 				'field' => 'language_id'
 			]
 		],
-		'index'   => [
+		'index' => [
 			[
 				'name' => 'name',
 				'key'  => [
@@ -950,8 +950,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'topic_to_store',
-		'field'   => [
+		'name'  => 'topic_to_store',
+		'field' => [
 			[
 				'name' => 'topic_id',
 				'type' => 'int(11)'
@@ -984,8 +984,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'cart',
-		'field'   => [
+		'name'  => 'cart',
+		'field' => [
 			[
 				'name'           => 'cart_id',
 				'type'           => 'int(11)',
@@ -1062,7 +1062,7 @@ function oc_db_schema() {
 				'field' => 'subscription_plan_id'
 			]
 		],
-		'index'   => [
+		'index' => [
 			[
 				'name' => 'cart_id',
 				'key'  => [
@@ -1080,8 +1080,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'category',
-		'field'   => [
+		'name'  => 'category',
+		'field' => [
 			[
 				'name'           => 'category_id',
 				'type'           => 'int(11)',
@@ -1125,7 +1125,7 @@ function oc_db_schema() {
 		'primary' => [
 			'category_id'
 		],
-		'index'   => [
+		'index' => [
 			[
 				'name' => 'parent_id',
 				'key'  => [
@@ -1139,8 +1139,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'category_description',
-		'field'   => [
+		'name'  => 'category_description',
+		'field' => [
 			[
 				'name' => 'category_id',
 				'type' => 'int(11)'
@@ -1181,7 +1181,7 @@ function oc_db_schema() {
 				'field' => 'language_id'
 			]
 		],
-		'index'   => [
+		'index' => [
 			[
 				'name' => 'name',
 				'key'  => [
@@ -1195,8 +1195,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'category_filter',
-		'field'   => [
+		'name'  => 'category_filter',
+		'field' => [
 			[
 				'name' => 'category_id',
 				'type' => 'int(11)'
@@ -1228,8 +1228,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'category_path',
-		'field'   => [
+		'name'  => 'category_path',
+		'field' => [
 			[
 				'name' => 'category_id',
 				'type' => 'int(11)'
@@ -1260,8 +1260,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'category_to_layout',
-		'field'   => [
+		'name'  => 'category_to_layout',
+		'field' => [
 			[
 				'name' => 'category_id',
 				'type' => 'int(11)'
@@ -1302,8 +1302,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'category_to_store',
-		'field'   => [
+		'name'  => 'category_to_store',
+		'field' => [
 			[
 				'name' => 'category_id',
 				'type' => 'int(11)'
@@ -1336,8 +1336,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'country',
-		'field'   => [
+		'name'  => 'country',
+		'field' => [
 			[
 				'name'           => 'country_id',
 				'type'           => 'int(11)',
@@ -1378,8 +1378,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'coupon',
-		'field'   => [
+		'name'  => 'coupon',
+		'field' => [
 			[
 				'name'           => 'coupon_id',
 				'type'           => 'int(11)',
@@ -1447,8 +1447,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'coupon_category',
-		'field'   => [
+		'name'  => 'coupon_category',
+		'field' => [
 			[
 				'name' => 'coupon_id',
 				'type' => 'int(11)'
@@ -1480,8 +1480,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'coupon_history',
-		'field'   => [
+		'name'  => 'coupon_history',
+		'field' => [
 			[
 				'name'           => 'coupon_history_id',
 				'type'           => 'int(11)',
@@ -1534,8 +1534,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'coupon_product',
-		'field'   => [
+		'name'  => 'coupon_product',
+		'field' => [
 			[
 				'name'           => 'coupon_product_id',
 				'type'           => 'int(11)',
@@ -1571,8 +1571,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'cron',
-		'field'   => [
+		'name'  => 'cron',
+		'field' => [
 			[
 				'name'           => 'cron_id',
 				'type'           => 'int(11)',
@@ -1616,8 +1616,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'currency',
-		'field'   => [
+		'name'  => 'currency',
+		'field' => [
 			[
 				'name'           => 'currency_id',
 				'type'           => 'int(11)',
@@ -1665,8 +1665,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'customer',
-		'field'   => [
+		'name'  => 'customer',
+		'field' => [
 			[
 				'name'           => 'customer_id',
 				'type'           => 'int(11)',
@@ -1762,7 +1762,7 @@ function oc_db_schema() {
 				'field' => 'language_id'
 			]
 		],
-		'index'   => [
+		'index' => [
 			[
 				'name' => 'email',
 				'key'  => [
@@ -1776,8 +1776,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'customer_activity',
-		'field'   => [
+		'name'  => 'customer_activity',
+		'field' => [
 			[
 				'name'           => 'customer_activity_id',
 				'type'           => 'int(11)',
@@ -1820,8 +1820,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'customer_affiliate',
-		'field'   => [
+		'name'  => 'customer_affiliate',
+		'field' => [
 			[
 				'name' => 'customer_id',
 				'type' => 'int(11)'
@@ -1912,8 +1912,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'customer_affiliate_report',
-		'field'   => [
+		'name'  => 'customer_affiliate_report',
+		'field' => [
 			[
 				'name'           => 'customer_affiliate_report_id',
 				'type'           => 'int(11)',
@@ -1961,8 +1961,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'customer_approval',
-		'field'   => [
+		'name'  => 'customer_approval',
+		'field' => [
 			[
 				'name'           => 'customer_approval_id',
 				'type'           => 'int(11)',
@@ -1997,8 +1997,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'customer_authorize',
-		'field'   => [
+		'name'  => 'customer_authorize',
+		'field' => [
 			[
 				'name'           => 'customer_authorize_id',
 				'type'           => 'int(11)',
@@ -2049,8 +2049,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'customer_group',
-		'field'   => [
+		'name'  => 'customer_group',
+		'field' => [
 			[
 				'name'           => 'customer_group_id',
 				'type'           => 'int(11)',
@@ -2074,8 +2074,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'customer_group_description',
-		'field'   => [
+		'name'  => 'customer_group_description',
+		'field' => [
 			[
 				'name' => 'customer_group_id',
 				'type' => 'int(11)'
@@ -2115,8 +2115,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'customer_history',
-		'field'   => [
+		'name'  => 'customer_history',
+		'field' => [
 			[
 				'name'           => 'customer_history_id',
 				'type'           => 'int(11)',
@@ -2144,8 +2144,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'customer_login',
-		'field'   => [
+		'name'  => 'customer_login',
+		'field' => [
 			[
 				'name'           => 'customer_login_id',
 				'type'           => 'int(11)',
@@ -2175,7 +2175,7 @@ function oc_db_schema() {
 		'primary' => [
 			'customer_login_id'
 		],
-		'index'   => [
+		'index' => [
 			[
 				'name' => 'email',
 				'key'  => [
@@ -2195,8 +2195,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'customer_ip',
-		'field'   => [
+		'name'  => 'customer_ip',
+		'field' => [
 			[
 				'name'           => 'customer_ip_id',
 				'type'           => 'int(11)',
@@ -2238,7 +2238,7 @@ function oc_db_schema() {
 				'field' => 'store_id'
 			]
 		],
-		'index'   => [
+		'index' => [
 			[
 				'name' => 'ip',
 				'key'  => [
@@ -2252,8 +2252,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'customer_online',
-		'field'   => [
+		'name'  => 'customer_online',
+		'field' => [
 			[
 				'name' => 'ip',
 				'type' => 'varchar(40)'
@@ -2284,8 +2284,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'customer_reward',
-		'field'   => [
+		'name'  => 'customer_reward',
+		'field' => [
 			[
 				'name'           => 'customer_reward_id',
 				'type'           => 'int(11)',
@@ -2336,8 +2336,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'customer_transaction',
-		'field'   => [
+		'name'  => 'customer_transaction',
+		'field' => [
 			[
 				'name'           => 'customer_transaction_id',
 				'type'           => 'int(11)',
@@ -2385,8 +2385,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'customer_search',
-		'field'   => [
+		'name'  => 'customer_search',
+		'field' => [
 			[
 				'name'           => 'customer_search_id',
 				'type'           => 'int(11)',
@@ -2464,8 +2464,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'customer_wishlist',
-		'field'   => [
+		'name'  => 'customer_wishlist',
+		'field' => [
 			[
 				'name' => 'customer_id',
 				'type' => 'int(11)'
@@ -2501,8 +2501,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'custom_field',
-		'field'   => [
+		'name'  => 'custom_field',
+		'field' => [
 			[
 				'name'           => 'custom_field_id',
 				'type'           => 'int(11)',
@@ -2542,8 +2542,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'custom_field_customer_group',
-		'field'   => [
+		'name'  => 'custom_field_customer_group',
+		'field' => [
 			[
 				'name' => 'custom_field_id',
 				'type' => 'int(11)'
@@ -2579,8 +2579,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'custom_field_description',
-		'field'   => [
+		'name'  => 'custom_field_description',
+		'field' => [
 			[
 				'name' => 'custom_field_id',
 				'type' => 'int(11)'
@@ -2616,8 +2616,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'custom_field_value',
-		'field'   => [
+		'name'  => 'custom_field_value',
+		'field' => [
 			[
 				'name'           => 'custom_field_value_id',
 				'type'           => 'int(11)',
@@ -2648,8 +2648,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'custom_field_value_description',
-		'field'   => [
+		'name'  => 'custom_field_value_description',
+		'field' => [
 			[
 				'name' => 'custom_field_value_id',
 				'type' => 'int(11)'
@@ -2689,8 +2689,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'download',
-		'field'   => [
+		'name'  => 'download',
+		'field' => [
 			[
 				'name'           => 'download_id',
 				'type'           => 'int(11)',
@@ -2718,8 +2718,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'download_description',
-		'field'   => [
+		'name'  => 'download_description',
+		'field' => [
 			[
 				'name' => 'download_id',
 				'type' => 'int(11)'
@@ -2750,8 +2750,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'download_report',
-		'field'   => [
+		'name'  => 'download_report',
+		'field' => [
 			[
 				'name'           => 'download_report_id',
 				'type'           => 'int(11)',
@@ -2799,8 +2799,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'event',
-		'field'   => [
+		'name'  => 'event',
+		'field' => [
 			[
 				'name'           => 'event_id',
 				'type'           => 'int(11)',
@@ -2842,8 +2842,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'extension',
-		'field'   => [
+		'name'  => 'extension',
+		'field' => [
 			[
 				'name'           => 'extension_id',
 				'type'           => 'int(11)',
@@ -2871,8 +2871,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'extension_install',
-		'field'   => [
+		'name'  => 'extension_install',
+		'field' => [
 			[
 				'name'           => 'extension_install_id',
 				'type'           => 'int(11)',
@@ -2935,8 +2935,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'extension_path',
-		'field'   => [
+		'name'  => 'extension_path',
+		'field' => [
 			[
 				'name'           => 'extension_path_id',
 				'type'           => 'int(11)',
@@ -2961,7 +2961,7 @@ function oc_db_schema() {
 				'field' => 'extension_install_id'
 			]
 		],
-		'index'   => [
+		'index' => [
 			[
 				'name' => 'path',
 				'key'  => [
@@ -2975,8 +2975,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'filter',
-		'field'   => [
+		'name'  => 'filter',
+		'field' => [
 			[
 				'name'           => 'filter_id',
 				'type'           => 'int(11)',
@@ -3007,8 +3007,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'filter_description',
-		'field'   => [
+		'name'  => 'filter_description',
+		'field' => [
 			[
 				'name' => 'filter_id',
 				'type' => 'int(11)'
@@ -3048,8 +3048,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'filter_group',
-		'field'   => [
+		'name'  => 'filter_group',
+		'field' => [
 			[
 				'name'           => 'filter_group_id',
 				'type'           => 'int(11)',
@@ -3069,8 +3069,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'filter_group_description',
-		'field'   => [
+		'name'  => 'filter_group_description',
+		'field' => [
 			[
 				'name' => 'filter_group_id',
 				'type' => 'int(11)'
@@ -3106,8 +3106,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'gdpr',
-		'field'   => [
+		'name'  => 'gdpr',
+		'field' => [
 			[
 				'name'           => 'gdpr_id',
 				'type'           => 'int(11)',
@@ -3163,8 +3163,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'geo_zone',
-		'field'   => [
+		'name'  => 'geo_zone',
+		'field' => [
 			[
 				'name'           => 'geo_zone_id',
 				'type'           => 'int(11)',
@@ -3188,8 +3188,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'information',
-		'field'   => [
+		'name'  => 'information',
+		'field' => [
 			[
 				'name'           => 'information_id',
 				'type'           => 'int(11)',
@@ -3220,8 +3220,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'information_description',
-		'field'   => [
+		'name'  => 'information_description',
+		'field' => [
 			[
 				'name' => 'information_id',
 				'type' => 'int(11)'
@@ -3268,8 +3268,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'information_to_layout',
-		'field'   => [
+		'name'  => 'information_to_layout',
+		'field' => [
 			[
 				'name' => 'information_id',
 				'type' => 'int(11)'
@@ -3310,8 +3310,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'information_to_store',
-		'field'   => [
+		'name'  => 'information_to_store',
+		'field' => [
 			[
 				'name' => 'information_id',
 				'type' => 'int(11)'
@@ -3343,8 +3343,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'language',
-		'field'   => [
+		'name'  => 'language',
+		'field' => [
 			[
 				'name'           => 'language_id',
 				'type'           => 'int(11)',
@@ -3379,7 +3379,7 @@ function oc_db_schema() {
 		'primary' => [
 			'language_id'
 		],
-		'index'   => [
+		'index' => [
 			[
 				'name' => 'name',
 				'key'  => [
@@ -3393,8 +3393,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'layout',
-		'field'   => [
+		'name'  => 'layout',
+		'field' => [
 			[
 				'name'           => 'layout_id',
 				'type'           => 'int(11)',
@@ -3414,8 +3414,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'layout_module',
-		'field'   => [
+		'name'  => 'layout_module',
+		'field' => [
 			[
 				'name'           => 'layout_module_id',
 				'type'           => 'int(11)',
@@ -3454,8 +3454,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'layout_route',
-		'field'   => [
+		'name'  => 'layout_route',
+		'field' => [
 			[
 				'name'           => 'layout_route_id',
 				'type'           => 'int(11)',
@@ -3495,8 +3495,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'length_class',
-		'field'   => [
+		'name'  => 'length_class',
+		'field' => [
 			[
 				'name'           => 'length_class_id',
 				'type'           => 'int(11)',
@@ -3516,8 +3516,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'length_class_description',
-		'field'   => [
+		'name'  => 'length_class_description',
+		'field' => [
 			[
 				'name' => 'length_class_id',
 				'type' => 'int(11)'
@@ -3557,8 +3557,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'location',
-		'field'   => [
+		'name'  => 'location',
+		'field' => [
 			[
 				'name'           => 'location_id',
 				'type'           => 'int(11)',
@@ -3596,7 +3596,7 @@ function oc_db_schema() {
 		'primary' => [
 			'location_id'
 		],
-		'index'   => [
+		'index' => [
 			[
 				'name' => 'name',
 				'key'  => [
@@ -3610,8 +3610,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'manufacturer',
-		'field'   => [
+		'name'  => 'manufacturer',
+		'field' => [
 			[
 				'name'           => 'manufacturer_id',
 				'type'           => 'int(11)',
@@ -3639,8 +3639,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'manufacturer_to_layout',
-		'field'   => [
+		'name'  => 'manufacturer_to_layout',
+		'field' => [
 			[
 				'name' => 'manufacturer_id',
 				'type' => 'int(11)'
@@ -3681,8 +3681,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'manufacturer_to_store',
-		'field'   => [
+		'name'  => 'manufacturer_to_store',
+		'field' => [
 			[
 				'name' => 'manufacturer_id',
 				'type' => 'int(11)'
@@ -3714,8 +3714,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'marketing',
-		'field'   => [
+		'name'  => 'marketing',
+		'field' => [
 			[
 				'name'           => 'marketing_id',
 				'type'           => 'int(11)',
@@ -3752,8 +3752,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'marketing_report',
-		'field'   => [
+		'name'  => 'marketing_report',
+		'field' => [
 			[
 				'name'           => 'marketing_report_id',
 				'type'           => 'int(11)',
@@ -3801,8 +3801,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'modification',
-		'field'   => [
+		'name'  => 'modification',
+		'field' => [
 			[
 				'name'           => 'modification_id',
 				'type'           => 'int(11)',
@@ -3859,8 +3859,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'module',
-		'field'   => [
+		'name'  => 'module',
+		'field' => [
 			[
 				'name'           => 'module_id',
 				'type'           => 'int(11)',
@@ -3888,8 +3888,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'notification',
-		'field'   => [
+		'name'  => 'notification',
+		'field' => [
 			[
 				'name'           => 'notification_id',
 				'type'           => 'int(11)',
@@ -3921,8 +3921,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'option',
-		'field'   => [
+		'name'  => 'option',
+		'field' => [
 			[
 				'name'           => 'option_id',
 				'type'           => 'int(11)',
@@ -3946,8 +3946,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'option_description',
-		'field'   => [
+		'name'  => 'option_description',
+		'field' => [
 			[
 				'name' => 'option_id',
 				'type' => 'int(11)'
@@ -3978,8 +3978,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'option_value',
-		'field'   => [
+		'name'  => 'option_value',
+		'field' => [
 			[
 				'name'           => 'option_value_id',
 				'type'           => 'int(11)',
@@ -4014,8 +4014,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'option_value_description',
-		'field'   => [
+		'name'  => 'option_value_description',
+		'field' => [
 			[
 				'name' => 'option_value_id',
 				'type' => 'int(11)'
@@ -4055,8 +4055,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'order',
-		'field'   => [
+		'name'  => 'order',
+		'field' => [
 			[
 				'name'           => 'order_id',
 				'type'           => 'int(11)',
@@ -4383,7 +4383,7 @@ function oc_db_schema() {
 				'field' => 'currency_id'
 			]
 		],
-		'index'   => [
+		'index' => [
 			[
 				'name' => 'email',
 				'key'  => [
@@ -4397,8 +4397,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'order_history',
-		'field'   => [
+		'name'  => 'order_history',
+		'field' => [
 			[
 				'name'           => 'order_history_id',
 				'type'           => 'int(11)',
@@ -4447,8 +4447,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'order_option',
-		'field'   => [
+		'name'  => 'order_option',
+		'field' => [
 			[
 				'name'           => 'order_option_id',
 				'type'           => 'int(11)',
@@ -4515,8 +4515,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'order_product',
-		'field'   => [
+		'name'  => 'order_product',
+		'field' => [
 			[
 				'name'           => 'order_product_id',
 				'type'           => 'int(11)',
@@ -4586,7 +4586,7 @@ function oc_db_schema() {
 				'field' => 'product_id'
 			]
 		],
-		'index'   => [
+		'index' => [
 			[
 				'name' => 'order_id',
 				'key'  => [
@@ -4600,8 +4600,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'order_subscription',
-		'field'   => [
+		'name'  => 'order_subscription',
+		'field' => [
 			[
 				'name'           => 'order_subscription_id',
 				'type'           => 'int(11)',
@@ -4697,7 +4697,7 @@ function oc_db_schema() {
 				'field' => 'subscription_status_id'
 			]
 		],
-		'index'   => [
+		'index' => [
 			[
 				'name' => 'order_id',
 				'key'  => [
@@ -4711,8 +4711,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'order_status',
-		'field'   => [
+		'name'  => 'order_status',
+		'field' => [
 			[
 				'name'           => 'order_status_id',
 				'type'           => 'int(11)',
@@ -4744,8 +4744,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'order_total',
-		'field'   => [
+		'name'  => 'order_total',
+		'field' => [
 			[
 				'name'           => 'order_total_id',
 				'type'           => 'int(10)',
@@ -4787,7 +4787,7 @@ function oc_db_schema() {
 				'field' => 'order_id'
 			]
 		],
-		'index'   => [
+		'index' => [
 			[
 				'name' => 'order_id',
 				'key'  => [
@@ -4801,8 +4801,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'order_voucher',
-		'field'   => [
+		'name'  => 'order_voucher',
+		'field' => [
 			[
 				'name'           => 'order_voucher_id',
 				'type'           => 'int(11)',
@@ -4874,8 +4874,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'product',
-		'field'   => [
+		'name'  => 'product',
+		'field' => [
 			[
 				'name'           => 'product_id',
 				'type'           => 'int(11)',
@@ -5072,8 +5072,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'product_attribute',
-		'field'   => [
+		'name'  => 'product_attribute',
+		'field' => [
 			[
 				'name' => 'product_id',
 				'type' => 'int(11)'
@@ -5119,8 +5119,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'product_description',
-		'field'   => [
+		'name'  => 'product_description',
+		'field' => [
 			[
 				'name' => 'product_id',
 				'type' => 'int(11)'
@@ -5170,7 +5170,7 @@ function oc_db_schema() {
 				'field' => 'language_id'
 			]
 		],
-		'index'   => [
+		'index' => [
 			[
 				'name' => 'name',
 				'key'  => [
@@ -5184,8 +5184,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'product_discount',
-		'field'   => [
+		'name'  => 'product_discount',
+		'field' => [
 			[
 				'name'           => 'product_discount_id',
 				'type'           => 'int(11)',
@@ -5238,7 +5238,7 @@ function oc_db_schema() {
 				'field' => 'customer_group_id'
 			]
 		],
-		'index'   => [
+		'index' => [
 			[
 				'name' => 'product_id',
 				'key'  => [
@@ -5252,8 +5252,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'product_filter',
-		'field'   => [
+		'name'  => 'product_filter',
+		'field' => [
 			[
 				'name' => 'product_id',
 				'type' => 'int(11)'
@@ -5285,8 +5285,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'product_image',
-		'field'   => [
+		'name'  => 'product_image',
+		'field' => [
 			[
 				'name'           => 'product_image_id',
 				'type'           => 'int(11)',
@@ -5316,7 +5316,7 @@ function oc_db_schema() {
 				'field' => 'product_id'
 			]
 		],
-		'index'   => [
+		'index' => [
 			[
 				'name' => 'product_id',
 				'key'  => [
@@ -5330,8 +5330,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'product_option',
-		'field'   => [
+		'name'  => 'product_option',
+		'field' => [
 			[
 				'name'           => 'product_option_id',
 				'type'           => 'int(11)',
@@ -5375,8 +5375,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'product_option_value',
-		'field'   => [
+		'name'  => 'product_option_value',
+		'field' => [
 			[
 				'name'           => 'product_option_value_id',
 				'type'           => 'int(11)',
@@ -5462,8 +5462,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'product_subscription',
-		'field'   => [
+		'name'  => 'product_subscription',
+		'field' => [
 			[
 				'name' => 'product_id',
 				'type' => 'int(11)'
@@ -5513,8 +5513,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'product_related',
-		'field'   => [
+		'name'  => 'product_related',
+		'field' => [
 			[
 				'name' => 'product_id',
 				'type' => 'int(11)'
@@ -5546,8 +5546,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'product_report',
-		'field'   => [
+		'name'  => 'product_report',
+		'field' => [
 			[
 				'name'           => 'product_report_id',
 				'type'           => 'int(11)',
@@ -5596,8 +5596,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'product_reward',
-		'field'   => [
+		'name'  => 'product_reward',
+		'field' => [
 			[
 				'name'           => 'product_reward_id',
 				'type'           => 'int(11)',
@@ -5640,8 +5640,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'product_special',
-		'field'   => [
+		'name'  => 'product_special',
+		'field' => [
 			[
 				'name'           => 'product_special_id',
 				'type'           => 'int(11)',
@@ -5689,7 +5689,7 @@ function oc_db_schema() {
 				'field' => 'customer_group_id'
 			]
 		],
-		'index'   => [
+		'index' => [
 			[
 				'name' => 'product_id',
 				'key'  => [
@@ -5703,8 +5703,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'product_to_category',
-		'field'   => [
+		'name'  => 'product_to_category',
+		'field' => [
 			[
 				'name' => 'product_id',
 				'type' => 'int(11)'
@@ -5730,7 +5730,7 @@ function oc_db_schema() {
 				'field' => 'category_id'
 			]
 		],
-		'index'   => [
+		'index' => [
 			[
 				'name' => 'category_id',
 				'key'  => [
@@ -5744,8 +5744,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'product_to_download',
-		'field'   => [
+		'name'  => 'product_to_download',
+		'field' => [
 			[
 				'name' => 'product_id',
 				'type' => 'int(11)'
@@ -5777,8 +5777,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'product_to_layout',
-		'field'   => [
+		'name'  => 'product_to_layout',
+		'field' => [
 			[
 				'name' => 'product_id',
 				'type' => 'int(11)'
@@ -5819,8 +5819,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'product_to_store',
-		'field'   => [
+		'name'  => 'product_to_store',
+		'field' => [
 			[
 				'name' => 'product_id',
 				'type' => 'int(11)'
@@ -5853,8 +5853,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'product_viewed',
-		'field'   => [
+		'name'  => 'product_viewed',
+		'field' => [
 			[
 				'name' => 'product_id',
 				'type' => 'int(11)'
@@ -5880,8 +5880,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'return',
-		'field'   => [
+		'name'  => 'return',
+		'field' => [
 			[
 				'name'           => 'return_id',
 				'type'           => 'int(11)',
@@ -6001,8 +6001,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'return_action',
-		'field'   => [
+		'name'  => 'return_action',
+		'field' => [
 			[
 				'name'           => 'return_action_id',
 				'type'           => 'int(11)',
@@ -6035,8 +6035,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'return_history',
-		'field'   => [
+		'name'  => 'return_history',
+		'field' => [
 			[
 				'name'           => 'return_history_id',
 				'type'           => 'int(11)',
@@ -6084,8 +6084,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'return_reason',
-		'field'   => [
+		'name'  => 'return_reason',
+		'field' => [
 			[
 				'name'           => 'return_reason_id',
 				'type'           => 'int(11)',
@@ -6118,8 +6118,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'return_status',
-		'field'   => [
+		'name'  => 'return_status',
+		'field' => [
 			[
 				'name'           => 'return_status_id',
 				'type'           => 'int(11)',
@@ -6152,8 +6152,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'review',
-		'field'   => [
+		'name'  => 'review',
+		'field' => [
 			[
 				'name'           => 'review_id',
 				'type'           => 'int(11)',
@@ -6208,7 +6208,7 @@ function oc_db_schema() {
 				'field' => 'customer_id'
 			]
 		],
-		'index'   => [
+		'index' => [
 			[
 				'name' => 'product_id',
 				'key'  => [
@@ -6222,8 +6222,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'startup',
-		'field'   => [
+		'name'  => 'startup',
+		'field' => [
 			[
 				'name'           => 'startup_id',
 				'type'           => 'int(11)',
@@ -6259,8 +6259,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'statistics',
-		'field'   => [
+		'name'  => 'statistics',
+		'field' => [
 			[
 				'name'           => 'statistics_id',
 				'type'           => 'int(11)',
@@ -6284,8 +6284,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'session',
-		'field'   => [
+		'name'  => 'session',
+		'field' => [
 			[
 				'name' => 'session_id',
 				'type' => 'varchar(32)'
@@ -6302,7 +6302,7 @@ function oc_db_schema() {
 		'primary' => [
 			'session_id'
 		],
-		'index'   => [
+		'index' => [
 			[
 				'name' => 'expire',
 				'key'  => [
@@ -6316,8 +6316,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'setting',
-		'field'   => [
+		'name'  => 'setting',
+		'field' => [
 			[
 				'name'           => 'setting_id',
 				'type'           => 'int(11)',
@@ -6362,8 +6362,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'stock_status',
-		'field'   => [
+		'name'  => 'stock_status',
+		'field' => [
 			[
 				'name'           => 'stock_status_id',
 				'type'           => 'int(11)',
@@ -6395,8 +6395,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'store',
-		'field'   => [
+		'name'  => 'store',
+		'field' => [
 			[
 				'name'           => 'store_id',
 				'type'           => 'int(11)',
@@ -6420,8 +6420,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'subscription',
-		'field'   => [
+		'name'  => 'subscription',
+		'field' => [
 			[
 				'name'           => 'subscription_id',
 				'type'           => 'int(11)',
@@ -6606,7 +6606,7 @@ function oc_db_schema() {
 				'field' => 'subscription_status_id'
 			]
 		],
-		'index'   => [
+		'index' => [
 			[
 				'name' => 'order_id',
 				'key'  => [
@@ -6620,8 +6620,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'subscription_history',
-		'field'   => [
+		'name'  => 'subscription_history',
+		'field' => [
 			[
 				'name'           => 'subscription_history_id',
 				'type'           => 'int(11)',
@@ -6670,8 +6670,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'subscription_plan',
-		'field'   => [
+		'name'  => 'subscription_plan',
+		'field' => [
 			[
 				'name'           => 'subscription_plan_id',
 				'type'           => 'int(11)',
@@ -6723,8 +6723,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'subscription_plan_description',
-		'field'   => [
+		'name'  => 'subscription_plan_description',
+		'field' => [
 			[
 				'name' => 'subscription_plan_id',
 				'type' => 'int(11)'
@@ -6755,8 +6755,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'subscription_status',
-		'field'   => [
+		'name'  => 'subscription_status',
+		'field' => [
 			[
 				'name'           => 'subscription_status_id',
 				'type'           => 'int(11)',
@@ -6788,8 +6788,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'tax_class',
-		'field'   => [
+		'name'  => 'tax_class',
+		'field' => [
 			[
 				'name'           => 'tax_class_id',
 				'type'           => 'int(11)',
@@ -6813,8 +6813,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'tax_rate',
-		'field'   => [
+		'name'  => 'tax_rate',
+		'field' => [
 			[
 				'name'           => 'tax_rate_id',
 				'type'           => 'int(11)',
@@ -6855,8 +6855,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'tax_rate_to_customer_group',
-		'field'   => [
+		'name'  => 'tax_rate_to_customer_group',
+		'field' => [
 			[
 				'name' => 'tax_rate_id',
 				'type' => 'int(11)'
@@ -6888,8 +6888,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'tax_rule',
-		'field'   => [
+		'name'  => 'tax_rule',
+		'field' => [
 			[
 				'name'           => 'tax_rule_id',
 				'type'           => 'int(11)',
@@ -6934,8 +6934,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'theme',
-		'field'   => [
+		'name'  => 'theme',
+		'field' => [
 			[
 				'name'           => 'theme_id',
 				'type'           => 'int(11)',
@@ -6974,8 +6974,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'translation',
-		'field'   => [
+		'name'  => 'translation',
+		'field' => [
 			[
 				'name'           => 'translation_id',
 				'type'           => 'int(11)',
@@ -7027,8 +7027,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'upload',
-		'field'   => [
+		'name'  => 'upload',
+		'field' => [
 			[
 				'name'           => 'upload_id',
 				'type'           => 'int(11)',
@@ -7060,8 +7060,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'seo_url',
-		'field'   => [
+		'name'  => 'seo_url',
+		'field' => [
 			[
 				'name'           => 'seo_url_id',
 				'type'           => 'int(11)',
@@ -7107,7 +7107,7 @@ function oc_db_schema() {
 				'field' => 'language_id'
 			]
 		],
-		'index'   => [
+		'index' => [
 			[
 				'name' => 'keyword',
 				'key'  => [
@@ -7128,8 +7128,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'user',
-		'field'   => [
+		'name'  => 'user',
+		'field' => [
 			[
 				'name'           => 'user_id',
 				'type'           => 'int(11)',
@@ -7199,8 +7199,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'user_authorize',
-		'field'   => [
+		'name'  => 'user_authorize',
+		'field' => [
 			[
 				'name'           => 'user_authorize_id',
 				'type'           => 'int(11)',
@@ -7251,8 +7251,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'user_group',
-		'field'   => [
+		'name'  => 'user_group',
+		'field' => [
 			[
 				'name'           => 'user_group_id',
 				'type'           => 'int(11)',
@@ -7276,8 +7276,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'user_login',
-		'field'   => [
+		'name'  => 'user_login',
+		'field' => [
 			[
 				'name'           => 'user_login_id',
 				'type'           => 'int(11)',
@@ -7316,8 +7316,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'voucher',
-		'field'   => [
+		'name'  => 'voucher',
+		'field' => [
 			[
 				'name'           => 'voucher_id',
 				'type'           => 'int(11)',
@@ -7384,8 +7384,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'voucher_history',
-		'field'   => [
+		'name'  => 'voucher_history',
+		'field' => [
 			[
 				'name'           => 'voucher_history_id',
 				'type'           => 'int(11)',
@@ -7429,8 +7429,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'voucher_theme',
-		'field'   => [
+		'name'  => 'voucher_theme',
+		'field' => [
 			[
 				'name'           => 'voucher_theme_id',
 				'type'           => 'int(11)',
@@ -7450,8 +7450,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'voucher_theme_description',
-		'field'   => [
+		'name'  => 'voucher_theme_description',
+		'field' => [
 			[
 				'name' => 'voucher_theme_id',
 				'type' => 'int(11)'
@@ -7482,8 +7482,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'weight_class',
-		'field'   => [
+		'name'  => 'weight_class',
+		'field' => [
 			[
 				'name'           => 'weight_class_id',
 				'type'           => 'int(11)',
@@ -7504,8 +7504,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'weight_class_description',
-		'field'   => [
+		'name'  => 'weight_class_description',
+		'field' => [
 			[
 				'name' => 'weight_class_id',
 				'type' => 'int(11)'
@@ -7540,8 +7540,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'zone',
-		'field'   => [
+		'name'  => 'zone',
+		'field' => [
 			[
 				'name'           => 'zone_id',
 				'type'           => 'int(11)',
@@ -7581,8 +7581,8 @@ function oc_db_schema() {
 	];
 
 	$tables[] = [
-		'name'    => 'zone_to_geo_zone',
-		'field'   => [
+		'name'  => 'zone_to_geo_zone',
+		'field' => [
 			[
 				'name'           => 'zone_to_geo_zone_id',
 				'type'           => 'int(11)',


### PR DESCRIPTION
This was done using php-cs-fixer's binary_operator_spaces rule. Once all outstanding PR regarding code formatting have been merged future changes can be checked for issues in GitHub action and developers can run the tool locally to fix any formatting issues with there code.