### PR TITLE
Remove redundant check on filename

### DIFF
--- a/upload/system/library/template/template.php
+++ b/upload/system/library/template/template.php
@@ -54,7 +54,7 @@ class Template {
 				}
 			}
 
-			if (isset($file) && is_file($file)) {
+			if (is_file($file)) {
 				$code = file_get_contents($file);
 			} else {
 				throw new \Exception('Error: Could not load template ' . $filename . '!');


### PR DESCRIPTION
File is always set and will always have some string value.

Introduced in https://github.com/opencart/opencart/commit/78306cc026505023cd6437faef1a092e31214f7d