### PR TITLE
Fix for timezone change breaking session expiration

### DIFF
--- a/upload/system/library/session/db.php
+++ b/upload/system/library/session/db.php
@@ -14,7 +14,7 @@ final class DB {
 	}
 
 	public function read($session_id) {
-		$query = $this->db->query("SELECT `data` FROM `" . DB_PREFIX . "session` WHERE `session_id` = '" . $this->db->escape($session_id) . "' AND `expire` > '" . $this->db->escape(date('Y-m-d H:i:s', time())) . "'");
+		$query = $this->db->query("SELECT `data` FROM `" . DB_PREFIX . "session` WHERE `session_id` = '" . $this->db->escape($session_id) . "' AND `expire` > '" . $this->db->escape(gmdate('Y-m-d H:i:s', time())) . "'");
 
 		if ($query->num_rows) {
 			return json_decode($query->row['data'], true);
@@ -25,7 +25,7 @@ final class DB {
 
 	public function write($session_id, $data) {
 		if ($session_id) {
-			$this->db->query("REPLACE INTO `" . DB_PREFIX . "session` SET `session_id` = '" . $this->db->escape($session_id) . "', `data` = '" . $this->db->escape(json_encode($data)) . "', `expire` = '" . $this->db->escape(date('Y-m-d H:i:s', time() + (int)$this->maxlifetime)) . "'");
+			$this->db->query("REPLACE INTO `" . DB_PREFIX . "session` SET `session_id` = '" . $this->db->escape($session_id) . "', `data` = '" . $this->db->escape(json_encode($data)) . "', `expire` = '" . $this->db->escape(gmdate('Y-m-d H:i:s', time() + (int)$this->maxlifetime)) . "'");
 		}
 
 		return true;
@@ -51,7 +51,7 @@ final class DB {
 		}
 
 		if (mt_rand() / mt_getrandmax() < $gc_probability / $gc_divisor) {
-			$this->db->query("DELETE FROM `" . DB_PREFIX . "session` WHERE `expire` < '" . $this->db->escape(date('Y-m-d H:i:s', time())) . "'");
+			$this->db->query("DELETE FROM `" . DB_PREFIX . "session` WHERE `expire` < '" . $this->db->escape(gmdate('Y-m-d H:i:s', time())) . "'");
 
 			return true;
 		}


### PR DESCRIPTION
This is the same as https://github.com/opencart/opencart/pull/9633 that was never applied to the 3.0.x.x branch. Should fix https://github.com/opencart/opencart/issues/9237 that prenvented admin login when the timezone was a negative value. However, it won't fix the issue a negative value causes with the API https://github.com/opencart/opencart/issues/9492. That would require a change in the API session code or a change in the startup order.

