### PR TITLE
Remove incorrect use of return value

### DIFF
--- a/upload/admin/controller/design/translation.php
+++ b/upload/admin/controller/design/translation.php
@@ -298,7 +298,7 @@ class Translation extends \Opencart\System\Engine\Controller {
 			$this->load->model('design/translation');
 
 			if (!$this->request->post['translation_id']) {
-				$json['translation_id'] = $this->model_design_translation->addTranslation($this->request->post);
+				$this->model_design_translation->addTranslation($this->request->post);
 			} else {
 				$this->model_design_translation->editTranslation($this->request->post['translation_id'], $this->request->post);
 			}


### PR DESCRIPTION
`Translation::addTranslation()` does not return the translation_id of the new translation. It has a void return and the value would then always be set to `null`.

Alternatively this could be fixed by letting `Translation::addTranslation()` actually return the new row id, maybe something in the other end is dependent on it :shrug: 

Introduced in https://github.com/opencart/opencart/commit/1cadd3c691c8a5da6ae4152fa68bfe7b5ef20a8f