### PR TITLE
Remove broken pagination arguments

### DIFF
--- a/upload/admin/controller/sale/subscription.php
+++ b/upload/admin/controller/sale/subscription.php
@@ -953,7 +953,7 @@ class Subscription extends \Opencart\System\Engine\Controller {
 
 		$this->load->model('sale/order');
 
-		$results = $this->model_sale_order->getOrdersBySubscriptionId($subscription_id, ($page - 1) * $limit, $limit);
+		$results = $this->model_sale_order->getOrdersBySubscriptionId($subscription_id);
 
 		foreach ($results as $result) {
 			$data['orders'][] = [

--- a/upload/catalog/controller/account/order.php
+++ b/upload/catalog/controller/account/order.php
@@ -445,7 +445,7 @@ class Order extends \Opencart\System\Engine\Controller {
 
 		$this->load->model('account/order');
 
-		$results = $this->model_account_order->getHistories($order_id, ($page - 1) * $limit, $limit);
+		$results = $this->model_account_order->getHistories($order_id);
 
 		foreach ($results as $result) {
 			$data['histories'][] = [


### PR DESCRIPTION
Neither `getOrdersBySubscriptionId()` nor `getHistories()` accepts arguments for paging there data. This likely means that the UI for this is broken, so a more proper solution would likely be to either implement support for this, or fully remove the paging variables and possibly update the UI. 

Introduced here: https://github.com/opencart/opencart/commit/efbc1d44ead5c7c6eefbd3bcc6a8bed051495f1c and here https://github.com/opencart/opencart/commit/c6bf54bbd8dbb5c4fdacf8b7bc47da66ded49567