### PR TITLE
Fix check for empty customer info

### DIFF
--- a/upload/catalog/controller/account/edit.php
+++ b/upload/catalog/controller/account/edit.php
@@ -68,7 +68,7 @@ class Edit extends \Opencart\System\Engine\Controller {
 			}
 		}
 
-		if (isset($customer_info)) {
+		if ($customer_info) {
 			$data['account_custom_field'] = $customer_info['custom_field'];
 		} else {
 			$data['account_custom_field'] = [];


### PR DESCRIPTION
$customer_info is an empty array when the customer isn't found, so a simple fix is to just do a truthy check.

Looks like it was introduced here: https://github.com/opencart/opencart/commit/4b2600780d70b5a60ba6381e76c4d72df2469ab2