### PR TITLE
Correct return type for format()

### DIFF
--- a/upload/system/library/cart/currency.php
+++ b/upload/system/library/cart/currency.php
@@ -43,9 +43,9 @@ class Currency {
 	 * @param float  $value
 	 * @param bool   $format
 	 *
-	 * @return string
+	 * @return float|string
 	 */
-	public function format(float $number, string $currency, float $value = 0, bool $format = true): string {
+	public function format(float $number, string $currency, float $value = 0, bool $format = true) {
 		if (!isset($this->currencies[$currency])) {
 			return '';
 		}


### PR DESCRIPTION
If $format is set to false the function will return the value in a float form. Issue introduced in 977710c5ba995d49261f20273e971482c584970b