### PR TITLE
[Master] Update language.php

### DIFF
--- a/upload/admin/controller/startup/language.php
+++ b/upload/admin/controller/startup/language.php
@@ -25,20 +25,22 @@ class Language extends \Opencart\System\Engine\Controller {
 
 		self::$languages = $this->model_localisation_language->getLanguages();
 
-		if (isset(self::$languages[$code])) {
-			$language_info = self::$languages[$code];
-
-			// Language
-			if ($language_info['extension']) {
-				$this->language->addPath('extension/' . $language_info['extension'], DIR_EXTENSION . $language_info['extension'] . '/admin/language/');
-			}
-
-			// Set the config language_id key
-			$this->config->set('config_language_id', $language_info['language_id']);
-			$this->config->set('config_language_admin', $language_info['code']);
-
-			$this->load->language('default');
+		if (!isset(self::$languages[$code])) {
+			$code = array_key_first(self::$languages);
 		}
+			
+		$language_info = self::$languages[$code];
+
+		// Language
+		if ($language_info['extension']) {
+			$this->language->addPath('extension/' . $language_info['extension'], DIR_EXTENSION . $language_info['extension'] . '/admin/language/');
+		}
+
+		// Set the config language_id key
+		$this->config->set('config_language_id', $language_info['language_id']);
+		$this->config->set('config_language_admin', $language_info['code']);
+
+		$this->load->language('default');
 	}
 
 	// Fill the language up with default values


### PR DESCRIPTION
The problem: when a cookie is already set (e.g. de-de from another installation on the same server) and the new installation is made fresh with English only, **each admin database call for entries (e.g. stock status, order status, returns, etc.) is NOT successful!** 
Because de-de could not be found - it is still not installed (only en-gb)!

Therefore the language_id in config_language_id is always 0. 
Therefore the db result is always an empty array!

This commit solves this problem, or define the path for all cookies as it is done already for the OCSESSID.
And it will solve what is described here (empty lists without clearing cookies after installation): https://github.com/opencart/opencart/issues/12290