### PR TITLE
Simplify use of ternary statments

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -155,6 +155,7 @@ return $config
         'string_length_to_empty' => true,
         'string_line_ending' => true,
         'switch_continue_to_break' => true,
+        'ternary_to_elvis_operator' => true,
         'trim_array_spaces' => true,
         'type_declaration_spaces' => true,
         'types_spaces' => true,

--- a/upload/admin/controller/marketing/contact.php
+++ b/upload/admin/controller/marketing/contact.php
@@ -208,7 +208,7 @@ class Contact extends \Opencart\System\Engine\Controller {
 				$end = $start + $limit;
 
 				if ($end < $email_total) {
-					$json['text'] = sprintf($this->language->get('text_sent'), $start ? $start : 1, $email_total);
+					$json['text'] = sprintf($this->language->get('text_sent'), $start ?: 1, $email_total);
 
 					$json['next'] = $this->url->link('marketing/contact.send', 'user_token=' . $this->session->data['user_token'] . '&page=' . ($page + 1), true);
 				} else {

--- a/upload/admin/controller/startup/error.php
+++ b/upload/admin/controller/startup/error.php
@@ -10,7 +10,7 @@ class Error extends \Opencart\System\Engine\Controller {
 	 * @return void
 	 */
 	public function index(): void {
-		$this->registry->set('log', new \Opencart\System\Library\Log($this->config->get('config_error_filename') ? $this->config->get('config_error_filename') : $this->config->get('error_filename')));
+		$this->registry->set('log', new \Opencart\System\Library\Log($this->config->get('config_error_filename') ?: $this->config->get('error_filename')));
 
 		set_error_handler([$this, 'error']);
 		set_exception_handler([$this, 'exception']);

--- a/upload/admin/controller/tool/upload.php
+++ b/upload/admin/controller/tool/upload.php
@@ -299,7 +299,7 @@ class Upload extends \Opencart\System\Engine\Controller {
 				if (is_file($file)) {
 					header('Content-Type: application/octet-stream');
 					header('Content-Description: File Transfer');
-					header('Content-Disposition: attachment; filename="' . ($mask ? $mask : basename($file)) . '"');
+					header('Content-Disposition: attachment; filename="' . ($mask ?: basename($file)) . '"');
 					header('Content-Transfer-Encoding: binary');
 					header('Expires: 0');
 					header('Cache-Control: must-revalidate, post-check=0, pre-check=0');

--- a/upload/catalog/controller/account/download.php
+++ b/upload/catalog/controller/account/download.php
@@ -134,7 +134,7 @@ class Download extends \Opencart\System\Engine\Controller {
 			if (!headers_sent()) {
 				if (is_file($file)) {
 					header('Content-Type: application/octet-stream');
-					header('Content-Disposition: attachment; filename="' . ($mask ? $mask : basename($file)) . '"');
+					header('Content-Disposition: attachment; filename="' . ($mask ?: basename($file)) . '"');
 					header('Expires: 0');
 					header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
 					header('Pragma: public');

--- a/upload/catalog/model/catalog/product.php
+++ b/upload/catalog/model/catalog/product.php
@@ -37,7 +37,7 @@ class Product extends \Opencart\System\Engine\Model {
 
 			$product_data['variant'] = (array)json_decode($query->row['variant'], true);
 			$product_data['override'] = (array)json_decode($query->row['override'], true);
-			$product_data['price'] = (float)($query->row['discount'] ? $query->row['discount'] : $query->row['price']);
+			$product_data['price'] = (float)($query->row['discount'] ?: $query->row['price']);
 			$product_data['rating'] = (int)$query->row['rating'];
 			$product_data['reviews'] = (int)$query->row['reviews'] ? $query->row['reviews'] : 0;
 


### PR DESCRIPTION
When the first and secound part of a ternary are the same the secound can be omitted, this can help avoid mistakes where one is miss typed and also makes for less code to go over when reading it.