### PR TITLE
Correct json error format for Cloud::save()

### DIFF
--- a/upload/extension/opencart/admin/controller/other/cloud.php
+++ b/upload/extension/opencart/admin/controller/other/cloud.php
@@ -58,7 +58,7 @@ class Cloud extends \Opencart\System\Engine\Controller {
 		$json = [];
 
 		if (!$this->user->hasPermission('modify', 'extension/opencart/other/cloud')) {
-			$json['error'] = $this->language->get('error_permission');
+			$json['error']['permission'] = $this->language->get('error_permission');
 		}
 
 		if ((oc_strlen($this->request->post['other_cloud_key']) < 3) || (oc_strlen($this->request->post['other_cloud_key']) > 64)) {


### PR DESCRIPTION
If a permission error happened it would cause a fatal error if there was also a key or secret error since they treat ['error'] as an array, but it would have been set to a string. This is solved by also treating permission as a key on the error array.

Introduced here: 53496577d702c2ec92506ee7ca31f03d55deb49a