### PR TITLE
Copy missing edit functions for catalog account subscription model

### DIFF
--- a/upload/catalog/model/account/subscription.php
+++ b/upload/catalog/model/account/subscription.php
@@ -151,4 +151,28 @@ class Subscription extends \Opencart\System\Engine\Model {
 
 		return (int)$query->row['total'];
 	}
+
+	/**
+	 * Edit Remaining
+	 *
+	 * @param int $subscription_id
+	 * @param int $remaining
+	 *
+	 * @return void
+	 */
+	public function editRemaining(int $subscription_id, int $remaining): void {
+		$this->db->query("UPDATE `" . DB_PREFIX . "subscription` SET `remaining` = '" . (int)$remaining . "' WHERE `subscription_id` = '" . (int)$subscription_id . "'");
+	}
+
+	/**
+	 * Edit Trial Remaining
+	 *
+	 * @param int $subscription_id
+	 * @param int $trial_remaining
+	 *
+	 * @return void
+	 */
+	public function editTrialRemaining(int $subscription_id, int $trial_remaining): void {
+		$this->db->query("UPDATE `" . DB_PREFIX . "subscription` SET `trial_remaining` = '" . (int)$trial_remaining . "' WHERE `subscription_id` = '" . (int)$subscription_id . "'");
+	}
 }


### PR DESCRIPTION
These methods are used here:
https://github.com/opencart/opencart/blob/549381fe854cfd43baf1b1522e52a3e00734ad39/upload/catalog/controller/cron/subscription.php#L391

But where not implemented on the correct model, copied from `Opencart\Admin\Model\Sale\Subscription`.