### PR TITLE
Correctly align array initilizations in extension

### DIFF
--- a/upload/extension/opencart/admin/controller/report/customer.php
+++ b/upload/extension/opencart/admin/controller/report/customer.php
@@ -143,9 +143,9 @@ class Customer extends \Opencart\System\Engine\Controller {
 		$data['customers'] = [];
 
 		$filter_data = [
-			'filter_date_start'	=> $filter_date_start,
-			'filter_date_end'	=> $filter_date_end,
-			'filter_group'           => $filter_group,
+			'filter_date_start' => $filter_date_start,
+			'filter_date_end'   => $filter_date_end,
+			'filter_group'      => $filter_group,
 			'start'             => ($page - 1) * 20,
 			'limit'             => 20
 		];

--- a/upload/extension/opencart/admin/controller/report/customer_activity.php
+++ b/upload/extension/opencart/admin/controller/report/customer_activity.php
@@ -129,8 +129,8 @@ class CustomerActivity extends \Opencart\System\Engine\Controller {
 		$filter_data = [
 			'filter_customer'   => $filter_customer,
 			'filter_ip'         => $filter_ip,
-			'filter_date_start'	=> $filter_date_start,
-			'filter_date_end'	=> $filter_date_end,
+			'filter_date_start' => $filter_date_start,
+			'filter_date_end'   => $filter_date_end,
 			'start'             => ($page - 1) * 20,
 			'limit'             => 20
 		];

--- a/upload/extension/opencart/admin/controller/report/customer_order.php
+++ b/upload/extension/opencart/admin/controller/report/customer_order.php
@@ -131,12 +131,12 @@ class CustomerOrder extends \Opencart\System\Engine\Controller {
 		$data['customers'] = [];
 
 		$filter_data = [
-			'filter_date_start'			=> $filter_date_start,
-			'filter_date_end'			=> $filter_date_end,
-			'filter_customer'			=> $filter_customer,
-			'filter_order_status_id'	=> $filter_order_status_id,
-			'start'						=> ($page - 1) * $this->config->get('config_pagination'),
-			'limit'						=> $this->config->get('config_pagination')
+			'filter_date_start'      => $filter_date_start,
+			'filter_date_end'        => $filter_date_end,
+			'filter_customer'        => $filter_customer,
+			'filter_order_status_id' => $filter_order_status_id,
+			'start'                  => ($page - 1) * $this->config->get('config_pagination'),
+			'limit'                  => $this->config->get('config_pagination')
 		];
 
 		$this->load->model('extension/opencart/report/customer');

--- a/upload/extension/opencart/admin/controller/report/customer_reward.php
+++ b/upload/extension/opencart/admin/controller/report/customer_reward.php
@@ -121,11 +121,11 @@ class CustomerReward extends \Opencart\System\Engine\Controller {
 		$data['customers'] = [];
 
 		$filter_data = [
-			'filter_date_start'	=> $filter_date_start,
-			'filter_date_end'	=> $filter_date_end,
-			'filter_customer'	=> $filter_customer,
-			'start'				=> ($page - 1) * $this->config->get('config_pagination'),
-			'limit'				=> $this->config->get('config_pagination')
+			'filter_date_start' => $filter_date_start,
+			'filter_date_end'   => $filter_date_end,
+			'filter_customer'   => $filter_customer,
+			'start'             => ($page - 1) * $this->config->get('config_pagination'),
+			'limit'             => $this->config->get('config_pagination')
 		];
 
 		$this->load->model('extension/opencart/report/customer');

--- a/upload/extension/opencart/admin/controller/report/customer_transaction.php
+++ b/upload/extension/opencart/admin/controller/report/customer_transaction.php
@@ -121,11 +121,11 @@ class CustomerTransaction extends \Opencart\System\Engine\Controller {
 		$data['customers'] = [];
 
 		$filter_data = [
-			'filter_date_start'	=> $filter_date_start,
-			'filter_date_end'	=> $filter_date_end,
-			'filter_customer'	=> $filter_customer,
-			'start'				=> ($page - 1) * $this->config->get('config_pagination'),
-			'limit'				=> $this->config->get('config_pagination')
+			'filter_date_start' => $filter_date_start,
+			'filter_date_end'   => $filter_date_end,
+			'filter_customer'   => $filter_customer,
+			'start'             => ($page - 1) * $this->config->get('config_pagination'),
+			'limit'             => $this->config->get('config_pagination')
 		];
 
 		$this->load->model('extension/opencart/report/customer_transaction');

--- a/upload/extension/opencart/admin/controller/report/marketing.php
+++ b/upload/extension/opencart/admin/controller/report/marketing.php
@@ -125,8 +125,8 @@ class Marketing extends \Opencart\System\Engine\Controller {
 		$data['marketings'] = [];
 
 		$filter_data = [
-			'filter_date_start'	     => $filter_date_start,
-			'filter_date_end'	     => $filter_date_end,
+			'filter_date_start'      => $filter_date_start,
+			'filter_date_end'        => $filter_date_end,
 			'filter_order_status_id' => $filter_order_status_id,
 			'start'                  => ($page - 1) * $this->config->get('config_pagination'),
 			'limit'                  => $this->config->get('config_pagination')

--- a/upload/extension/opencart/admin/controller/report/product_purchased.php
+++ b/upload/extension/opencart/admin/controller/report/product_purchased.php
@@ -125,8 +125,8 @@ class ProductPurchased extends \Opencart\System\Engine\Controller {
 		$data['products'] = [];
 
 		$filter_data = [
-			'filter_date_start'	     => $filter_date_start,
-			'filter_date_end'	     => $filter_date_end,
+			'filter_date_start'      => $filter_date_start,
+			'filter_date_end'        => $filter_date_end,
 			'filter_order_status_id' => $filter_order_status_id,
 			'start'                  => ($page - 1) * $this->config->get('config_pagination'),
 			'limit'                  => $this->config->get('config_pagination')

--- a/upload/extension/opencart/admin/controller/report/sale_coupon.php
+++ b/upload/extension/opencart/admin/controller/report/sale_coupon.php
@@ -115,8 +115,8 @@ class SaleCoupon extends \Opencart\System\Engine\Controller {
 		$data['coupons'] = [];
 
 		$filter_data = [
-			'filter_date_start'	=> $filter_date_start,
-			'filter_date_end'	=> $filter_date_end,
+			'filter_date_start' => $filter_date_start,
+			'filter_date_end'   => $filter_date_end,
 			'start'             => ($page - 1) * $this->config->get('config_pagination'),
 			'limit'             => $this->config->get('config_pagination')
 		];

--- a/upload/extension/opencart/admin/controller/report/sale_order.php
+++ b/upload/extension/opencart/admin/controller/report/sale_order.php
@@ -153,8 +153,8 @@ class SaleOrder extends \Opencart\System\Engine\Controller {
 		$data['orders'] = [];
 
 		$filter_data = [
-			'filter_date_start'	     => $filter_date_start,
-			'filter_date_end'	     => $filter_date_end,
+			'filter_date_start'      => $filter_date_start,
+			'filter_date_end'        => $filter_date_end,
 			'filter_group'           => $filter_group,
 			'filter_order_status_id' => $filter_order_status_id,
 			'start'                  => ($page - 1) * $this->config->get('config_pagination'),

--- a/upload/extension/opencart/admin/controller/report/sale_return.php
+++ b/upload/extension/opencart/admin/controller/report/sale_return.php
@@ -153,8 +153,8 @@ class SaleReturn extends \Opencart\System\Engine\Controller {
 		$data['returns'] = [];
 
 		$filter_data = [
-			'filter_date_start'	      => $filter_date_start,
-			'filter_date_end'	      => $filter_date_end,
+			'filter_date_start'       => $filter_date_start,
+			'filter_date_end'         => $filter_date_end,
 			'filter_group'            => $filter_group,
 			'filter_return_status_id' => $filter_return_status_id,
 			'start'                   => ($page - 1) * $this->config->get('config_pagination'),

--- a/upload/extension/opencart/admin/controller/report/sale_shipping.php
+++ b/upload/extension/opencart/admin/controller/report/sale_shipping.php
@@ -153,8 +153,8 @@ class SaleShipping extends \Opencart\System\Engine\Controller {
 		$data['orders'] = [];
 
 		$filter_data = [
-			'filter_date_start'	     => $filter_date_start,
-			'filter_date_end'	     => $filter_date_end,
+			'filter_date_start'      => $filter_date_start,
+			'filter_date_end'        => $filter_date_end,
 			'filter_group'           => $filter_group,
 			'filter_order_status_id' => $filter_order_status_id,
 			'start'                  => ($page - 1) * $this->config->get('config_pagination'),

--- a/upload/extension/opencart/admin/controller/report/sale_tax.php
+++ b/upload/extension/opencart/admin/controller/report/sale_tax.php
@@ -153,8 +153,8 @@ class SaleTax extends \Opencart\System\Engine\Controller {
 		$data['orders'] = [];
 
 		$filter_data = [
-			'filter_date_start'	     => $filter_date_start,
-			'filter_date_end'	     => $filter_date_end,
+			'filter_date_start'      => $filter_date_start,
+			'filter_date_end'        => $filter_date_end,
 			'filter_group'           => $filter_group,
 			'filter_order_status_id' => $filter_order_status_id,
 			'start'                  => ($page - 1) * $this->config->get('config_pagination'),


### PR DESCRIPTION
This was done using php-cs-fixer's binary_operator_spaces rule. Once all outstanding PR regarding code formatting have been merged future changes can be checked for issues in GitHub action and developers can run the tool locally to fix any formatting issues with there code.