### PR TITLE
Normalize some unconventional calling conventions

### DIFF
--- a/upload/catalog/controller/api/sale/cart.php
+++ b/upload/catalog/controller/api/sale/cart.php
@@ -25,7 +25,7 @@ class Cart extends \Opencart\System\Engine\Controller {
 
 		$this->load->model('checkout/cart');
 
-		($this->model_checkout_cart->getTotals)($totals, $taxes, $total);
+		$this->model_checkout_cart->getTotals($totals, $taxes, $total);
 
 		$json['products'] = [];
 

--- a/upload/catalog/controller/api/sale/order.php
+++ b/upload/catalog/controller/api/sale/order.php
@@ -440,7 +440,7 @@ class Order extends \Opencart\System\Engine\Controller {
 
 			$this->load->model('checkout/cart');
 
-			($this->model_checkout_cart->getTotals)($totals, $taxes, $total);
+			$this->model_checkout_cart->getTotals($totals, $taxes, $total);
 
 			$total_data = [
 				'totals' => $totals,

--- a/upload/catalog/controller/checkout/cart.php
+++ b/upload/catalog/controller/checkout/cart.php
@@ -214,7 +214,7 @@ class Cart extends \Opencart\System\Engine\Controller {
 
 		// Display prices
 		if ($this->customer->isLogged() || !$this->config->get('config_customer_price')) {
-			($this->model_checkout_cart->getTotals)($totals, $taxes, $total);
+			$this->model_checkout_cart->getTotals($totals, $taxes, $total);
 
 			foreach ($totals as $result) {
 				$data['totals'][] = [

--- a/upload/catalog/controller/checkout/confirm.php
+++ b/upload/catalog/controller/checkout/confirm.php
@@ -19,7 +19,7 @@ class Confirm extends \Opencart\System\Engine\Controller {
 
 		$this->load->model('checkout/cart');
 
-		($this->model_checkout_cart->getTotals)($totals, $taxes, $total);
+		$this->model_checkout_cart->getTotals($totals, $taxes, $total);
 
 		$status = ($this->customer->isLogged() || !$this->config->get('config_customer_price'));
 

--- a/upload/catalog/controller/common/cart.php
+++ b/upload/catalog/controller/common/cart.php
@@ -19,7 +19,7 @@ class Cart extends \Opencart\System\Engine\Controller {
 		$this->load->model('checkout/cart');
 
 		if ($this->customer->isLogged() || !$this->config->get('config_customer_price')) {
-			($this->model_checkout_cart->getTotals)($totals, $taxes, $total);
+			$this->model_checkout_cart->getTotals($totals, $taxes, $total);
 		}
 
 		$data['text_items'] = sprintf($this->language->get('text_items'), $this->cart->countProducts() + (isset($this->session->data['vouchers']) ? count($this->session->data['vouchers']) : 0), $this->currency->format($total, $this->session->data['currency']));

--- a/upload/catalog/controller/cron/subscription.php
+++ b/upload/catalog/controller/cron/subscription.php
@@ -292,7 +292,7 @@ class Subscription extends \Opencart\System\Engine\Controller {
 
 					$store->load->model('checkout/cart');
 
-					($store->model_checkout_cart->getTotals)($totals, $taxes, $total);
+					$store->model_checkout_cart->getTotals($totals, $taxes, $total);
 
 					$total_data = [
 						'totals' => $totals,


### PR DESCRIPTION
The somewhat unusual calling convention would only work as long as it's a constructed object with properties containing callback, if an object with actual methods where returned this would have resulted in a fatal error. Instead use the common calling convention.

Introduced in fcf2a8173a983d00c470824a4ae088afdb1931bf, 0a3f518cc3cca9208c69a1f237c5099ec9fe9e62, and 7f16b030abc39fa7763fddb098b876fa8ce5b670