### PR TITLE
Fix type error when getting unitialized image

### DIFF
--- a/upload/system/library/image.php
+++ b/upload/system/library/image.php
@@ -88,8 +88,8 @@ class Image {
 	 *
 	 * @return ?\GdImage
 	 */
-	public function getImage(): object {
-		return $this->image;
+	public function getImage(): ?\GdImage {
+		return $this->image ?: null;
 	}
 
 	/**


### PR DESCRIPTION
Filename can be false (on error) or null (when uninitialized), simply return null in that case instead of throwing a type error.

This was previously improperly fixed here: https://github.com/opencart/opencart/commit/da308c65667e52583e0a257ba2c9410b6dd8e417