### PR TITLE
Remove trailing whitespace from empty lines in installer

### DIFF
--- a/upload/install/cli_install.php
+++ b/upload/install/cli_install.php
@@ -410,19 +410,19 @@ class CliInstall extends \Opencart\System\Engine\Controller {
 		$output .= 'define(\'DB_DATABASE\', \'' . addslashes($option['db_database']) . '\');' . "\n";
 		$output .= 'define(\'DB_PREFIX\', \'' . addslashes($option['db_prefix']) . '\');' . "\n";
 		$output .= 'define(\'DB_PORT\', \'' . addslashes($option['db_port']) . '\');' . "\n";
-		
+
 		if ($option['db_ssl_key']) {
 			$output .= 'define(\'DB_SSL_KEY\', \'' . addslashes($option['db_ssl_key']) . '\');' . "\n";
 		}
-		
+
 		if ($option['db_ssl_cert']) {
 			$output .= 'define(\'DB_SSL_CERT\', \'' . addslashes($option['db_ssl_cert']) . '\');' . "\n";
 		}
-		
+
 		if ($option['db_ssl_ca']) {
 			$output .= 'define(\'DB_SSL_CA\', \'' . addslashes($option['db_ssl_ca']) . '\');' . "\n";
 		}
-		
+
 		$file = fopen(DIR_OPENCART . 'config.php', 'w');
 
 		fwrite($file, $output);
@@ -463,15 +463,15 @@ class CliInstall extends \Opencart\System\Engine\Controller {
 		$output .= 'define(\'DB_DATABASE\', \'' . addslashes($option['db_database']) . '\');' . "\n";
 		$output .= 'define(\'DB_PREFIX\', \'' . addslashes($option['db_prefix']) . '\');' . "\n";
 		$output .= 'define(\'DB_PORT\', \'' . addslashes($option['db_port']) . '\');' . "\n\n";
-		
+
 		if ($option['db_ssl_key']) {
 			$output .= 'define(\'DB_SSL_KEY\', \'' . addslashes($option['db_ssl_key']) . '\');' . "\n";
 		}
-		
+
 		if ($option['db_ssl_cert']) {
 			$output .= 'define(\'DB_SSL_CERT\', \'' . addslashes($option['db_ssl_cert']) . '\');' . "\n";
 		}
-		
+
 		if ($option['db_ssl_ca']) {
 			$output .= 'define(\'DB_SSL_CA\', \'' . addslashes($option['db_ssl_ca']) . '\');' . "\n";
 		}

--- a/upload/install/controller/common/footer.php
+++ b/upload/install/controller/common/footer.php
@@ -11,7 +11,7 @@ class Footer extends \Opencart\System\Engine\Controller {
 	 */
 	public function index(): string {
 		$this->load->language('common/footer');
-		
+
 		$data['text_project'] = $this->language->get('text_project');
 		$data['text_documentation'] = $this->language->get('text_documentation');
 		$data['text_support'] = $this->language->get('text_support');

--- a/upload/install/controller/common/header.php
+++ b/upload/install/controller/common/header.php
@@ -11,7 +11,7 @@ class Header extends \Opencart\System\Engine\Controller {
 	 */
 	public function index(): string {
 		$this->load->language('common/header');
-		
+
 		$data['title'] = $this->document->getTitle();
 		$data['description'] = $this->document->getDescription();
 		$data['base'] = HTTP_SERVER;

--- a/upload/install/controller/error/not_found.php
+++ b/upload/install/controller/error/not_found.php
@@ -13,7 +13,7 @@ class NotFound extends \Opencart\System\Engine\Controller {
 		$this->load->language('error/not_found');
 
 		$this->document->setTitle($this->language->get('heading_title'));
-		
+
 		$data['heading_title'] = $this->language->get('heading_title');
 
 		$data['text_error'] = $this->language->get('text_error');

--- a/upload/install/controller/install/step_3.php
+++ b/upload/install/controller/install/step_3.php
@@ -16,7 +16,7 @@ class Step3 extends \Opencart\System\Engine\Controller {
 	 */
 	public function index(): void {
 		$this->load->language('install/step_3');
-		
+
 		if (($this->request->server['REQUEST_METHOD'] == 'POST') && $this->validate()) {
 			$this->load->model('install/install');
 
@@ -46,7 +46,7 @@ class Step3 extends \Opencart\System\Engine\Controller {
 			$output .= 'define(\'DIR_LOGS\', DIR_STORAGE . \'logs/\');' . "\n";
 			$output .= 'define(\'DIR_SESSION\', DIR_STORAGE . \'session/\');' . "\n";
 			$output .= 'define(\'DIR_UPLOAD\', DIR_STORAGE . \'upload/\');' . "\n\n";
-			
+
 			$output .= '// DB' . "\n";
 			$output .= 'define(\'DB_DRIVER\', \'' . addslashes($this->request->post['db_driver']) . '\');' . "\n";
 			$output .= 'define(\'DB_HOSTNAME\', \'' . addslashes($this->request->post['db_hostname']) . '\');' . "\n";
@@ -106,35 +106,35 @@ class Step3 extends \Opencart\System\Engine\Controller {
 			$output .= 'define(\'DIR_LOGS\', DIR_STORAGE . \'logs/\');' . "\n";
 			$output .= 'define(\'DIR_SESSION\', DIR_STORAGE . \'session/\');' . "\n";
 			$output .= 'define(\'DIR_UPLOAD\', DIR_STORAGE . \'upload/\');' . "\n\n";
-			
+
 			$output .= '// DB' . "\n";
 			$output .= 'define(\'DB_DRIVER\', \'' . addslashes($this->request->post['db_driver']) . '\');' . "\n";
 			$output .= 'define(\'DB_HOSTNAME\', \'' . addslashes($this->request->post['db_hostname']) . '\');' . "\n";
 			$output .= 'define(\'DB_USERNAME\', \'' . addslashes($this->request->post['db_username']) . '\');' . "\n";
 			$output .= 'define(\'DB_PASSWORD\', \'' . addslashes(html_entity_decode($this->request->post['db_password'], ENT_QUOTES, 'UTF-8')) . '\');' . "\n";
-			
+
 			if ((isset($this->request->post['db_ssl_key']) && $this->request->post['db_ssl_key'] !== '')) {
 				$output .= 'define(\'DB_SSL_KEY\', \'' . addslashes($this->request->post['db_ssl_key']) . '\');' . "\n";
 			} else {
 				$output .= 'define(\'DB_SSL_KEY\', \'\');' . "\n";
 			}
-			
+
 			if ((isset($this->request->post['db_ssl_cert']) && $this->request->post['db_ssl_cert'] !== '')) {
 				$output .= 'define(\'DB_SSL_CERT\', \'' . addslashes($this->request->post['db_ssl_cert']) . '\');' . "\n";
 			} else {
 				$output .= 'define(\'DB_SSL_CERT\', \'\');' . "\n";
 			}
-			
+
 			if ((isset($this->request->post['db_ssl_ca']) && $this->request->post['db_ssl_ca'] !== '')) {
 				$output .= 'define(\'DB_SSL_CA\', \'' . addslashes($this->request->post['db_ssl_ca']) . '\');' . "\n";
 			} else {
 				$output .= 'define(\'DB_SSL_CA\', \'\');' . "\n";
 			}
-			
+
 			$output .= 'define(\'DB_DATABASE\', \'' . addslashes($this->request->post['db_database']) . '\');' . "\n";
 			$output .= 'define(\'DB_PORT\', \'' . addslashes($this->request->post['db_port']) . '\');' . "\n";
 			$output .= 'define(\'DB_PREFIX\', \'' . addslashes($this->request->post['db_prefix']) . '\');' . "\n\n";
-			
+
 			$output .= '// OpenCart API' . "\n";
 			$output .= 'define(\'OPENCART_SERVER\', \'https://www.opencart.com/\');' . "\n";
 
@@ -150,7 +150,7 @@ class Step3 extends \Opencart\System\Engine\Controller {
 		$this->document->setTitle($this->language->get('heading_title'));
 
 		$data['heading_title'] = $this->language->get('heading_title');
-		
+
 		$data['text_step_3'] = $this->language->get('text_step_3');
 		$data['text_db_connection'] = $this->language->get('text_db_connection');
 		$data['text_db_administration'] = $this->language->get('text_db_administration');
@@ -210,13 +210,13 @@ class Step3 extends \Opencart\System\Engine\Controller {
 		} else {
 			$data['error_db_database'] = '';
 		}
-		
+
 		if (isset($this->error['db_port'])) {
 			$data['error_db_port'] = $this->error['db_port'];
 		} else {
 			$data['error_db_port'] = '';
 		}
-		
+
 		if (isset($this->error['db_prefix'])) {
 			$data['error_db_prefix'] = $this->error['db_prefix'];
 		} else {
@@ -288,7 +288,7 @@ class Step3 extends \Opencart\System\Engine\Controller {
 		} else {
 			$data['db_ssl_key'] = '';
 		}
-		
+
 		if (isset($this->request->post['db_ssl_cert'])) {
 			$data['db_ssl_cert'] = $this->request->post['db_ssl_cert'];
 		} else {
@@ -306,13 +306,13 @@ class Step3 extends \Opencart\System\Engine\Controller {
 		} else {
 			$data['db_database'] = '';
 		}
-		
+
 		if (isset($this->request->post['db_port'])) {
 			$data['db_port'] = $this->request->post['db_port'];
 		} else {
 			$data['db_port'] = 3306;
 		}
-		
+
 		if (isset($this->request->post['db_prefix'])) {
 			$data['db_prefix'] = $this->request->post['db_prefix'];
 		} else {

--- a/upload/install/controller/startup/database.php
+++ b/upload/install/controller/startup/database.php
@@ -45,7 +45,7 @@ class Database extends \Opencart\System\Engine\Controller {
 			} else {
 				$port = ini_get('mysqli.default_port');
 			}
-			
+
 			$this->registry->set('db', new \Opencart\System\Library\DB(DB_DRIVER, DB_HOSTNAME, DB_USERNAME, DB_PASSWORD, DB_DATABASE, $port, $db_ssl_key, $db_ssl_cert, $db_ssl_ca));
 		}
 	}

--- a/upload/install/controller/upgrade/upgrade_5.php
+++ b/upload/install/controller/upgrade/upgrade_5.php
@@ -255,7 +255,7 @@ class Upgrade5 extends \Opencart\System\Engine\Controller {
 
 			// Event - Remove admin promotion from OC 3.x, since it is no longer required to have in OC v4.x releases.
 			$this->db->query("DELETE FROM `" . DB_PREFIX . "event` WHERE `action` = 'extension/extension/promotion.getList'");
-			
+
 			// Rename subscription to mail_subscription
             $this->db->query("UPDATE `" . DB_PREFIX . "event` SET `code` = 'mail_subscription' WHERE `code` = 'subscription'");
 		} catch (\ErrorException $exception) {

--- a/upload/install/controller/upgrade/upgrade_8.php
+++ b/upload/install/controller/upgrade/upgrade_8.php
@@ -119,7 +119,7 @@ class Upgrade8 extends \Opencart\System\Engine\Controller {
 			if ($query->num_rows) {
 				$this->db->query("UPDATE `" . DB_PREFIX . "api` SET `name` = `username` WHERE `username` IS NULL or `username` = ''");
 			}
-			
+
 			// Cart - Subscriptions
 			$query = $this->db->query("SELECT * FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = '" . DB_DATABASE . "' AND TABLE_NAME = '" . DB_PREFIX . "cart' AND COLUMN_NAME = 'subscription_plan_id'");
 
@@ -129,7 +129,7 @@ class Upgrade8 extends \Opencart\System\Engine\Controller {
 				$this->db->query("ALTER TABLE `" . DB_PREFIX . "cart` DROP COLUMN `recurring_id`");
 				$this->db->query("ALTER TABLE `" . DB_PREFIX . "cart` ADD COLUMN `subscription_plan_id` int(11) NOT NULL AFTER `product_id`");
 			}
-			
+
 			// Addresses
             $query = $this->db->query("SELECT * FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = '" . DB_DATABASE . "' AND TABLE_NAME = '" . DB_PREFIX . "address' AND COLUMN_NAME = 'default'");
 

--- a/upload/install/model/install/install.php
+++ b/upload/install/model/install/install.php
@@ -111,7 +111,7 @@ class Install extends \Opencart\System\Engine\Model {
 		}
 
 		$db->query("SET CHARACTER SET utf8mb4");
-		
+
 		$db->query("SET @@session.sql_mode = ''");
 
 		$db->query("DELETE FROM `" . $data['db_prefix'] . "user` WHERE `user_id` = '1'");


### PR DESCRIPTION
This was done using php-cs-fixer's no_whitespace_in_blank_line rule. Once all outstanding PR regarding code formatting have been merged future changes can be checked for issues in GitHub action and developers can run the tool locally to fix any formatting issues with there code.