### PR TITLE
Remove unused arguments

### DIFF
--- a/upload/system/library/db/pdo.php
+++ b/upload/system/library/db/pdo.php
@@ -27,11 +27,8 @@ class PDO {
 	 * @param string $password
 	 * @param string $database
 	 * @param string $port
-	 * @param string $sslKey
-	 * @param string $sslCert
-	 * @param string $sslCa
 	 */
-	public function __construct(string $hostname, string $username, string $password, string $database, string $port = '', string $sslKey = '', string $sslCert = '', string $sslCa = '') {
+	public function __construct(string $hostname, string $username, string $password, string $database, string $port = '') {
 		if (!$port) {
 			$port = '3306';
 		}

--- a/upload/system/library/db/pgsql.php
+++ b/upload/system/library/db/pgsql.php
@@ -19,11 +19,8 @@ class PgSQL {
 	 * @param string $password
 	 * @param string $database
 	 * @param string $port
-	 * @param string $ssl_key
-	 * @param string $ssl_cert
-	 * @param string $ssl_ca
 	 */
-	public function __construct(string $hostname, string $username, string $password, string $database, string $port = '', string $ssl_key = '', string $ssl_cert = '', string $ssl_ca = '') {
+	public function __construct(string $hostname, string $username, string $password, string $database, string $port = '') {
 		if (!$port) {
 			$port = '5432';
 		}


### PR DESCRIPTION
The SSL arguments are never actually used inside the function, removing them doesn't affect comparability as PHP will silently ignore additional augments in invocations.

Intorudced here: https://github.com/opencart/opencart/commit/671d16272e397471e65f1d6a3748197d1953d3bd