### PR TITLE
Fix removing gift vouchers from cart

### DIFF
--- a/upload/catalog/controller/checkout/voucher.php
+++ b/upload/catalog/controller/checkout/voucher.php
@@ -165,8 +165,8 @@ class Voucher extends \Opencart\System\Engine\Controller {
 
 		$json = [];
 
-		if (isset($this->request->get['key'])) {
-			$key = $this->request->get['key'];
+		if (isset($this->request->post['key'])) {
+			$key = $this->request->post['key'];
 		} else {
 			$key = '';
 		}

--- a/upload/catalog/controller/common/cart.php
+++ b/upload/catalog/controller/common/cart.php
@@ -173,12 +173,12 @@ class Cart extends \Opencart\System\Engine\Controller {
 	 * @return void
 	 */
 	public function removeVoucher(): void {
-		$this->load->language('checkout/cart');
+		$this->load->language('checkout/voucher');
 
 		$json = [];
 
-		if (isset($this->request->get['key'])) {
-			$key = $this->request->get['key'];
+		if (isset($this->request->post['key'])) {
+			$key = $this->request->post['key'];
 		} else {
 			$key = '';
 		}

--- a/upload/catalog/language/en-gb/checkout/voucher.php
+++ b/upload/catalog/language/en-gb/checkout/voucher.php
@@ -9,6 +9,7 @@ $_['text_description'] = 'This gift certificate will be emailed to the recipient
 $_['text_agree']       = 'I understand that gift certificates are non-refundable';
 $_['text_message']     = '<p>Thank you for purchasing a gift certificate! Once you have completed your order your gift certificate recipient will be sent an e-mail with details how to redeem their gift certificate.</p>';
 $_['text_for']         = '%s Gift Certificate for %s';
+$_['text_remove']      = 'Success: You have removed a gift voucher from your shopping cart!';
 
 // Entry
 $_['entry_to_name']    = 'Recipient\'s Name';

--- a/upload/catalog/model/checkout/cart.php
+++ b/upload/catalog/model/checkout/cart.php
@@ -101,8 +101,8 @@ class Cart extends \Opencart\System\Engine\Model {
 		$voucher_data = [];
 
 		if (!empty($this->session->data['vouchers'])) {
-			foreach ($this->session->data['vouchers'] as $voucher) {
-				$voucher_data[] = [
+			foreach ($this->session->data['vouchers'] as $key => $voucher) {
+				$voucher_data[$key] = [
 					'code'             => $voucher['code'],
 					'description'      => $voucher['description'],
 					'from_name'        => $voucher['from_name'],


### PR DESCRIPTION
In 4.0.2.3, you're unable to remove gift vouchers from the shopping cart.
This PR implements the changes proposed in #13090 to fix this.

![image](https://github.com/opencart/opencart/assets/7365747/a85239a0-64c4-4711-8609-8e6a8fbdbd13)