### PR TITLE
Correct call to getHistory in order controller

### DIFF
--- a/upload/catalog/controller/account/order.php
+++ b/upload/catalog/controller/account/order.php
@@ -391,7 +391,7 @@ class Order extends \Opencart\System\Engine\Controller {
 			$data['comment'] = nl2br($order_info['comment']);
 
 			// History
-			$data['history'] = $this->getHistory($order_info['order_id']);
+			$data['history'] = $this->getHistory();
 
 			$data['continue'] = $this->url->link('account/order', 'language=' . $this->config->get('config_language') . '&customer_token=' . $this->session->data['customer_token']);
 


### PR DESCRIPTION
This function does not take any arguments, but both `info()` and `getHistory()` resolves the order id in the same way which is why this hasn't resulted in any errors so fare. Removing it to avoid confusion, the alternative is to change `getHistory()` to accept order id as an argument, but that would require some refactoring.

This issue has existed in various forms since https://github.com/opencart/opencart/commit/e75532d9f3b17647fbbbb6f918bc108e5900bff4