### PR TITLE
Correctly align array initilizations in admin menu

### DIFF
--- a/upload/admin/controller/common/column_left.php
+++ b/upload/admin/controller/common/column_left.php
@@ -19,8 +19,8 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 			// Menu
 			$data['menus'][] = [
 				'id'       => 'menu-dashboard',
-				'icon'	   => 'fas fa-home',
-				'name'	   => $this->language->get('text_dashboard'),
+				'icon'     => 'fas fa-home',
+				'name'     => $this->language->get('text_dashboard'),
 				'href'     => $this->url->link('common/dashboard', 'user_token=' . $this->session->data['user_token']),
 				'children' => []
 			];
@@ -30,7 +30,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'catalog/category')) {
 				$catalog[] = [
-					'name'	   => $this->language->get('text_category'),
+					'name'     => $this->language->get('text_category'),
 					'href'     => $this->url->link('catalog/category', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -38,7 +38,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'catalog/product')) {
 				$catalog[] = [
-					'name'	   => $this->language->get('text_product'),
+					'name'     => $this->language->get('text_product'),
 					'href'     => $this->url->link('catalog/product', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -46,7 +46,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'catalog/subscription_plan')) {
 				$catalog[] = [
-					'name'	   => $this->language->get('text_subscription_plan'),
+					'name'     => $this->language->get('text_subscription_plan'),
 					'href'     => $this->url->link('catalog/subscription_plan', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -54,7 +54,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'catalog/filter')) {
 				$catalog[] = [
-					'name'	   => $this->language->get('text_filter'),
+					'name'     => $this->language->get('text_filter'),
 					'href'     => $this->url->link('catalog/filter', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -73,7 +73,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'catalog/attribute_group')) {
 				$attribute[] = [
-					'name'	   => $this->language->get('text_attribute_group'),
+					'name'     => $this->language->get('text_attribute_group'),
 					'href'     => $this->url->link('catalog/attribute_group', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -81,7 +81,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($attribute) {
 				$catalog[] = [
-					'name'	   => $this->language->get('text_attribute'),
+					'name'     => $this->language->get('text_attribute'),
 					'href'     => '',
 					'children' => $attribute
 				];
@@ -89,7 +89,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'catalog/option')) {
 				$catalog[] = [
-					'name'	   => $this->language->get('text_option'),
+					'name'     => $this->language->get('text_option'),
 					'href'     => $this->url->link('catalog/option', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -97,7 +97,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'catalog/manufacturer')) {
 				$catalog[] = [
-					'name'	   => $this->language->get('text_manufacturer'),
+					'name'     => $this->language->get('text_manufacturer'),
 					'href'     => $this->url->link('catalog/manufacturer', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -105,7 +105,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'catalog/download')) {
 				$catalog[] = [
-					'name'	   => $this->language->get('text_download'),
+					'name'     => $this->language->get('text_download'),
 					'href'     => $this->url->link('catalog/download', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -113,7 +113,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'catalog/review')) {
 				$catalog[] = [
-					'name'	   => $this->language->get('text_review'),
+					'name'     => $this->language->get('text_review'),
 					'href'     => $this->url->link('catalog/review', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -121,7 +121,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'catalog/information')) {
 				$catalog[] = [
-					'name'	   => $this->language->get('text_information'),
+					'name'     => $this->language->get('text_information'),
 					'href'     => $this->url->link('catalog/information', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -130,8 +130,8 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 			if ($catalog) {
 				$data['menus'][] = [
 					'id'       => 'menu-catalog',
-					'icon'	   => 'fa-solid fa-tag',
-					'name'	   => $this->language->get('text_catalog'),
+					'icon'     => 'fa-solid fa-tag',
+					'name'     => $this->language->get('text_catalog'),
 					'href'     => '',
 					'children' => $catalog
 				];
@@ -141,7 +141,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'cms/topic')) {
 				$cms[] = [
-					'name'	   => $this->language->get('text_topic'),
+					'name'     => $this->language->get('text_topic'),
 					'href'     => $this->url->link('cms/topic', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -149,7 +149,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'cms/article')) {
 				$cms[] = [
-					'name'	   => $this->language->get('text_article'),
+					'name'     => $this->language->get('text_article'),
 					'href'     => $this->url->link('cms/article', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -157,7 +157,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'cms/comment')) {
 				$cms[] = [
-					'name'	   => $this->language->get('text_comment'),
+					'name'     => $this->language->get('text_comment'),
 					'href'     => $this->url->link('cms/comment', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -165,7 +165,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'cms/antispam')) {
 				$cms[] = [
-					'name'	   => $this->language->get('text_antispam'),
+					'name'     => $this->language->get('text_antispam'),
 					'href'     => $this->url->link('cms/antispam', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -174,8 +174,8 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 			if ($cms) {
 				$data['menus'][] = [
 					'id'       => 'menu-cms',
-					'icon'	   => 'fa-regular fa-newspaper',
-					'name'	   => $this->language->get('text_cms'),
+					'icon'     => 'fa-regular fa-newspaper',
+					'name'     => $this->language->get('text_cms'),
 					'href'     => '',
 					'children' => $cms
 				];
@@ -186,7 +186,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'marketplace/marketplace')) {
 				$marketplace[] = [
-					'name'	   => $this->language->get('text_marketplace'),
+					'name'     => $this->language->get('text_marketplace'),
 					'href'     => $this->url->link('marketplace/marketplace', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -194,7 +194,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'marketplace/installer')) {
 				$marketplace[] = [
-					'name'	   => $this->language->get('text_installer'),
+					'name'     => $this->language->get('text_installer'),
 					'href'     => $this->url->link('marketplace/installer', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -202,7 +202,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'marketplace/extension')) {
 				$marketplace[] = [
-					'name'	   => $this->language->get('text_extension'),
+					'name'     => $this->language->get('text_extension'),
 					'href'     => $this->url->link('marketplace/extension', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -210,7 +210,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'marketplace/modification')) {
 				$marketplace[] = [
-					'name'	   => $this->language->get('text_modification'),
+					'name'     => $this->language->get('text_modification'),
 					'href'     => $this->url->link('marketplace/modification', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -218,7 +218,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'marketplace/startup')) {
 				$marketplace[] = [
-					'name'	   => $this->language->get('text_startup'),
+					'name'     => $this->language->get('text_startup'),
 					'href'     => $this->url->link('marketplace/startup', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -226,7 +226,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'marketplace/event')) {
 				$marketplace[] = [
-					'name'	   => $this->language->get('text_event'),
+					'name'     => $this->language->get('text_event'),
 					'href'     => $this->url->link('marketplace/event', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -234,7 +234,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'marketplace/cron')) {
 				$marketplace[] = [
-					'name'	   => $this->language->get('text_cron'),
+					'name'     => $this->language->get('text_cron'),
 					'href'     => $this->url->link('marketplace/cron', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -243,8 +243,8 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 			if ($marketplace) {
 				$data['menus'][] = [
 					'id'       => 'menu-extension',
-					'icon'	   => 'fas fa-puzzle-piece',
-					'name'	   => $this->language->get('text_extension'),
+					'icon'     => 'fas fa-puzzle-piece',
+					'name'     => $this->language->get('text_extension'),
 					'href'     => '',
 					'children' => $marketplace
 				];
@@ -255,7 +255,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'design/layout')) {
 				$design[] = [
-					'name'	   => $this->language->get('text_layout'),
+					'name'     => $this->language->get('text_layout'),
 					'href'     => $this->url->link('design/layout', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -263,7 +263,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'design/theme')) {
 				$design[] = [
-					'name'	   => $this->language->get('text_theme'),
+					'name'     => $this->language->get('text_theme'),
 					'href'     => $this->url->link('design/theme', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -271,7 +271,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'design/translation')) {
 				$design[] = [
-					'name'	   => $this->language->get('text_language_editor'),
+					'name'     => $this->language->get('text_language_editor'),
 					'href'     => $this->url->link('design/translation', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -279,7 +279,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'design/banner')) {
 				$design[] = [
-					'name'	   => $this->language->get('text_banner'),
+					'name'     => $this->language->get('text_banner'),
 					'href'     => $this->url->link('design/banner', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -287,7 +287,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'design/seo_url')) {
 				$design[] = [
-					'name'	   => $this->language->get('text_seo_url'),
+					'name'     => $this->language->get('text_seo_url'),
 					'href'     => $this->url->link('design/seo_url', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -296,8 +296,8 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 			if ($design) {
 				$data['menus'][] = [
 					'id'       => 'menu-design',
-					'icon'	   => 'fas fa-desktop',
-					'name'	   => $this->language->get('text_design'),
+					'icon'     => 'fas fa-desktop',
+					'name'     => $this->language->get('text_design'),
 					'href'     => '',
 					'children' => $design
 				];
@@ -308,7 +308,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'sale/order')) {
 				$sale[] = [
-					'name'	   => $this->language->get('text_order'),
+					'name'     => $this->language->get('text_order'),
 					'href'     => $this->url->link('sale/order', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -316,7 +316,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'sale/subscription')) {
 				$sale[] = [
-					'name'	   => $this->language->get('text_subscription'),
+					'name'     => $this->language->get('text_subscription'),
 					'href'     => $this->url->link('sale/subscription', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -324,7 +324,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'sale/returns')) {
 				$sale[] = [
-					'name'	   => $this->language->get('text_return'),
+					'name'     => $this->language->get('text_return'),
 					'href'     => $this->url->link('sale/returns', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -335,7 +335,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'sale/voucher')) {
 				$voucher[] = [
-					'name'	   => $this->language->get('text_voucher'),
+					'name'     => $this->language->get('text_voucher'),
 					'href'     => $this->url->link('sale/voucher', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -343,7 +343,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'sale/voucher_theme')) {
 				$voucher[] = [
-					'name'	   => $this->language->get('text_voucher_theme'),
+					'name'     => $this->language->get('text_voucher_theme'),
 					'href'     => $this->url->link('sale/voucher_theme', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -351,7 +351,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($voucher) {
 				$sale[] = [
-					'name'	   => $this->language->get('text_voucher'),
+					'name'     => $this->language->get('text_voucher'),
 					'href'     => '',
 					'children' => $voucher
 				];
@@ -360,8 +360,8 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 			if ($sale) {
 				$data['menus'][] = [
 					'id'       => 'menu-sale',
-					'icon'	   => 'fas fa-shopping-cart',
-					'name'	   => $this->language->get('text_sale'),
+					'icon'     => 'fas fa-shopping-cart',
+					'name'     => $this->language->get('text_sale'),
 					'href'     => '',
 					'children' => $sale
 				];
@@ -372,7 +372,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'customer/customer')) {
 				$customer[] = [
-					'name'	   => $this->language->get('text_customer'),
+					'name'     => $this->language->get('text_customer'),
 					'href'     => $this->url->link('customer/customer', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -380,7 +380,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'customer/customer_group')) {
 				$customer[] = [
-					'name'	   => $this->language->get('text_customer_group'),
+					'name'     => $this->language->get('text_customer_group'),
 					'href'     => $this->url->link('customer/customer_group', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -388,7 +388,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'customer/customer_approval')) {
 				$customer[] = [
-					'name'	   => $this->language->get('text_customer_approval'),
+					'name'     => $this->language->get('text_customer_approval'),
 					'href'     => $this->url->link('customer/customer_approval', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -396,7 +396,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'customer/gdpr')) {
 				$customer[] = [
-					'name'	   => $this->language->get('text_gdpr'),
+					'name'     => $this->language->get('text_gdpr'),
 					'href'     => $this->url->link('customer/gdpr', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -404,7 +404,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'customer/custom_field')) {
 				$customer[] = [
-					'name'	   => $this->language->get('text_custom_field'),
+					'name'     => $this->language->get('text_custom_field'),
 					'href'     => $this->url->link('customer/custom_field', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -413,8 +413,8 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 			if ($customer) {
 				$data['menus'][] = [
 					'id'       => 'menu-customer',
-					'icon'	   => 'fas fa-user',
-					'name'	   => $this->language->get('text_customer'),
+					'icon'     => 'fas fa-user',
+					'name'     => $this->language->get('text_customer'),
 					'href'     => '',
 					'children' => $customer
 				];
@@ -425,7 +425,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'marketing/affiliate')) {
 				$marketing[] = [
-					'name'	   => $this->language->get('text_affiliate'),
+					'name'     => $this->language->get('text_affiliate'),
 					'href'     => $this->url->link('marketing/affiliate', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -433,7 +433,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'marketing/marketing')) {
 				$marketing[] = [
-					'name'	   => $this->language->get('text_marketing'),
+					'name'     => $this->language->get('text_marketing'),
 					'href'     => $this->url->link('marketing/marketing', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -441,7 +441,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'marketing/coupon')) {
 				$marketing[] = [
-					'name'	   => $this->language->get('text_coupon'),
+					'name'     => $this->language->get('text_coupon'),
 					'href'     => $this->url->link('marketing/coupon', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -449,7 +449,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'marketing/contact')) {
 				$marketing[] = [
-					'name'	   => $this->language->get('text_contact'),
+					'name'     => $this->language->get('text_contact'),
 					'href'     => $this->url->link('marketing/contact', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -458,8 +458,8 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 			if ($marketing) {
 				$data['menus'][] = [
 					'id'       => 'menu-marketing',
-					'icon'	   => 'fas fa-share-alt',
-					'name'	   => $this->language->get('text_marketing'),
+					'icon'     => 'fas fa-share-alt',
+					'name'     => $this->language->get('text_marketing'),
 					'href'     => '',
 					'children' => $marketing
 				];
@@ -470,7 +470,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'setting/setting')) {
 				$system[] = [
-					'name'	   => $this->language->get('text_setting'),
+					'name'     => $this->language->get('text_setting'),
 					'href'     => $this->url->link('setting/store', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -481,7 +481,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'user/user')) {
 				$user[] = [
-					'name'	   => $this->language->get('text_users'),
+					'name'     => $this->language->get('text_users'),
 					'href'     => $this->url->link('user/user', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -489,7 +489,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'user/user_permission')) {
 				$user[] = [
-					'name'	   => $this->language->get('text_user_group'),
+					'name'     => $this->language->get('text_user_group'),
 					'href'     => $this->url->link('user/user_permission', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -497,7 +497,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'user/api')) {
 				$user[] = [
-					'name'	   => $this->language->get('text_api'),
+					'name'     => $this->language->get('text_api'),
 					'href'     => $this->url->link('user/api', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -505,7 +505,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($user) {
 				$system[] = [
-					'name'	   => $this->language->get('text_users'),
+					'name'     => $this->language->get('text_users'),
 					'href'     => '',
 					'children' => $user
 				];
@@ -516,7 +516,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'localisation/location')) {
 				$localisation[] = [
-					'name'	   => $this->language->get('text_location'),
+					'name'     => $this->language->get('text_location'),
 					'href'     => $this->url->link('localisation/location', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -524,7 +524,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'localisation/language')) {
 				$localisation[] = [
-					'name'	   => $this->language->get('text_language'),
+					'name'     => $this->language->get('text_language'),
 					'href'     => $this->url->link('localisation/language', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -532,7 +532,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'localisation/currency')) {
 				$localisation[] = [
-					'name'	   => $this->language->get('text_currency'),
+					'name'     => $this->language->get('text_currency'),
 					'href'     => $this->url->link('localisation/currency', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -540,7 +540,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'localisation/stock_status')) {
 				$localisation[] = [
-					'name'	   => $this->language->get('text_stock_status'),
+					'name'     => $this->language->get('text_stock_status'),
 					'href'     => $this->url->link('localisation/stock_status', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -548,7 +548,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'localisation/order_status')) {
 				$localisation[] = [
-					'name'	   => $this->language->get('text_order_status'),
+					'name'     => $this->language->get('text_order_status'),
 					'href'     => $this->url->link('localisation/order_status', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -556,7 +556,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'localisation/subscription_status')) {
 				$localisation[] = [
-					'name'	   => $this->language->get('text_subscription_status'),
+					'name'     => $this->language->get('text_subscription_status'),
 					'href'     => $this->url->link('localisation/subscription_status', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -567,7 +567,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'localisation/return_status')) {
 				$returns[] = [
-					'name'	   => $this->language->get('text_return_status'),
+					'name'     => $this->language->get('text_return_status'),
 					'href'     => $this->url->link('localisation/return_status', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -575,7 +575,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'localisation/return_action')) {
 				$returns[] = [
-					'name'	   => $this->language->get('text_return_action'),
+					'name'     => $this->language->get('text_return_action'),
 					'href'     => $this->url->link('localisation/return_action', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -583,7 +583,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'localisation/return_reason')) {
 				$returns[] = [
-					'name'	   => $this->language->get('text_return_reason'),
+					'name'     => $this->language->get('text_return_reason'),
 					'href'     => $this->url->link('localisation/return_reason', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -591,7 +591,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($returns) {
 				$localisation[] = [
-					'name'	   => $this->language->get('text_return'),
+					'name'     => $this->language->get('text_return'),
 					'href'     => '',
 					'children' => $returns
 				];
@@ -599,7 +599,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'localisation/country')) {
 				$localisation[] = [
-					'name'	   => $this->language->get('text_country'),
+					'name'     => $this->language->get('text_country'),
 					'href'     => $this->url->link('localisation/country', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -607,7 +607,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'localisation/zone')) {
 				$localisation[] = [
-					'name'	   => $this->language->get('text_zone'),
+					'name'     => $this->language->get('text_zone'),
 					'href'     => $this->url->link('localisation/zone', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -615,7 +615,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'localisation/geo_zone')) {
 				$localisation[] = [
-					'name'	   => $this->language->get('text_geo_zone'),
+					'name'     => $this->language->get('text_geo_zone'),
 					'href'     => $this->url->link('localisation/geo_zone', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -626,7 +626,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'localisation/tax_class')) {
 				$tax[] = [
-					'name'	   => $this->language->get('text_tax_class'),
+					'name'     => $this->language->get('text_tax_class'),
 					'href'     => $this->url->link('localisation/tax_class', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -634,7 +634,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'localisation/tax_rate')) {
 				$tax[] = [
-					'name'	   => $this->language->get('text_tax_rate'),
+					'name'     => $this->language->get('text_tax_rate'),
 					'href'     => $this->url->link('localisation/tax_rate', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -642,7 +642,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($tax) {
 				$localisation[] = [
-					'name'	   => $this->language->get('text_tax'),
+					'name'     => $this->language->get('text_tax'),
 					'href'     => '',
 					'children' => $tax
 				];
@@ -650,7 +650,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'localisation/length_class')) {
 				$localisation[] = [
-					'name'	   => $this->language->get('text_length_class'),
+					'name'     => $this->language->get('text_length_class'),
 					'href'     => $this->url->link('localisation/length_class', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -658,7 +658,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'localisation/weight_class')) {
 				$localisation[] = [
-					'name'	   => $this->language->get('text_weight_class'),
+					'name'     => $this->language->get('text_weight_class'),
 					'href'     => $this->url->link('localisation/weight_class', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -666,7 +666,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'localisation/address_format')) {
 				$localisation[] = [
-					'name'	   => $this->language->get('text_address_format'),
+					'name'     => $this->language->get('text_address_format'),
 					'href'     => $this->url->link('localisation/address_format', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -674,7 +674,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($localisation) {
 				$system[] = [
-					'name'	   => $this->language->get('text_localisation'),
+					'name'     => $this->language->get('text_localisation'),
 					'href'     => '',
 					'children' => $localisation
 				];
@@ -685,7 +685,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'tool/upgrade')) {
 				$maintenance[] = [
-					'name'	   => $this->language->get('text_upgrade'),
+					'name'     => $this->language->get('text_upgrade'),
 					'href'     => $this->url->link('tool/upgrade', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -693,7 +693,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'tool/backup')) {
 				$maintenance[] = [
-					'name'	   => $this->language->get('text_backup'),
+					'name'     => $this->language->get('text_backup'),
 					'href'     => $this->url->link('tool/backup', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -701,7 +701,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'tool/upload')) {
 				$maintenance[] = [
-					'name'	   => $this->language->get('text_upload'),
+					'name'     => $this->language->get('text_upload'),
 					'href'     => $this->url->link('tool/upload', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -709,7 +709,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'tool/log')) {
 				$maintenance[] = [
-					'name'	   => $this->language->get('text_log'),
+					'name'     => $this->language->get('text_log'),
 					'href'     => $this->url->link('tool/log', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -717,7 +717,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($maintenance) {
 				$system[] = [
-					'name'	   => $this->language->get('text_maintenance'),
+					'name'     => $this->language->get('text_maintenance'),
 					'href'     => '',
 					'children' => $maintenance
 				];
@@ -726,8 +726,8 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 			if ($system) {
 				$data['menus'][] = [
 					'id'       => 'menu-system',
-					'icon'	   => 'fas fa-cog',
-					'name'	   => $this->language->get('text_system'),
+					'icon'     => 'fas fa-cog',
+					'name'     => $this->language->get('text_system'),
 					'href'     => '',
 					'children' => $system
 				];
@@ -737,7 +737,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'report/report')) {
 				$report[] = [
-					'name'	   => $this->language->get('text_reports'),
+					'name'     => $this->language->get('text_reports'),
 					'href'     => $this->url->link('report/report', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -745,7 +745,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'report/online')) {
 				$report[] = [
-					'name'	   => $this->language->get('text_online'),
+					'name'     => $this->language->get('text_online'),
 					'href'     => $this->url->link('report/online', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -753,7 +753,7 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 
 			if ($this->user->hasPermission('access', 'report/statistics')) {
 				$report[] = [
-					'name'	   => $this->language->get('text_statistics'),
+					'name'     => $this->language->get('text_statistics'),
 					'href'     => $this->url->link('report/statistics', 'user_token=' . $this->session->data['user_token']),
 					'children' => []
 				];
@@ -762,8 +762,8 @@ class ColumnLeft extends \Opencart\System\Engine\Controller {
 			if ($report) {
 				$data['menus'][] = [
 					'id'       => 'menu-report',
-					'icon'	   => 'fas fa-chart-bar',
-					'name'	   => $this->language->get('text_reports'),
+					'icon'     => 'fas fa-chart-bar',
+					'name'     => $this->language->get('text_reports'),
 					'href'     => '',
 					'children' => $report
 				];


### PR DESCRIPTION
This was done using php-cs-fixer's binary_operator_spaces rule. Once all outstanding PR regarding code formatting have been merged future changes can be checked for issues in GitHub action and developers can run the tool locally to fix any formatting issues with there code.