### PR TITLE
Remove trailing whitespace from empty lines in extensions

### DIFF
--- a/upload/extension/opencart/admin/controller/dashboard/customer.php
+++ b/upload/extension/opencart/admin/controller/dashboard/customer.php
@@ -37,7 +37,7 @@ class Customer extends \Opencart\System\Engine\Controller {
 		$data['dashboard_customer_width'] = $this->config->get('dashboard_customer_width');
 
 		$data['columns'] = [];
-		
+
 		for ($i = 3; $i <= 12; $i++) {
 			$data['columns'][] = $i;
 		}

--- a/upload/extension/opencart/admin/controller/dashboard/order.php
+++ b/upload/extension/opencart/admin/controller/dashboard/order.php
@@ -38,7 +38,7 @@ class Order extends \Opencart\System\Engine\Controller {
 		$data['dashboard_order_width'] = $this->config->get('dashboard_order_width');
 
 		$data['columns'] = [];
-		
+
 		for ($i = 3; $i <= 12; $i++) {
 			$data['columns'][] = $i;
 		}

--- a/upload/extension/opencart/admin/controller/dashboard/recent.php
+++ b/upload/extension/opencart/admin/controller/dashboard/recent.php
@@ -37,7 +37,7 @@ class Recent extends \Opencart\System\Engine\Controller {
 		$data['dashboard_recent_width'] = $this->config->get('dashboard_recent_width');
 
 		$data['columns'] = [];
-		
+
 		for ($i = 3; $i <= 12; $i++) {
 			$data['columns'][] = $i;
 		}
@@ -93,7 +93,7 @@ class Recent extends \Opencart\System\Engine\Controller {
 		];
 
 		$this->load->model('sale/order');
-		
+
 		$results = $this->model_sale_order->getOrders($filter_data);
 
 		foreach ($results as $result) {

--- a/upload/extension/opencart/admin/controller/module/banner.php
+++ b/upload/extension/opencart/admin/controller/module/banner.php
@@ -115,7 +115,7 @@ class Banner extends \Opencart\System\Engine\Controller {
 		} else {
 			$data['status'] = '';
 		}
-		
+
 		if (isset($this->request->get['module_id'])) {
 			$data['module_id'] = (int)$this->request->get['module_id'];
 		} else {

--- a/upload/extension/opencart/admin/controller/module/bestseller.php
+++ b/upload/extension/opencart/admin/controller/module/bestseller.php
@@ -87,7 +87,7 @@ class BestSeller extends \Opencart\System\Engine\Controller {
 		} else {
 			$data['status'] = '';
 		}
-		
+
 		if (isset($this->request->get['module_id'])) {
 			$data['module_id'] = (int)$this->request->get['module_id'];
 		} else {

--- a/upload/extension/opencart/admin/controller/module/featured.php
+++ b/upload/extension/opencart/admin/controller/module/featured.php
@@ -102,7 +102,7 @@ class Featured extends \Opencart\System\Engine\Controller {
 		} else {
 			$data['status'] = '';
 		}
-		
+
 		if (isset($this->request->get['module_id'])) {
 			$data['module_id'] = (int)$this->request->get['module_id'];
 		} else {

--- a/upload/extension/opencart/admin/controller/module/html.php
+++ b/upload/extension/opencart/admin/controller/module/html.php
@@ -76,7 +76,7 @@ class HTML extends \Opencart\System\Engine\Controller {
 		} else {
 			$data['status'] = '';
 		}
-		
+
 		if (isset($this->request->get['module_id'])) {
 			$data['module_id'] = (int)$this->request->get['module_id'];
 		} else {

--- a/upload/extension/opencart/admin/controller/module/latest.php
+++ b/upload/extension/opencart/admin/controller/module/latest.php
@@ -87,7 +87,7 @@ class Latest extends \Opencart\System\Engine\Controller {
 		} else {
 			$data['status'] = '';
 		}
-		
+
 		if (isset($this->request->get['module_id'])) {
 			$data['module_id'] = (int)$this->request->get['module_id'];
 		} else {

--- a/upload/extension/opencart/admin/controller/module/special.php
+++ b/upload/extension/opencart/admin/controller/module/special.php
@@ -87,7 +87,7 @@ class Special extends \Opencart\System\Engine\Controller {
 		} else {
 			$data['status'] = '';
 		}
-		
+
 		if (isset($this->request->get['module_id'])) {
 			$data['module_id'] = (int)$this->request->get['module_id'];
 		} else {

--- a/upload/extension/opencart/admin/controller/payment/bank_transfer.php
+++ b/upload/extension/opencart/admin/controller/payment/bank_transfer.php
@@ -39,7 +39,7 @@ class BankTransfer extends \Opencart\System\Engine\Controller {
 		$data['payment_bank_transfer_bank'] = [];
 
 		$languages = $this->model_localisation_language->getLanguages();
-		
+
 		foreach ($languages as $language) {
 			$data['payment_bank_transfer_bank'][$language['language_id']] = $this->config->get('payment_bank_transfer_bank_' . $language['language_id']);
 		}

--- a/upload/extension/opencart/admin/controller/report/subscription.php
+++ b/upload/extension/opencart/admin/controller/report/subscription.php
@@ -11,111 +11,111 @@ class Subscription extends \Opencart\System\Engine\Controller {
      */
     public function index(): void {
         $this->load->language('extension/opencart/report/subscription');
-        
+
         $this->document->setTitle($this->language->get('heading_title'));
-        
+
         $data['breadcrumbs'] = [];
-        
+
         $data['breadcrumbs'][] = [
             'text' => $this->language->get('text_home'),
             'href' => $this->url->link('common/dashboard', 'user_token=' . $this->session->data['user_token'])
         ];
-        
+
         $data['breadcrumbs'][] = [
             'text' => $this->language->get('text_extension'),
             'href' => $this->url->link('marketplace/extension', 'user_token=' . $this->session->data['user_token'] . '&type=report')
         ];
-        
+
         $data['breadcrumbs'][] = [
             'text' => $this->language->get('heading_title'),
             'href' => $this->url->link('extension/opencart/report/subscription', 'user_token=' . $this->session->data['user_token'])
         ];
-        
+
         $data['save'] = $this->url->link('extension/opencart/report/subscription.save', 'user_token=' . $this->session->data['user_token']);
         $data['back'] = $this->url->link('marketplace/extension', 'user_token=' . $this->session->data['user_token'] . '&type=report');
-        
+
         $data['report_subscription_status'] = $this->config->get('report_subscription_status');
         $data['report_subscription_sort_order'] = $this->config->get('report_subscription_sort_order');
-        
+
         $data['header'] = $this->load->controller('common/header');
         $data['column_left'] = $this->load->controller('common/column_left');
         $data['footer'] = $this->load->controller('common/footer');
-        
+
         $this->response->setOutput($this->load->view('extension/opencart/report/subscription_form', $data));
     }
-    
+
     /**
      * @return void
      */
     public function save(): void {
         $this->load->language('extension/opencart/report/subscription');
-        
+
         $json = [];
-        
+
         if (!$this->user->hasPermission('modify', 'extension/opencart/report/subscription')) {
             $json['error'] = $this->language->get('error_permission');
         }
-        
+
         if (!$json) {
             $this->load->model('setting/setting');
-            
+
             $this->model_setting_setting->editSetting('report_subscription', $this->request->post);
-            
+
             $json['success'] = $this->language->get('text_success');
         }
-        
+
         $this->response->addHeader('Content-Type: application/json');
         $this->response->setOutput(json_encode($json));
     }
-    
+
     /**
      * @return void
      */
     public function report(): void {
         $this->load->language('extension/opencart/report/subscription');
-        
+
         $data['list'] = $this->getReport();
-        
+
         $this->load->model('localisation/subscription_status');
-        
+
         $data['subscription_statuses'] = $this->model_localisation_subscription_status->getSubscriptionStatuses();
-        
+
         $data['groups'] = [];
-        
+
         $data['groups'][] = [
             'text'  => $this->language->get('text_year'),
             'value' => 'year',
         ];
-        
+
         $data['groups'][] = [
             'text'  => $this->language->get('text_month'),
             'value' => 'month',
         ];
-        
+
         $data['groups'][] = [
             'text'  => $this->language->get('text_week'),
             'value' => 'week',
         ];
-        
+
         $data['groups'][] = [
             'text'  => $this->language->get('text_day'),
             'value' => 'day',
         ];
-        
+
         $data['user_token'] = $this->session->data['user_token'];
-        
+
         $this->response->setOutput($this->load->view('extension/opencart/report/subscription', $data));
     }
-    
+
     /**
      * @return void
      */
     public function list(): void {
         $this->load->language('extension/opencart/report/subscription');
-        
+
         $this->response->setOutput($this->getReport());
     }
-    
+
     /**
      * @return string
      */
@@ -125,33 +125,33 @@ class Subscription extends \Opencart\System\Engine\Controller {
         } else {
             $filter_date_start = date('Y-m-d', strtotime(date('Y') . '-' . date('m') . '-01'));
         }
-        
+
         if (isset($this->request->get['filter_date_end'])) {
             $filter_date_end = $this->request->get['filter_date_end'];
         } else {
             $filter_date_end = date('Y-m-d');
         }
-        
+
         if (isset($this->request->get['filter_group'])) {
             $filter_group = $this->request->get['filter_group'];
         } else {
             $filter_group = 'week';
         }
-        
+
         if (isset($this->request->get['filter_subscription_status_id'])) {
             $filter_subscription_status_id = (int)$this->request->get['filter_subscription_status_id'];
         } else {
             $filter_subscription_status_id = 0;
         }
-        
+
         if (isset($this->request->get['page'])) {
             $page = (int)$this->request->get['page'];
         } else {
             $page = 1;
         }
-        
+
         $data['subscriptions'] = [];
-        
+
         $filter_data = [
             'filter_date_start'             => $filter_date_start,
             'filter_date_end'               => $filter_date_end,
@@ -160,13 +160,13 @@ class Subscription extends \Opencart\System\Engine\Controller {
             'start'                         => ($page - 1) * $this->config->get('config_pagination'),
             'limit'                         => $this->config->get('config_pagination')
         ];
-        
+
         $this->load->model('extension/opencart/report/subscription');
-        
+
         $subscription_total = $this->model_extension_opencart_report_subscription->getTotalSubscriptions($filter_data);
-        
+
         $results = $this->model_extension_opencart_report_subscription->getSubscriptions($filter_data);
-        
+
         foreach ($results as $result) {
             $data['subscriptions'][] = [
                 'date_start'    => date($this->language->get('date_format_short'), strtotime($result['date_start'])),
@@ -177,41 +177,41 @@ class Subscription extends \Opencart\System\Engine\Controller {
                 'total'         => $this->currency->format((float)$result['total'], $this->config->get('config_currency'))
             ];
         }
-        
+
         $url = '';
-        
+
         if (isset($this->request->get['filter_date_start'])) {
             $url .= '&filter_date_start=' . $this->request->get['filter_date_start'];
         }
-        
+
         if (isset($this->request->get['filter_date_end'])) {
             $url .= '&filter_date_end=' . $this->request->get['filter_date_end'];
         }
-        
+
         if (isset($this->request->get['filter_group'])) {
             $url .= '&filter_group=' . $this->request->get['filter_group'];
         }
-        
+
         if (isset($this->request->get['filter_subscription_status_id'])) {
             $url .= '&filter_subscription_status_id=' . $this->request->get['filter_subscription_status_id'];
         }
-        
+
         $data['pagination'] = $this->load->controller('common/pagination', [
             'total' => $subscription_total,
             'page'  => $page,
             'limit' => $this->config->get('config_pagination'),
             'url'   => $this->url->link('extension/opencart/report/subscription', 'user_token=' . $this->session->data['user_token'] . '&code=subscription' . $url . '&page={page}')
         ]);
-        
+
         $data['results'] = sprintf($this->language->get('text_pagination'), ($subscription_total) ? (($page - 1) * $this->config->get('config_pagination')) + 1 : 0, ((($page - 1) * $this->config->get('config_pagination')) > ($subscription_total - $this->config->get('config_pagination'))) ? $subscription_total : ((($page - 1) * $this->config->get('config_pagination')) + $this->config->get('config_pagination')), $subscription_total, ceil($subscription_total / $this->config->get('config_pagination')));
-        
+
         $data['filter_date_start'] = $filter_date_start;
         $data['filter_date_end'] = $filter_date_end;
         $data['filter_group'] = $filter_group;
         $data['filter_subscription_status_id'] = $filter_subscription_status_id;
-        
+
         $data['user_token'] = $this->session->data['user_token'];
-        
+
         return $this->load->view('extension/opencart/report/subscription_list', $data);
     }
 }

--- a/upload/extension/opencart/admin/model/report/subscription.php
+++ b/upload/extension/opencart/admin/model/report/subscription.php
@@ -13,27 +13,27 @@ class Subscription extends \Opencart\System\Engine\Model {
      */
     public function getSubscriptions(array $data = []): array {
         $sql = "SELECT MIN(`s`.`date_added`) AS date_start, MAX(`s`.`date_added`) AS date_end, COUNT(*) AS `subscriptions`, SUM((SELECT SUM(`ot`.`value`) FROM `" . DB_PREFIX . "order_total` ot WHERE ot.`order_id` = `s`.`order_id` AND ot.`code` = 'tax' GROUP BY ot.`order_id`)) AS tax, SUM(`s`.`quantity`) AS `products`, SUM(`s`.`price`) AS `total` FROM `" . DB_PREFIX . "subscription` `s`";
-        
+
         if (!empty($data['filter_subscription_status_id'])) {
             $sql .= " WHERE `s`.`subscription_status_id` = '" . (int)$data['filter_subscription_status_id'] . "'";
         } else {
             $sql .= " WHERE `s`.`subscription_status_id` > '0'";
         }
-        
+
         if (!empty($data['filter_date_start'])) {
             $sql .= " AND DATE(`s`.`date_added`) >= DATE('" . $this->db->escape((string)$data['filter_date_start']) . "')";
         }
-        
+
         if (!empty($data['filter_date_end'])) {
             $sql .= " AND DATE(`s`.`date_added`) <= DATE('" . $this->db->escape((string)$data['filter_date_end']) . "')";
         }
-        
+
         if (!empty($data['filter_group'])) {
             $group = $data['filter_group'];
         } else {
             $group = 'week';
         }
-        
+
         switch ($group) {
             case 'day':
                 $sql .= " GROUP BY YEAR(`s`.`date_added`), MONTH(`s`.`date_added`), DAY(`s`.`date_added`)";
@@ -49,26 +49,26 @@ class Subscription extends \Opencart\System\Engine\Model {
                 $sql .= " GROUP BY YEAR(`s`.`date_added`)";
                 break;
         }
-        
+
         $sql .= " ORDER BY `s`.`date_added` DESC";
-        
+
         if (isset($data['start']) || isset($data['limit'])) {
             if ($data['start'] < 0) {
                 $data['start'] = 0;
             }
-            
+
             if ($data['limit'] < 1) {
                 $data['limit'] = 20;
             }
-            
+
             $sql .= " LIMIT " . (int)$data['start'] . "," . (int)$data['limit'];
         }
-        
+
         $query = $this->db->query($sql);
-        
+
         return $query->rows;
     }
-    
+
     /**
      * @param array $data
      *
@@ -80,7 +80,7 @@ class Subscription extends \Opencart\System\Engine\Model {
         } else {
             $group = 'week';
         }
-        
+
         switch ($group) {
             case 'day':
                 $sql = "SELECT COUNT(DISTINCT YEAR(`date_added`), MONTH(`date_added`), DAY(`date_added`)) AS `total` FROM `" . DB_PREFIX . "subscription`";
@@ -96,23 +96,23 @@ class Subscription extends \Opencart\System\Engine\Model {
                 $sql = "SELECT COUNT(DISTINCT YEAR(`date_added`)) AS `total` FROM `" . DB_PREFIX . "subscription`";
                 break;
         }
-        
+
         if (!empty($data['filter_subscription_status_id'])) {
             $sql .= " WHERE `subscription_status_id` = '" . (int)$data['filter_subscription_status_id'] . "'";
         } else {
             $sql .= " WHERE `subscription_status_id` > '0'";
         }
-        
+
         if (!empty($data['filter_date_start'])) {
             $sql .= " AND DATE(`date_added`) >= DATE('" . $this->db->escape((string)$data['filter_date_start']) . "')";
         }
-        
+
         if (!empty($data['filter_date_end'])) {
             $sql .= " AND DATE(`date_added`) <= DATE('" . $this->db->escape((string)$data['filter_date_end']) . "')";
         }
-        
+
         $query = $this->db->query($sql);
-        
+
         return (int)$query->row['total'];
     }
 }


### PR DESCRIPTION
This was done using php-cs-fixer's no_whitespace_in_blank_line rule. Once all outstanding PR regarding code formatting have been merged future changes can be checked for issues in GitHub action and developers can run the tool locally to fix any formatting issues with there code.