### PR TITLE
Avoid type error when MySQL connection fails

### DIFF
--- a/upload/system/library/db/mysqli.php
+++ b/upload/system/library/db/mysqli.php
@@ -66,7 +66,7 @@ class MySQLi {
 		}
 
 		try {
-			$this->connection = mysqli_init();
+			$this->connection = mysqli_init() ?: null;
 
 			if ($temp_ssl_key_file || $temp_ssl_cert_file || $temp_ssl_ca_file) {
 				$this->connection->ssl_set($temp_ssl_key_file, $temp_ssl_cert_file, $temp_ssl_ca_file, null, null);
@@ -158,7 +158,7 @@ class MySQLi {
 	 * @return bool
 	 */
 	public function isConnected(): bool {
-		return $this->connection;
+		return $this->connection !== null;
 	}
 
 	/**


### PR DESCRIPTION
`mysqli_init()` returns `false` on error, which is not accepted by the property, swap it for `null` instead.

Introduced here: https://github.com/opencart/opencart/commit/671d16272e397471e65f1d6a3748197d1953d3bd