### PR TITLE
Remove unused argument for Session::destroy()

### DIFF
--- a/upload/admin/controller/marketplace/cron.php
+++ b/upload/admin/controller/marketplace/cron.php
@@ -212,7 +212,7 @@ class Cron extends \Opencart\System\Engine\Controller {
 
 				$store->load->controller($cron_info['action'], $cron_id, $cron_info['code'], $cron_info['cycle'], $cron_info['date_added'], $cron_info['date_modified']);
 
-				$store->session->destroy($store->session->getId());
+				$store->session->destroy();
 
 				$this->model_setting_cron->editCron($cron_info['cron_id']);
 			}


### PR DESCRIPTION
This does not take an id:
https://github.com/opencart/opencart/blob/3c766c228374b00918e63725c3aa1892b93acafa/upload/system/library/session.php#L108

Issue was introduced here: https://github.com/opencart/opencart/commit/bb5c6606b1d7c20e13c05e60b15cb466e6504667