### PR TITLE
Correct call to addModule() in extension module

### DIFF
--- a/upload/admin/controller/extension/module.php
+++ b/upload/admin/controller/extension/module.php
@@ -229,7 +229,7 @@ class Module extends \Opencart\System\Engine\Controller {
 
 			$this->load->model('setting/module');
 
-			$this->model_setting_module->addModule($this->request->get['extension'] . '.' . $this->request->get['code'], $this->language->get('extension_heading_title'));
+			$this->model_setting_module->addModule($this->request->get['extension'] . '.' . $this->request->get['code'], ['name' => $this->language->get('extension_heading_title')]);
 
 			$json['success'] = $this->language->get('text_success');
 		}


### PR DESCRIPTION
`addModule()` takes a data array as the second argument, not a title.
https://github.com/opencart/opencart/blob/3f42879ced0f65ac16b0cc80b3402cfc46246e93/upload/admin/model/setting/module.php#L15

This issue was introduced in https://github.com/opencart/opencart/commit/0ce03aab7e9c19457805b7f91483be70d6d09a29