### PR TITLE
Remove trailing whitespace from empty lines in catalog

### DIFF
--- a/upload/catalog/controller/account/download.php
+++ b/upload/catalog/controller/account/download.php
@@ -94,7 +94,7 @@ class Download extends \Opencart\System\Engine\Controller {
 		]);
 
 		$data['results'] = sprintf($this->language->get('text_pagination'), ($download_total) ? (($page - 1) * $limit) + 1 : 0, ((($page - 1) * $limit) > ($download_total - $limit)) ? $download_total : ((($page - 1) * $limit) + $limit), $download_total, ceil($download_total / $limit));
-		
+
 		$data['continue'] = $this->url->link('account/account', 'language=' . $this->config->get('config_language') . '&customer_token=' . $this->session->data['customer_token']);
 
 		$data['column_left'] = $this->load->controller('common/column_left');

--- a/upload/catalog/controller/account/login.php
+++ b/upload/catalog/controller/account/login.php
@@ -247,12 +247,12 @@ class Login extends \Opencart\System\Engine\Controller {
 				'telephone'         => $customer_info['telephone'],
 				'custom_field'      => $customer_info['custom_field']
 			];
-			
+
 			// Default Addresses
 			$this->load->model('account/address');
-			
+
 			$address_info = $this->model_account_address->getAddress($this->customer->getId(), $this->customer->getAddressId());
-			
+
 			if ($address_info) {
 				$this->session->data['shipping_address'] = $address_info;
 			}

--- a/upload/catalog/controller/account/order.php
+++ b/upload/catalog/controller/account/order.php
@@ -25,13 +25,13 @@ class Order extends \Opencart\System\Engine\Controller {
 		}
 
 		$this->document->setTitle($this->language->get('heading_title'));
-		
+
 		$url = '';
 
 		if (isset($this->request->get['page'])) {
 			$url .= '&page=' . $this->request->get['page'];
 		}
-		
+
 		$data['breadcrumbs'] = [];
 
 		$data['breadcrumbs'][] = [
@@ -43,7 +43,7 @@ class Order extends \Opencart\System\Engine\Controller {
 			'text' => $this->language->get('text_account'),
 			'href' => $this->url->link('account/account', 'language=' . $this->config->get('config_language') . '&customer_token=' . $this->session->data['customer_token'])
 		];
-		
+
 		$data['breadcrumbs'][] = [
 			'text' => $this->language->get('heading_title'),
 			'href' => $this->url->link('account/order', 'language=' . $this->config->get('config_language') . '&customer_token=' . $this->session->data['customer_token'] . $url)

--- a/upload/catalog/controller/event/activity.php
+++ b/upload/catalog/controller/event/activity.php
@@ -26,7 +26,7 @@ class Activity extends \Opencart\System\Engine\Controller {
 			$this->model_account_activity->addActivity('register', $activity_data);
 		}
 	}
-	
+
 	// catalog/model/account/customer/editCustomer/after
 
 	/**
@@ -48,7 +48,7 @@ class Activity extends \Opencart\System\Engine\Controller {
 			$this->model_account_activity->addActivity('edit', $activity_data);
 		}
 	}
-	
+
 	// catalog/model/account/customer/editPassword/after
 
 	/**
@@ -61,29 +61,29 @@ class Activity extends \Opencart\System\Engine\Controller {
 	public function editPassword(string &$route, array &$args, &$output): void {
 		if ($this->config->get('config_customer_activity')) {
 			$this->load->model('account/activity');
-			
+
 			if ($this->customer->isLogged()) {
 				$activity_data = [
 					'customer_id' => $this->customer->getId(),
 					'name'        => $this->customer->getFirstName() . ' ' . $this->customer->getLastName()
 				];
-	
+
 				$this->model_account_activity->addActivity('password', $activity_data);
 			} else {
 				$customer_info = $this->model_account_customer->getCustomerByEmail($args[0]);
-		
+
 				if ($customer_info) {
 					$activity_data = [
 						'customer_id' => $customer_info['customer_id'],
 						'name'        => $customer_info['firstname'] . ' ' . $customer_info['lastname']
 					];
-	
+
 					$this->model_account_activity->addActivity('reset', $activity_data);
 				}
 			}	
 		}
 	}
-	
+
 	// catalog/model/account/customer/deleteLoginAttempts/after
 
 	/**
@@ -99,17 +99,17 @@ class Activity extends \Opencart\System\Engine\Controller {
 
 			if ($customer_info) {
 				$this->load->model('account/activity');
-	
+
 				$activity_data = [
 					'customer_id' => $customer_info['customer_id'],
 					'name'        => $customer_info['firstname'] . ' ' . $customer_info['lastname']
 				];
-	
+
 				$this->model_account_activity->addActivity('login', $activity_data);
 			}
 		}	
 	}
-	
+
 	// catalog/model/account/customer/editCode/after
 
 	/**
@@ -122,7 +122,7 @@ class Activity extends \Opencart\System\Engine\Controller {
 	public function forgotten(string &$route, array &$args, &$output): void {
 		if (isset($this->request->get['route']) && $this->request->get['route'] == 'account/forgotten' && $this->config->get('config_customer_activity')) {
 			$this->load->model('account/customer');
-			
+
 			$customer_info = $this->model_account_customer->getCustomerByEmail($args[0]);
 
 			if ($customer_info) {
@@ -137,7 +137,7 @@ class Activity extends \Opencart\System\Engine\Controller {
 			}
 		}	
 	}
-	
+
 	// catalog/model/account/customer/addTransaction/after
 
 	/**
@@ -150,18 +150,18 @@ class Activity extends \Opencart\System\Engine\Controller {
 	public function addTransaction(string &$route, array &$args, &$output): void {
 		if ($this->config->get('config_customer_activity')) {
 			$this->load->model('account/customer');
-			
+
 			$customer_info = $this->model_account_customer->getCustomer($args[0]);
 
 			if ($customer_info) {
 				$this->load->model('account/activity');
-	
+
 				$activity_data = [
 					'customer_id' => $customer_info['customer_id'],
 					'name'        => $customer_info['firstname'] . ' ' . $customer_info['lastname'],
 					'order_id'    => $args[3]
 				];
-	
+
 				$this->model_account_activity->addActivity('transaction', $activity_data);
 			}
 		}
@@ -210,7 +210,7 @@ class Activity extends \Opencart\System\Engine\Controller {
 			$this->model_account_activity->addActivity('affiliate_edit', $activity_data);
 		}
 	}
-	
+
 	// catalog/model/account/address/addAddress/after
 
 	/**
@@ -232,7 +232,7 @@ class Activity extends \Opencart\System\Engine\Controller {
 			$this->model_account_activity->addActivity('address_add', $activity_data);
 		}	
 	}
-	
+
 	// catalog/model/account/address/editAddress/after
 
 	/**
@@ -254,7 +254,7 @@ class Activity extends \Opencart\System\Engine\Controller {
 			$this->model_account_activity->addActivity('address_edit', $activity_data);
 		}	
 	}
-	
+
 	// catalog/model/account/address/deleteAddress/after
 
 	/**
@@ -272,11 +272,11 @@ class Activity extends \Opencart\System\Engine\Controller {
 				'customer_id' => $this->customer->getId(),
 				'name'        => $this->customer->getFirstName() . ' ' . $this->customer->getLastName()
 			];
-			
+
 			$this->model_account_activity->addActivity('address_delete', $activity_data);
 		}
 	}
-	
+
 	// catalog/model/account/returns/addReturn/after
 
 	/**
@@ -321,26 +321,26 @@ class Activity extends \Opencart\System\Engine\Controller {
 		if ($this->config->get('config_customer_activity')) {
 			// If the last order status id returns 0, and the new order status is not, then we record it as new order
 			$this->load->model('checkout/order');
-			
+
 			$order_info = $this->model_checkout_order->getOrder($args[0]);
 
 			if ($order_info && !$order_info['order_status_id'] && $args[1]) {
 				$this->load->model('account/activity');
-	
+
 				if ($order_info['customer_id']) {
 					$activity_data = [
 						'customer_id' => $order_info['customer_id'],
 						'name'        => $order_info['firstname'] . ' ' . $order_info['lastname'],
 						'order_id'    => $args[0]
 					];
-	
+
 					$this->model_account_activity->addActivity('order_account', $activity_data);
 				} else {
 					$activity_data = [
 						'name'     => $order_info['firstname'] . ' ' . $order_info['lastname'],
 						'order_id' => $args[0]
 					];
-	
+
 					$this->model_account_activity->addActivity('order_guest', $activity_data);
 				}
 			}

--- a/upload/catalog/controller/event/statistics.php
+++ b/upload/catalog/controller/event/statistics.php
@@ -19,7 +19,7 @@ class Statistics extends \Opencart\System\Engine\Controller {
 
 		$this->model_report_statistics->addValue('review', 1);	
 	}
-		
+
 	// catalog/model/account/returns/addReturn/after
 
 	/**
@@ -34,7 +34,7 @@ class Statistics extends \Opencart\System\Engine\Controller {
 
 		$this->model_report_statistics->addValue('returns', 1);
 	}
-	
+
 	// catalog/model/checkout/order/addHistory/before
 
 	/**
@@ -45,7 +45,7 @@ class Statistics extends \Opencart\System\Engine\Controller {
 	 */
 	public function addHistory(string &$route, array &$args): void {
 		$this->load->model('checkout/order');
-				
+
 		$order_info = $this->model_checkout_order->getOrder($args[0]);
 
 		if ($order_info) {
@@ -63,7 +63,7 @@ class Statistics extends \Opencart\System\Engine\Controller {
 			if (in_array($new_status_id, $active_status) && !in_array($old_status_id, $active_status)) {
 				$this->model_report_statistics->addValue('order_sale', $order_info['total']);
 			}
-			
+
 			// If order status not in complete or processing remove value to sale total
 			if (!in_array($new_status_id, $active_status) && in_array($old_status_id, $active_status)) {
 				$this->model_report_statistics->removeValue('order_sale', $order_info['total']);

--- a/upload/catalog/controller/startup/error.php
+++ b/upload/catalog/controller/startup/error.php
@@ -53,7 +53,7 @@ class Error extends \Opencart\System\Engine\Controller {
 			header('Location: ' . $this->config->get('error_page'));
 			exit();
 		}
-	
+
 		return true;
 	}
 

--- a/upload/catalog/controller/startup/event.php
+++ b/upload/catalog/controller/startup/event.php
@@ -12,9 +12,9 @@ class Event extends \Opencart\System\Engine\Controller {
 	public function index(): void {
 		// Add events from the DB
 		$this->load->model('setting/event');
-		
+
 		$results = $this->model_setting_event->getEvents();
-		
+
 		foreach ($results as $result) {
 			$part = explode('/', $result['trigger']);
 

--- a/upload/catalog/controller/startup/language.php
+++ b/upload/catalog/controller/startup/language.php
@@ -40,7 +40,7 @@ class Language extends \Opencart\System\Engine\Controller {
 			$this->load->language('default');
 		}
 	}
-	
+
 	// Override the language default values
 
 	/**

--- a/upload/catalog/model/design/layout.php
+++ b/upload/catalog/model/design/layout.php
@@ -29,7 +29,7 @@ class Layout extends \Opencart\System\Engine\Model {
 	 */
 	public function getModules(int $layout_id, string $position): array {
 		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "layout_module` WHERE `layout_id` = '" . (int)$layout_id . "' AND `position` = '" . $this->db->escape($position) . "' ORDER BY `sort_order`");
-		
+
 		return $query->rows;
 	}
 }

--- a/upload/catalog/model/localisation/order_status.php
+++ b/upload/catalog/model/localisation/order_status.php
@@ -34,7 +34,7 @@ class OrderStatus extends \Opencart\System\Engine\Model {
 
 			$this->cache->set('order_status.' . $key, $order_status_data);
 		}
-		
+
 		return $order_status_data;
 	}
 }

--- a/upload/catalog/model/setting/module.php
+++ b/upload/catalog/model/setting/module.php
@@ -13,7 +13,7 @@ class Module extends \Opencart\System\Engine\Model {
 	 */
 	public function getModule(int $module_id): array {
 		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "module` WHERE `module_id` = '" . (int)$module_id . "'");
-		
+
 		if ($query->row) {
 			return json_decode($query->row['setting'], true);
 		} else {

--- a/upload/catalog/model/tool/image.php
+++ b/upload/catalog/model/tool/image.php
@@ -27,11 +27,11 @@ class Image extends \Opencart\System\Engine\Model {
 
 		if (!is_file(DIR_IMAGE . $image_new) || (filemtime(DIR_IMAGE . $image_old) > filemtime(DIR_IMAGE . $image_new))) {
 			[$width_orig, $height_orig, $image_type] = getimagesize(DIR_IMAGE . $image_old);
-				 
+
 			if (!in_array($image_type, [IMAGETYPE_PNG, IMAGETYPE_JPEG, IMAGETYPE_GIF, IMAGETYPE_WEBP])) {
 				return $this->config->get('config_url') . 'image/' . $image_old;
 			}
-						
+
 			$path = '';
 
 			$directories = explode('/', dirname($image_new));
@@ -56,9 +56,9 @@ class Image extends \Opencart\System\Engine\Model {
 				copy(DIR_IMAGE . $image_old, DIR_IMAGE . $image_new);
 			}
 		}
-		
+
 		$image_new = str_replace(' ', '%20', $image_new);  // fix bug when attach image on email (gmail.com). it is automatically changing space from " " to +
-		
+
 		return $this->config->get('config_url') . 'image/' . $image_new;
 	}
 }


### PR DESCRIPTION
This was done using php-cs-fixer's no_whitespace_in_blank_line rule. Once all outstanding PR regarding code formatting have been merged future changes can be checked for issues in GitHub action and developers can run the tool locally to fix any formatting issues with there code.