### PR TITLE
Correct return value of localization functions

### DIFF
--- a/upload/admin/model/localisation/order_status.php
+++ b/upload/admin/model/localisation/order_status.php
@@ -11,9 +11,10 @@ class OrderStatus extends \Opencart\System\Engine\Model {
 	 *
 	 * @param array $data
 	 *
-	 * @return int
+	 * @return ?int
 	 */
-	public function addOrderStatus(array $data): int {
+	public function addOrderStatus(array $data): ?int {
+		$order_status_id = null;
 		foreach ($data['order_status'] as $language_id => $value) {
 			if (isset($order_status_id)) {
 				$this->db->query("INSERT INTO `" . DB_PREFIX . "order_status` SET `order_status_id` = '" . (int)$order_status_id . "', `language_id` = '" . (int)$language_id . "', `name` = '" . $this->db->escape($value['name']) . "'");

--- a/upload/admin/model/localisation/return_reason.php
+++ b/upload/admin/model/localisation/return_reason.php
@@ -11,9 +11,10 @@ class ReturnReason extends \Opencart\System\Engine\Model {
 	 *
 	 * @param array $data
 	 *
-	 * @return int
+	 * @return ?int
 	 */
-	public function addReturnReason(array $data): int {
+	public function addReturnReason(array $data): ?int {
+		$return_reason_id = null;
 		foreach ($data['return_reason'] as $language_id => $value) {
 			if (isset($return_reason_id)) {
 				$this->db->query("INSERT INTO `" . DB_PREFIX . "return_reason` SET `return_reason_id` = '" . (int)$return_reason_id . "', `language_id` = '" . (int)$language_id . "', `name` = '" . $this->db->escape($value['name']) . "'");

--- a/upload/admin/model/localisation/return_status.php
+++ b/upload/admin/model/localisation/return_status.php
@@ -11,9 +11,10 @@ class ReturnStatus extends \Opencart\System\Engine\Model {
 	 *
 	 * @param array $data
 	 *
-	 * @return int
+	 * @return ?int
 	 */
-	public function addReturnStatus(array $data): int {
+	public function addReturnStatus(array $data): ?int {
+		$return_status_id = null;
 		foreach ($data['return_status'] as $language_id => $value) {
 			if (isset($return_status_id)) {
 				$this->db->query("INSERT INTO `" . DB_PREFIX . "return_status` SET `return_status_id` = '" . (int)$return_status_id . "', `language_id` = '" . (int)$language_id . "', `name` = '" . $this->db->escape($value['name']) . "'");

--- a/upload/admin/model/localisation/stock_status.php
+++ b/upload/admin/model/localisation/stock_status.php
@@ -11,9 +11,10 @@ class StockStatus extends \Opencart\System\Engine\Model {
 	 *
 	 * @param array $data
 	 *
-	 * @return int
+	 * @return ?int
 	 */
-	public function addStockStatus(array $data): int {
+	public function addStockStatus(array $data): ?int {
+		$stock_status_id = null;
 		foreach ($data['stock_status'] as $language_id => $value) {
 			if (isset($stock_status_id)) {
 				$this->db->query("INSERT INTO `" . DB_PREFIX . "stock_status` SET `stock_status_id` = '" . (int)$stock_status_id . "', `language_id` = '" . (int)$language_id . "', `name` = '" . $this->db->escape($value['name']) . "'");

--- a/upload/admin/model/localisation/subscription_status.php
+++ b/upload/admin/model/localisation/subscription_status.php
@@ -11,9 +11,10 @@ class SubscriptionStatus extends \Opencart\System\Engine\Model {
 	 *
 	 * @param array $data
 	 *
-	 * @return int
+	 * @return ?int
 	 */
-	public function addSubscriptionStatus(array $data): int {
+	public function addSubscriptionStatus(array $data): ?int {
+		$subscription_status_id = null;
 		foreach ($data['subscription_status'] as $language_id => $value) {
 			if (isset($subscription_status_id)) {
 				$this->db->query("INSERT INTO `" . DB_PREFIX . "subscription_status` SET `subscription_status_id` = '" . (int)$subscription_status_id . "', `language_id` = '" . (int)$language_id . "', `name` = '" . $this->db->escape($value['name']) . "'");


### PR DESCRIPTION
These functions would return an uninitialized variable if the given data does not contain any language elements.
This would result in a `TypeError` exception. This PR changes things so that the variable is null initialized and permit a null return from the functions.

This issue was introduced in 55edabfedb3e9854098973b4f7dd8f87629b8fbe and https://github.com/opencart/opencart/commit/c2640263dd4ecb0074b2cde85df2a385f7b0dfa8