### PR TITLE
Fix loading subscription data

### DIFF
--- a/upload/admin/controller/customer/customer.php
+++ b/upload/admin/controller/customer/customer.php
@@ -882,9 +882,9 @@ class Customer extends \Opencart\System\Engine\Controller {
 
 		$data['payment_methods'] = [];
 
-		$this->load->model('customer/customer');
+		$this->load->model('sale/subscription');
 
-		$results = $this->model_customer_customer->getPaymentMethods($customer_id, ($page - 1) * $limit, $limit);
+		$results = $this->model_sale_subscription->getSubscriptions(['filter_customer_id' => $customer_id]);
 
 		foreach ($results as $result) {
 			if (isset($result['image'])) {
@@ -904,7 +904,7 @@ class Customer extends \Opencart\System\Engine\Controller {
 			];
 		}
 
-		$payment_total = $this->model_customer_customer->getTotalPaymentMethods($customer_id);
+		$payment_total = $this->model_sale_subscription->getTotalSubscriptions(['filter_customer_id' => $customer_id]);
 
 		$data['pagination'] = $this->load->controller('common/pagination', [
 			'total' => $payment_total,

--- a/upload/admin/controller/mail/subscription.php
+++ b/upload/admin/controller/mail/subscription.php
@@ -68,13 +68,13 @@ class Subscription extends \Opencart\System\Engine\Controller {
 					$subscription_status_info = $this->model_localisation_subscription_status->getSubscriptionStatus($subscription_status_id);
 
 					if ($subscription_status_info) {
-						// Customers
-						$this->load->model('customer/customer');
-
 						// Customer payment
-						$customer_payment_info = $this->model_customer_customer->getPaymentMethod($subscription['customer_id'], $subscription['customer_payment_id']);
+						$customer_payment_info = $this->model_sale_subscription->getSubscriptions(['filter_customer_id' => $subscription['customer_id'], 'filter_customer_payment_id' => $subscription['customer_payment_id']]);
 
 						if ($customer_payment_info) {
+							// Customers
+							$this->load->model('customer/customer');
+
 							// Since the customer payment is integrated into the customer/customer page,
 							// we need to gather the customer's information rather than the order
 							$customer_info = $this->model_customer_customer->getCustomer($subscription['customer_id']);
@@ -230,8 +230,10 @@ class Subscription extends \Opencart\System\Engine\Controller {
 		$subscriptions = $this->model_checkout_subscription->getSubscriptions($filter_data);
 
 		if ($subscriptions) {
+			$this->load->model('customer/customer');
+
 			foreach ($subscriptions as $subscription) {
-				$transaction_total = $this->model_sale_subscription->getTotalTransactions($subscription_id);
+				$transaction_total = $this->model_customer_customer->getTotalTransactionsByOrderId($subscription['order_id']);
 
 				if ($transaction_total) {
 					// Orders

--- a/upload/admin/controller/sale/subscription.php
+++ b/upload/admin/controller/sale/subscription.php
@@ -660,8 +660,8 @@ class Subscription extends \Opencart\System\Engine\Controller {
 
 		// Product data
 		if (!empty($subscription_info)) {
-			$this->load->model('sale/order');
-			$product_info = $this->model_sale_order->getProductByOrderProductId($subscription_info['order_id'], $subscription_info['order_product_id']);
+			$this->load->model('account/order');
+			$product_info = $this->model_account_order->getProduct($subscription_info['order_id'], $subscription_info['order_product_id']);
 		}
 
 		if (!empty($product_info['name'])) {
@@ -788,10 +788,10 @@ class Subscription extends \Opencart\System\Engine\Controller {
 
 		$subscription_info = $this->model_sale_subscription->getSubscription($subscription_id);
 
-		if (!$subscription_info) {
-			$this->load->model('customer/customer');
+		if ($subscription_info) {
+			$this->load->model('sale/subscription');
 
-			$payment_method_info = $this->model_customer_customer->getPaymentMethod($subscription_info['customer_id'], $this->request->post['customer_payment_id']);
+			$payment_method_info = $this->model_sale_subscription->getSubscriptions(['filter_customer_id' => $subscription_info['customer_id'], 'filter_customer_payment_id' => $this->request->post['customer_payment_id']]);
 
 			if (!$payment_method_info) {
 				$json['error'] = $this->language->get('error_payment_method');

--- a/upload/admin/model/sale/subscription.php
+++ b/upload/admin/model/sale/subscription.php
@@ -139,6 +139,14 @@ class Subscription extends \Opencart\System\Engine\Model {
 			$implode[] = "`s`.`order_product_id` = '" . (int)$data['filter_order_product_id'] . "'";
 		}
 
+		if (!empty($data['filter_customer_payment_id'])) {
+			$implode[] = "`s`.`customer_payment_id` = " . (int)$data['filter_customer_payment_id'];
+		}
+
+		if (!empty($data['filter_customer_id'])) {
+			$implode[] = "`s`.`customer_id` = " . (int)$data['filter_customer_id'];
+		}
+
 		if (!empty($data['filter_customer'])) {
 			$implode[] = "LCASE(CONCAT(`o`.`firstname`, ' ', `o`.`lastname`)) LIKE '" . $this->db->escape(oc_strtolower($data['filter_customer']) . '%') . "'";
 		}
@@ -219,6 +227,10 @@ class Subscription extends \Opencart\System\Engine\Model {
 
 		if (!empty($data['filter_order_id'])) {
 			$implode[] = "`s`.`order_id` = '" . (int)$data['filter_order_id'] . "'";
+		}
+
+		if (!empty($data['filter_customer_id'])) {
+			$implode[] = "`s`.`customer_id` = " . (int)$data['filter_customer_id'];
 		}
 
 		if (!empty($data['filter_customer'])) {

--- a/upload/catalog/controller/cron/subscription.php
+++ b/upload/catalog/controller/cron/subscription.php
@@ -401,7 +401,8 @@ class Subscription extends \Opencart\System\Engine\Controller {
 							}
 
 							if ($date_next) {
-								$this->model_account_subscription->editDateNext($result['subscription_id'], $date_next);
+								$this->load->model('checkout/subscription');
+								$this->model_checkout_subscription->editDateNext($result['subscription_id'], $date_next);
 							}
 
 							$this->model_checkout_subscription->addHistory($result['subscription_id'], $this->config->get('config_subscription_active_status_id'), $this->language->get('text_success'), true);

--- a/upload/catalog/controller/mail/subscription.php
+++ b/upload/catalog/controller/mail/subscription.php
@@ -90,9 +90,9 @@ class Subscription extends \Opencart\System\Engine\Controller {
 				// order ID; only as a new order ID added by an extension
 				if ($value['customer_id'] == $subscription['customer_id'] && $value['order_id'] == $subscription['order_id']) {
 					// Payment Methods
-					$this->load->model('account/payment_method');
+					$this->load->model('sale/subscription');
 
-					$payment_method = $this->model_account_payment_method->getPaymentMethod($value['customer_id'], $value['customer_payment_id']);
+					$payment_method = $this->model_sale_subscription->getTotalSubscriptions(['filter_customer_id' => $value['customer_id']]);
 
 					if ($payment_method) {
 						// Subscription


### PR DESCRIPTION
`upload/admin/controller/sale/subscription.php` had an inverted case on line 791 meaning it never loaded the subscription data. This was introduced here: https://github.com/opencart/opencart/commit/e586908b1b17899d62133a13e65b95017e22e053

In `upload/catalog/controller/cron/subscription.php` the editDateNext() is called on a model that does not implement it looks to have been introduced in https://github.com/opencart/opencart/commit/0da669409629a3aca01aefe40c49765b34eb9491

`upload/admin/controller/sale/subscription.php`, `upload/catalog/controller/mail/subscription.php`, `upload/admin/controller/mail/subscription.php` and `upload/admin/controller/customer/customer.php` appears to have been broken since https://github.com/opencart/opencart/commit/23e7072059f9bf2987ec82e204be721a0caba257 and https://github.com/opencart/opencart/commit/8a00dffe8334133698dc863fe944bcf23735f7f4
I implemented some of the missing function, but did not implement support for paging which was previously used in `upload/admin/controller/customer/customer.php`.