### PR TITLE
[3.0.x.x] Remove Ref check from proxy.php

### DIFF
--- a/upload/system/engine/proxy.php
+++ b/upload/system/engine/proxy.php
@@ -36,11 +36,7 @@ class Proxy extends \stdClass {
 		$args = func_get_args();
 		
 		foreach ($args as $arg) {
-			if ($arg instanceof Ref) {
-				$arg_data[] =& $arg->getRef();
-			} else {
-				$arg_data[] =& $arg;
-			}
+			$arg_data[] =& $arg;
 		}
 		
 		if (isset($this->{$key})) {		


### PR DESCRIPTION
`Ref` does not exist ([and it doesn't appear it ever did](https://github.com/opencart/opencart/commits/master/upload/system/engine/ref.php)) so checking for it is pointless.

The check was originally added here: https://github.com/opencart/opencart/commit/248bf46d897385bd6de70404fa37d3a6a2857453

Then got changed to `Reference` in OC4, with comments about being broken from other devs:
https://github.com/opencart/opencart/commit/bca8e10322475bf3fc9c9b4ffa8d7c3f680b2413

`Reference` then got added here: https://github.com/opencart/opencart/commit/fe0b6910c5a2fd2ab1f2980faf3196b56f7cb853

Then fully removed here: https://github.com/opencart/opencart/commit/c705bc46fc48922c3154b6f07f1ae9a5ca9753c9