### PR TITLE
Cast input type early

### DIFF
--- a/upload/admin/controller/marketplace/modification.php
+++ b/upload/admin/controller/marketplace/modification.php
@@ -386,11 +386,7 @@ class Modification extends \Opencart\System\Engine\Controller {
 											$add = $operation->getElementsByTagName('add')->item(0)->textContent;
 											$trim = $operation->getElementsByTagName('add')->item(0)->getAttribute('trim');
 											$position = $operation->getElementsByTagName('add')->item(0)->getAttribute('position');
-											$offset = $operation->getElementsByTagName('add')->item(0)->getAttribute('offset');
-
-											if ($offset == '') {
-												$offset = 0;
-											}
+											$offset = (int)$operation->getElementsByTagName('add')->item(0)->getAttribute('offset');
 
 											// Trim line if is set to true.
 											if ($trim == 'true') {

--- a/upload/extension/opencart/catalog/model/total/reward.php
+++ b/upload/extension/opencart/catalog/model/total/reward.php
@@ -74,13 +74,13 @@ class Reward extends \Opencart\System\Engine\Model {
 	public function confirm(array $order_info, array $order_total): int {
 		$this->load->language('extension/opencart/total/reward');
 
-		$points = 0;
+		$points = 0.0;
 
 		$start = strpos($order_total['title'], '(') + 1;
 		$end = strrpos($order_total['title'], ')');
 
 		if ($start && $end) {
-			$points = substr($order_total['title'], $start, $end - $start);
+			$points = (float)substr($order_total['title'], $start, $end - $start);
 		}
 
 		$this->load->model('account/customer');


### PR DESCRIPTION
Determining the data type early one ensure we don't have any incorrect usage later in the code. Also this saves us the need for manually converting empty string to 0.

This could potential give hard to debug errors on none expected input, instead it is halted early with an error regarding the none well formed numerics.