### PR TITLE
Provide modern analyzable interface for getting models

### DIFF
--- a/upload/admin/controller/catalog/attribute_group.php
+++ b/upload/admin/controller/catalog/attribute_group.php
@@ -114,9 +114,9 @@ class AttributeGroup extends \Opencart\System\Engine\Controller {
 			'limit' => $this->config->get('config_pagination_admin')
 		];
 
-		$this->load->model('catalog/attribute_group');
+		$model_catalog_attribute_group = $this->load->getModel(\Opencart\Admin\Model\Catalog\AttributeGroup::class);
 
-		$results = $this->model_catalog_attribute_group->getAttributeGroups($filter_data);
+		$results = $model_catalog_attribute_group->getAttributeGroups($filter_data);
 
 		foreach ($results as $result) {
 			$data['attribute_groups'][] = [
@@ -148,7 +148,7 @@ class AttributeGroup extends \Opencart\System\Engine\Controller {
 			$url .= '&order=' . $this->request->get['order'];
 		}
 
-		$attribute_group_total = $this->model_catalog_attribute_group->getTotalAttributeGroups();
+		$attribute_group_total = $model_catalog_attribute_group->getTotalAttributeGroups();
 
 		$data['pagination'] = $this->load->controller('common/pagination', [
 			'total' => $attribute_group_total,
@@ -207,9 +207,9 @@ class AttributeGroup extends \Opencart\System\Engine\Controller {
 		$data['back'] = $this->url->link('catalog/attribute_group', 'user_token=' . $this->session->data['user_token'] . $url);
 
 		if (isset($this->request->get['attribute_group_id'])) {
-			$this->load->model('catalog/attribute_group');
+			$model_catalog_attribute_group = $this->load->getModel(\Opencart\Admin\Model\Catalog\AttributeGroup::class);
 
-			$attribute_group_info = $this->model_catalog_attribute_group->getAttributeGroup($this->request->get['attribute_group_id']);
+			$attribute_group_info = $model_catalog_attribute_group->getAttributeGroup($this->request->get['attribute_group_id']);
 		}
 
 		if (isset($this->request->get['attribute_group_id'])) {
@@ -218,12 +218,12 @@ class AttributeGroup extends \Opencart\System\Engine\Controller {
 			$data['attribute_group_id'] = 0;
 		}
 
-		$this->load->model('localisation/language');
+		$model_localisation_language = $this->load->getModel(\Opencart\Admin\Model\Localisation\Language::class);
 
-		$data['languages'] = $this->model_localisation_language->getLanguages();
+		$data['languages'] = $model_localisation_language->getLanguages();
 
 		if (isset($this->request->get['attribute_group_id'])) {
-			$data['attribute_group_description'] = $this->model_catalog_attribute_group->getDescriptions($this->request->get['attribute_group_id']);
+			$data['attribute_group_description'] = $model_catalog_attribute_group->getDescriptions($this->request->get['attribute_group_id']);
 		} else {
 			$data['attribute_group_description'] = [];
 		}
@@ -268,12 +268,12 @@ class AttributeGroup extends \Opencart\System\Engine\Controller {
 		}
 
 		if (!$json) {
-			$this->load->model('catalog/attribute_group');
+			$model_catalog_attribute_group = $this->load->getModel(\Opencart\Admin\Model\Catalog\AttributeGroup::class);
 
 			if (!$this->request->post['attribute_group_id']) {
-				$json['attribute_group_id'] = $this->model_catalog_attribute_group->addAttributeGroup($this->request->post);
+				$json['attribute_group_id'] = $model_catalog_attribute_group->addAttributeGroup($this->request->post);
 			} else {
-				$this->model_catalog_attribute_group->editAttributeGroup($this->request->post['attribute_group_id'], $this->request->post);
+				$model_catalog_attribute_group->editAttributeGroup($this->request->post['attribute_group_id'], $this->request->post);
 			}
 
 			$json['success'] = $this->language->get('text_success');
@@ -303,10 +303,10 @@ class AttributeGroup extends \Opencart\System\Engine\Controller {
 			$json['error'] = $this->language->get('error_permission');
 		}
 
-		$this->load->model('catalog/attribute');
+		$model_catalog_attribute = $this->load->getModel(\Opencart\Admin\Model\Catalog\Attribute::class);
 
 		foreach ($selected as $attribute_group_id) {
-			$attribute_total = $this->model_catalog_attribute->getTotalAttributesByAttributeGroupId($attribute_group_id);
+			$attribute_total = $model_catalog_attribute->getTotalAttributesByAttributeGroupId($attribute_group_id);
 
 			if ($attribute_total) {
 				$json['error'] = sprintf($this->language->get('error_attribute'), $attribute_total);
@@ -314,10 +314,10 @@ class AttributeGroup extends \Opencart\System\Engine\Controller {
 		}
 
 		if (!$json) {
-			$this->load->model('catalog/attribute_group');
+			$model_catalog_attribute_group = $this->load->getModel(\Opencart\Admin\Model\Catalog\AttributeGroup::class);
 
 			foreach ($selected as $attribute_group_id) {
-				$this->model_catalog_attribute_group->deleteAttributeGroup($attribute_group_id);
+				$model_catalog_attribute_group->deleteAttributeGroup($attribute_group_id);
 			}
 
 			$json['success'] = $this->language->get('text_success');

--- a/upload/system/engine/loader.php
+++ b/upload/system/engine/loader.php
@@ -98,13 +98,32 @@ class Loader {
 	}
 
 	/**
+	 * Get Model
+	 *
+	 * @template TModel of \Opencart\System\Engine\Model
+	 *
+	 * @param class-string<TModel> $class
+	 *
+	 * @return \Opencart\System\Engine\Proxy<TModel>
+	 */
+	public function getModel(string $class): \Opencart\System\Engine\Proxy {
+		$parts = explode('\\', $class);
+		$last_two_parts = array_slice($parts, -2);
+		$converted = implode('/', $last_two_parts);
+		$route = preg_replace('/([a-z])([A-Z])/', '$1_$2', $converted);
+		$route = strtolower($route);
+
+		return $this->model($route);
+	}
+
+	/**
 	 * Model
 	 *
 	 * @param string $route
 	 *
-	 * @return void
+	 * @return \Opencart\System\Engine\Proxy
 	 */
-	public function model(string $route): void {
+	public function model(string $route): \Opencart\System\Engine\Proxy {
 		// Sanitize the call
 		$route = preg_replace('/[^a-zA-Z0-9_\/]/', '', $route);
 
@@ -165,10 +184,14 @@ class Loader {
 				}
 
 				$this->registry->set($key, $proxy);
+
+				return $proxy;
 			} else {
 				throw new \Exception('Error: Could not load model ' . $class . '!');
 			}
 		}
+
+		return $this->registry->get($key);
 	}
 
 	/**

--- a/upload/system/engine/proxy.php
+++ b/upload/system/engine/proxy.php
@@ -11,6 +11,10 @@
 namespace Opencart\System\Engine;
 /**
  * Class Proxy
+ *
+ * @template TWraps of \Opencart\System\Engine\Model
+ *
+ * @mixin TWraps
  */
 class Proxy {
 	/**


### PR DESCRIPTION
This pull request introduces a method for loading models that enhances analyzability using modern tools. This improvement provides developers with better feedback in their IDEs and facilitates the early detection of bugs during code analysis.

The enhancement involves documenting the `Proxy` object as a [generic](https://phpstan.org/blog/generics-in-php-using-phpdocs) and adding a method to the loader that takes the class name as input, allowing for predictions about the concrete implementation to be returned.

An example usage in `attribute_group.php` has been updated to showcase the new method. While the initial implementation may seem verbose:
```php
$model_catalog_attribute_group = $this->load->getModel(\Opencart\Admin\Model\Catalog\AttributeGroup::class);

$model_catalog_attribute_group->deleteAttributeGroup($attribute_group_id);
```

It can be simplified, especially with namespace imports:
```php
$this->load->getModel(AttributeGroup::class)->deleteAttributeGroup($attribute_group_id);
```

After this change, the IDE can suggest relevant functions for $model_catalog_attribute_group, and tests can assert that deleteAttributeGroup() exists and is given the correct arguments, preventing potential bugs.