### PR TITLE
Apply missing void return

### DIFF
--- a/upload/admin/controller/event/modification.php
+++ b/upload/admin/controller/event/modification.php
@@ -14,7 +14,7 @@ class Modification extends \Opencart\System\Engine\Controller {
 	 *
 	 * @return void
 	 */
-	public function controller(string &$route, array &$args) {
+	public function controller(string &$route, array &$args): void {
 		if (substr($route, 0, 16) !== 'extension/ocmod/' && is_file(DIR_EXTENSION . 'ocmod/admin/controller/' . $route . '.php')) {
 			$route = 'extension/ocmod/' . $route;
 		}


### PR DESCRIPTION
This was done using php-cs-fixer's void_return rule. Once all outstanding PR regarding code formatting have been merged future changes can be checked for issues in GitHub action and developers can run the tool locally to fix any formatting issues with there code.