### PR TITLE
Use cannonical ordering of PHPDoc

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -122,6 +122,7 @@ return $config
         'phpdoc_no_access' => true,
         'phpdoc_no_alias_tag' => true,
         'phpdoc_no_useless_inheritdoc' => true,
+        'phpdoc_order' => true,
         'phpdoc_order_by_value' => true,
         'phpdoc_param_order' => true,
         'phpdoc_return_self_reference' => true,

--- a/upload/admin/controller/mail/affiliate.php
+++ b/upload/admin/controller/mail/affiliate.php
@@ -13,9 +13,9 @@ class Affiliate extends \Opencart\System\Engine\Controller {
 	 * @param array  $args
 	 * @param mixed  $output
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function approve(string &$route, array &$args, &$output): void {
 		if (isset($args[0])) {
@@ -99,9 +99,9 @@ class Affiliate extends \Opencart\System\Engine\Controller {
 	 * @param array  $args
 	 * @param mixed  $output
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function deny(string &$route, array &$args, &$output): void {
 		if (isset($args[0])) {

--- a/upload/admin/controller/mail/authorize.php
+++ b/upload/admin/controller/mail/authorize.php
@@ -14,9 +14,9 @@ class Authorize extends \Opencart\System\Engine\Controller {
 	 * @param $args
 	 * @param $output
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function index(&$route, &$args, &$output): void {
 		if (isset($this->request->get['route'])) {
@@ -71,9 +71,9 @@ class Authorize extends \Opencart\System\Engine\Controller {
 	 * @param $args
 	 * @param $output
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function reset(&$route, &$args, &$output): void {
 		if (isset($this->request->get['route'])) {

--- a/upload/admin/controller/mail/customer.php
+++ b/upload/admin/controller/mail/customer.php
@@ -13,9 +13,9 @@ class Customer extends \Opencart\System\Engine\Controller {
 	 * @param array  $args
 	 * @param mixed  $output
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function approve(string &$route, array &$args, &$output): void {
 		if (isset($args[0])) {
@@ -111,9 +111,9 @@ class Customer extends \Opencart\System\Engine\Controller {
 	 * @param array  $args
 	 * @param mixed  $output
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function deny(string &$route, array &$args, &$output): void {
 		if (isset($args[0])) {

--- a/upload/admin/controller/mail/forgotten.php
+++ b/upload/admin/controller/mail/forgotten.php
@@ -15,9 +15,9 @@ class Forgotten extends \Opencart\System\Engine\Controller {
 	 * @param array  $args
 	 * @param mixed  $output
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function index(string &$route, array &$args, &$output): void {
 		if (isset($this->request->get['route'])) {

--- a/upload/admin/controller/mail/gdpr.php
+++ b/upload/admin/controller/mail/gdpr.php
@@ -51,9 +51,9 @@ class Gdpr extends \Opencart\System\Engine\Controller {
 	 *
 	 * @param array $gdpr_info
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function export(array $gdpr_info): void {
 		$this->load->model('setting/store');
@@ -230,9 +230,9 @@ class Gdpr extends \Opencart\System\Engine\Controller {
 	 *
 	 * @param array $gdpr_info
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function approve(array $gdpr_info): void {
 		$this->load->model('setting/store');
@@ -324,9 +324,9 @@ class Gdpr extends \Opencart\System\Engine\Controller {
 	 *
 	 * @param array $gdpr_info
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function deny(array $gdpr_info): void {
 		$this->load->model('setting/store');
@@ -418,9 +418,9 @@ class Gdpr extends \Opencart\System\Engine\Controller {
 	 *
 	 * @param array $gdpr_info
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function remove(array $gdpr_info): void {
 		$this->load->model('setting/store');

--- a/upload/admin/controller/mail/returns.php
+++ b/upload/admin/controller/mail/returns.php
@@ -13,9 +13,9 @@ class Returns extends \Opencart\System\Engine\Controller {
 	 * @param array  $args
 	 * @param mixed  $output
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function index(string &$route, array &$args, &$output): void {
 		if (isset($args[0])) {

--- a/upload/admin/controller/mail/reward.php
+++ b/upload/admin/controller/mail/reward.php
@@ -13,9 +13,9 @@ class Reward extends \Opencart\System\Engine\Controller {
 	 * @param array  $args
 	 * @param mixed  $output
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function index(string $route, array $args, $output): void {
 		if (isset($args[0])) {

--- a/upload/admin/controller/mail/subscription.php
+++ b/upload/admin/controller/mail/subscription.php
@@ -14,9 +14,9 @@ class Subscription extends \Opencart\System\Engine\Controller {
 	 * @param array  $args
 	 * @param mixed  $output
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function history(string &$route, array &$args, &$output): void {
 		if (isset($args[0])) {
@@ -169,9 +169,9 @@ class Subscription extends \Opencart\System\Engine\Controller {
 	 * @param array  $args
 	 * @param mixed  $output
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function transaction(string &$route, array &$args, &$output): void {
 		if (isset($args[0])) {

--- a/upload/admin/controller/mail/transaction.php
+++ b/upload/admin/controller/mail/transaction.php
@@ -13,9 +13,9 @@ class Transaction extends \Opencart\System\Engine\Controller {
 	 * @param array  $args
 	 * @param mixed  $output
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function index(string &$route, array &$args, &$output): void {
 		if (isset($args[0])) {

--- a/upload/admin/controller/mail/voucher.php
+++ b/upload/admin/controller/mail/voucher.php
@@ -11,9 +11,9 @@ class Voucher extends \Opencart\System\Engine\Controller {
 	 *
 	 * @param int $voucher_id
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function index(int $voucher_id): void {
 		$this->load->model('sale/order');

--- a/upload/admin/controller/marketing/contact.php
+++ b/upload/admin/controller/marketing/contact.php
@@ -51,9 +51,9 @@ class Contact extends \Opencart\System\Engine\Controller {
 	/**
 	 * Send
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function send(): void {
 		$this->load->language('marketing/contact');

--- a/upload/admin/controller/marketplace/modification.php
+++ b/upload/admin/controller/marketplace/modification.php
@@ -184,9 +184,9 @@ class Modification extends \Opencart\System\Engine\Controller {
 	/**
 	 * Refresh
 	 *
-	 * @return void
-	 *
 	 * @throws Exception
+	 *
+	 * @return void
 	 */
 	public function refresh(): void {
 		$this->load->language('marketplace/modification');

--- a/upload/admin/controller/sale/order.php
+++ b/upload/admin/controller/sale/order.php
@@ -475,9 +475,9 @@ class Order extends \Opencart\System\Engine\Controller {
 	/**
 	 * Info
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function info(): void {
 		$this->load->language('sale/order');

--- a/upload/admin/controller/startup/sass.php
+++ b/upload/admin/controller/startup/sass.php
@@ -9,9 +9,9 @@ class Sass extends \Opencart\System\Engine\Controller {
 	/**
 	 * Index
 	 *
-	 * @return void
-	 *
 	 * @throws \ScssPhp\ScssPhp\Exception\SassException
+	 *
+	 * @return void
 	 */
 	public function index(): void {
 		$files = glob(DIR_APPLICATION . 'view/stylesheet/*.scss');

--- a/upload/admin/controller/startup/session.php
+++ b/upload/admin/controller/startup/session.php
@@ -9,9 +9,9 @@ class Session extends \Opencart\System\Engine\Controller {
 	/**
 	 * Index
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function index(): void {
 		$session = new \Opencart\System\Library\Session($this->config->get('session_engine'), $this->registry);

--- a/upload/admin/model/setting/store.php
+++ b/upload/admin/model/setting/store.php
@@ -126,9 +126,9 @@ class Store extends \Opencart\System\Engine\Model {
 	 * @param string $language
 	 * @param string $session_id
 	 *
-	 * @return \Opencart\System\Engine\Registry
-	 *
 	 * @throws \Exception
+	 *
+	 * @return \Opencart\System\Engine\Registry
 	 */
 	public function createStoreInstance(int $store_id = 0, string $language = '', string $session_id = ''): object {
 		// Autoloader

--- a/upload/admin/model/tool/image.php
+++ b/upload/admin/model/tool/image.php
@@ -13,9 +13,9 @@ class Image extends \Opencart\System\Engine\Model {
 	 * @param int    $width
 	 * @param int    $height
 	 *
-	 * @return string
-	 *
 	 * @throws \Exception
+	 *
+	 * @return string
 	 */
 	public function resize(string $filename, int $width, int $height): string {
 		if (!is_file(DIR_IMAGE . $filename) || substr(str_replace('\\', '/', realpath(DIR_IMAGE . $filename)), 0, strlen(DIR_IMAGE)) != DIR_IMAGE) {

--- a/upload/catalog/controller/information/contact.php
+++ b/upload/catalog/controller/information/contact.php
@@ -98,9 +98,9 @@ class Contact extends \Opencart\System\Engine\Controller {
 	/**
 	 * Send
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function send(): void {
 		$this->load->language('information/contact');

--- a/upload/catalog/controller/mail/affiliate.php
+++ b/upload/catalog/controller/mail/affiliate.php
@@ -11,9 +11,9 @@ class Affiliate extends \Opencart\System\Engine\Controller {
 	 * @param array  $args
 	 * @param mixed  $output
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function index(string &$route, array &$args, &$output): void {
 		$this->load->language('mail/affiliate');
@@ -78,9 +78,9 @@ class Affiliate extends \Opencart\System\Engine\Controller {
 	 * @param array  $args
 	 * @param mixed  $output
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function alert(string &$route, array &$args, &$output): void {
 		// Send to main admin email if new affiliate email is enabled

--- a/upload/catalog/controller/mail/forgotten.php
+++ b/upload/catalog/controller/mail/forgotten.php
@@ -12,9 +12,9 @@ class Forgotten extends \Opencart\System\Engine\Controller {
 	 * @param array  $args
 	 * @param mixed  $output
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function index(string &$route, array &$args, &$output): void {
 		if ($args[0] && $args[1]) {

--- a/upload/catalog/controller/mail/gdpr.php
+++ b/upload/catalog/controller/mail/gdpr.php
@@ -12,9 +12,9 @@ class Gdpr extends \Opencart\System\Engine\Controller {
 	 * @param array  $args
 	 * @param mixed  $output
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function index(string &$route, array &$args, &$output): void {
 		// $args[0] $code
@@ -89,9 +89,9 @@ class Gdpr extends \Opencart\System\Engine\Controller {
 	 * @param array  $args
 	 * @param mixed  $output
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function remove(string &$route, array &$args, &$output): void {
 		if (isset($args[0])) {

--- a/upload/catalog/controller/mail/order.php
+++ b/upload/catalog/controller/mail/order.php
@@ -63,9 +63,9 @@ class Order extends \Opencart\System\Engine\Controller {
 	 * @param string $comment
 	 * @param bool   $notify
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function add(array $order_info, int $order_status_id, string $comment, bool $notify): void {
 		// Check for any downloadable products
@@ -379,9 +379,9 @@ class Order extends \Opencart\System\Engine\Controller {
 	 * @param string $comment
 	 * @param bool   $notify
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function history(array $order_info, int $order_status_id, string $comment, bool $notify): void {
 		$store_name = html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8');
@@ -480,9 +480,9 @@ class Order extends \Opencart\System\Engine\Controller {
 	 *
 	 * Event called catalog/model/checkout/order/addHistory/before
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function alert(string &$route, array &$args): void {
 		if (isset($args[0])) {

--- a/upload/catalog/controller/mail/register.php
+++ b/upload/catalog/controller/mail/register.php
@@ -12,9 +12,9 @@ class Register extends \Opencart\System\Engine\Controller {
 	 * @param array  $args
 	 * @param mixed  $output
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function index(string &$route, array &$args, &$output): void {
 		$this->load->language('mail/register');
@@ -75,9 +75,9 @@ class Register extends \Opencart\System\Engine\Controller {
 	 * @param array  $args
 	 * @param mixed  $output
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function alert(string &$route, array &$args, &$output): void {
 		// Send to main admin email if new account email is enabled

--- a/upload/catalog/controller/mail/review.php
+++ b/upload/catalog/controller/mail/review.php
@@ -12,9 +12,9 @@ class Review extends \Opencart\System\Engine\Controller {
 	 * @param array  $args
 	 * @param mixed  $output
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function index(string &$route, array &$args, &$output): void {
 		if (in_array('review', (array)$this->config->get('config_mail_alert'))) {

--- a/upload/catalog/controller/mail/subscription.php
+++ b/upload/catalog/controller/mail/subscription.php
@@ -384,9 +384,9 @@ class Subscription extends \Opencart\System\Engine\Controller {
 	 * @param string $route
 	 * @param array  $args
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function alert(string &$route, array &$args): void {
 		if (isset($args[0])) {

--- a/upload/catalog/controller/mail/transaction.php
+++ b/upload/catalog/controller/mail/transaction.php
@@ -12,9 +12,9 @@ class Transaction extends \Opencart\System\Engine\Controller {
 	 * @param array  $args
 	 * @param mixed  $output
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function index(string &$route, array &$args, &$output): void {
 		$this->load->language('mail/transaction');

--- a/upload/catalog/controller/mail/voucher.php
+++ b/upload/catalog/controller/mail/voucher.php
@@ -11,9 +11,9 @@ class Voucher extends \Opencart\System\Engine\Controller {
 	 * @param array  $args
 	 * @param mixed  $output
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function index(string &$route, array &$args, &$output): void {
 		$this->load->model('checkout/order');

--- a/upload/catalog/controller/startup/sass.php
+++ b/upload/catalog/controller/startup/sass.php
@@ -7,9 +7,9 @@ namespace Opencart\Catalog\Controller\Startup;
  */
 class Sass extends \Opencart\System\Engine\Controller {
 	/**
-	 * @return void
-	 *
 	 * @throws \ScssPhp\ScssPhp\Exception\SassException
+	 *
+	 * @return void
 	 */
 	public function index(): void {
 		$files = glob(DIR_APPLICATION . 'view/stylesheet/*.scss');

--- a/upload/catalog/controller/startup/session.php
+++ b/upload/catalog/controller/startup/session.php
@@ -7,9 +7,9 @@ namespace Opencart\Catalog\Controller\Startup;
  */
 class Session extends \Opencart\System\Engine\Controller {
 	/**
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function index(): void {
 		$session = new \Opencart\System\Library\Session($this->config->get('session_engine'), $this->registry);

--- a/upload/catalog/model/setting/store.php
+++ b/upload/catalog/model/setting/store.php
@@ -62,9 +62,9 @@ class Store extends \Opencart\System\Engine\Model {
 	 * @param string $language
 	 * @param string $session_id
 	 *
-	 * @return \Opencart\System\Engine\Registry
-	 *
 	 * @throws \Exception
+	 *
+	 * @return \Opencart\System\Engine\Registry
 	 */
 	public function createStoreInstance(int $store_id = 0, string $language = '', string $session_id = ''): object {
 		// Autoloader

--- a/upload/catalog/model/tool/image.php
+++ b/upload/catalog/model/tool/image.php
@@ -14,9 +14,9 @@ class Image extends \Opencart\System\Engine\Model {
 	 * @param int    $height
 	 * @param string $default
 	 *
-	 * @return string
-	 *
 	 * @throws \Exception
+	 *
+	 * @return string
 	 */
 	public function resize(string $filename, int $width, int $height, string $default = ''): string {
 		if (!is_file(DIR_IMAGE . $filename) || substr(str_replace('\\', '/', realpath(DIR_IMAGE . $filename)), 0, strlen(DIR_IMAGE)) != DIR_IMAGE) {

--- a/upload/install/cli_cloud.php
+++ b/upload/install/cli_cloud.php
@@ -58,9 +58,9 @@ set_error_handler(/**
  * @param       $line
  * @param array $errcontext
  *
- * @return false
- *
  * @throws \ErrorException
+ *
+ * @return false
  */ function($code, $message, $file, $line, array $errcontext): bool {
 	// error was suppressed with the @-operator
 	if (error_reporting() === 0) {

--- a/upload/install/controller/startup/database.php
+++ b/upload/install/controller/startup/database.php
@@ -7,9 +7,9 @@ namespace Opencart\Install\Controller\Startup;
  */
 class Database extends \Opencart\System\Engine\Controller {
 	/**
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function index(): void {
 		if (is_file(DIR_OPENCART . 'config.php') && filesize(DIR_OPENCART . 'config.php') > 0) {

--- a/upload/install/model/install/install.php
+++ b/upload/install/model/install/install.php
@@ -9,9 +9,9 @@ class Install extends \Opencart\System\Engine\Model {
 	/**
 	 * @param array $data
 	 *
-	 * @return void
-	 *
 	 * @throws \Exception
+	 *
+	 * @return void
 	 */
 	public function database(array $data): void {
 		$db = new \Opencart\System\Library\DB($data['db_driver'], html_entity_decode($data['db_hostname'], ENT_QUOTES, 'UTF-8'), html_entity_decode($data['db_username'], ENT_QUOTES, 'UTF-8'), html_entity_decode($data['db_password'], ENT_QUOTES, 'UTF-8'), html_entity_decode($data['db_database'], ENT_QUOTES, 'UTF-8'), $data['db_port'], $this->request->post['db_ssl_key'], $this->request->post['db_ssl_cert'], $this->request->post['db_ssl_ca']);


### PR DESCRIPTION
This rule makes sure that PHPDoc is always written in the same order.

The only case where the project does not already follow this is a few cases of `@throws`.