### PR TITLE
Check for $filename initialization before utilization

### DIFF
--- a/upload/admin/controller/catalog/download.php
+++ b/upload/admin/controller/catalog/download.php
@@ -505,7 +505,7 @@ class Download extends \Opencart\System\Engine\Controller {
 			}
 		}
 
-		if (!$json) {
+		if (isset($filename) && !$json) {
 			$file = $filename . '.' . oc_token(32);
 
 			move_uploaded_file($this->request->files['file']['tmp_name'], DIR_DOWNLOAD . $file);


### PR DESCRIPTION
Check that `$filename` exists before we try to use it.