### PR TITLE
Correct getLastId() return value

### DIFF
--- a/upload/system/library/db/pdo.php
+++ b/upload/system/library/db/pdo.php
@@ -118,10 +118,12 @@ class PDO {
 	/**
 	 * getLastId
 	 *
-	 * @return int
+	 * @return ?int
 	 */
-	public function getLastId(): int {
-		return $this->connection->lastInsertId();
+	public function getLastId(): ?int {
+		$id = $this->connection->lastInsertId();
+
+		return $id ? (int)$id : null;
 	}
 
 	/**


### PR DESCRIPTION
The native return type is a string, cast it to `int`. Additionally when nothing was inserted it will return `false`, swap it for `null` and correct return type.

Introduced in https://github.com/opencart/opencart/commit/977710c5ba995d49261f20273e971482c584970b