### PR TITLE
Remove redundant code

### DIFF
--- a/upload/admin/controller/marketplace/modification.php
+++ b/upload/admin/controller/marketplace/modification.php
@@ -282,13 +282,8 @@ class Modification extends \Opencart\System\Engine\Controller {
 				// Log
 				$log[] = 'MOD: ' . $dom->getElementsByTagName('name')->item(0)->textContent;
 
-				// Wipe the past modification store in the backup array
-				$recovery = [];
-
 				// Store a backup recovery of the modification code in case we need to use it if an abort attribute is used.
-				if (isset($modification)) {
-					$recovery = $modification;
-				}
+				$recovery = $modification;
 
 				$files = $dom->getElementsByTagName('modification')->item(0)->getElementsByTagName('file');
 


### PR DESCRIPTION
Since $modification is initialized as an array it is always defined and never null, as such the code can be simplified to a single copy assignment, unless something else was intended? 

This looks to have been introduced when the class was originally created in dcc597d1c61652dcdf47eac3de4e2dbf1900bd7d