### PR TITLE
Broken URL in code comments

### DIFF
--- a/upload/catalog/controller/product/category.php
+++ b/upload/catalog/controller/product/category.php
@@ -408,7 +408,7 @@ class Category extends \Opencart\System\Engine\Controller {
 
 			$data['results'] = sprintf($this->language->get('text_pagination'), ($product_total) ? (($page - 1) * $limit) + 1 : 0, ((($page - 1) * $limit) > ($product_total - $limit)) ? $product_total : ((($page - 1) * $limit) + $limit), $product_total, ceil($product_total / $limit));
 
-			// http://googlewebmastercentral.blogspot.com/2011/09/pagination-with-relnext-and-relprev.html
+			// https://developers.google.com/search/blog/2011/09/pagination-with-relnext-and-relprev
 			if ($page == 1) {
 				$this->document->addLink($this->url->link('product/category', 'language=' . $this->config->get('config_language') . '&path=' . $this->request->get['path']), 'canonical');
 			} else {


### PR DESCRIPTION
Also in manufacturer.php, special.php, cms/blog.php 
But I think we should ditch the redundant code as Google [no longer uses](https://developers.google.com/search/docs/specialty/ecommerce/pagination-and-incremental-page-loading?hl=en&sjid=7744963422977639390-EU#:~:text=Google%20no%20longer%20uses%20these%20tags) the `rel="next"` and `rel="prev"` tags.