### PR TITLE
Clean up Backup::restore()

### DIFF
--- a/upload/admin/controller/tool/backup.php
+++ b/upload/admin/controller/tool/backup.php
@@ -281,7 +281,6 @@ class Backup extends \Opencart\System\Engine\Controller {
 		if (!$json) {
 			// We set $i so we can batch execute the queries rather than do them all at once.
 			$i = 0;
-			$start = false;
 
 			$handle = fopen($file, 'r');
 
@@ -292,26 +291,14 @@ class Backup extends \Opencart\System\Engine\Controller {
 
 				$line = fgets($handle, 1000000);
 
-				if (substr($line, 0, 14) == 'TRUNCATE TABLE' || substr($line, 0, 11) == 'INSERT INTO') {
-					$sql = '';
-
-					$start = true;
-				}
-
 				if ($i > 0 && (substr($line, 0, strlen('TRUNCATE TABLE `' . DB_PREFIX . 'user`')) == 'TRUNCATE TABLE `' . DB_PREFIX . 'user`' || substr($line, 0, strlen('TRUNCATE TABLE `' . DB_PREFIX . 'user_group`')) == 'TRUNCATE TABLE `' . DB_PREFIX . 'user_group`')) {
 					fseek($handle, $position, SEEK_SET);
 
 					break;
 				}
 
-				if ($start) {
-					$sql .= $line;
-				}
-
-				if ($start && substr($line, -2) == ";\n") {
-					$this->db->query(substr($sql, 0, strlen($sql) - 2));
-
-					$start = false;
+				if ((substr($line, 0, 14) == 'TRUNCATE TABLE' || substr($line, 0, 11) == 'INSERT INTO') && substr($line, -2) == ";\n") {
+					$this->db->query(substr($line, 0, strlen($line) - 2));
 				}
 
 				$i++;


### PR DESCRIPTION
There is no need to track `$start` and `$sql` individually as there state is always following the condition of the first check, which also is not affected by any in-between operations.
This avoid a bit of string copying which should help performance a some.

Introduced in https://github.com/opencart/opencart/commit/8a17e05e4f1f3b1b0f005b956efc9cfd166a3bd2