### PR TITLE
Fix deleteAuthorize()

### DIFF
--- a/upload/admin/controller/customer/customer.php
+++ b/upload/admin/controller/customer/customer.php
@@ -1412,21 +1412,28 @@ class Customer extends \Opencart\System\Engine\Controller {
 
 		$this->load->model('customer/customer');
 
-		$login_info = $this->model_customer_customer->getAuthorize($customer_authorize_id);
+		$login_infos = $this->model_customer_customer->getAuthorizes($customer_authorize_id);
 
-		if (!$login_info) {
+		if (!$login_infos) {
 			$json['error'] = $this->language->get('error_authorize');
 		}
 
 		if (!$json) {
 			$this->model_customer_customer->deleteAuthorize($customer_authorize_id);
 
-			// If the token is still present, then we enforce the customer to log out automatically.
-			if ($login_info['token'] == $token) {
-				$this->session->data['success'] = $this->language->get('text_success');
+			$tokenExists = false;
+			foreach ($login_infos as $login_info) {
+				// If the token is still present, then we enforce the customer to log out automatically.
+				if ($login_info['token'] == $token) {
+					$this->session->data['success'] = $this->language->get('text_success');
 
-				$json['redirect'] = $this->url->link('common/login', '', true);
-			} else {
+					$json['redirect'] = $this->url->link('common/login', '', true);
+					$tokenExists = true;
+					break;
+				}
+			}
+
+			if (!$tokenExists) {
 				$json['success'] = $this->language->get('text_success');
 			}
 		}

--- a/upload/admin/controller/user/user.php
+++ b/upload/admin/controller/user/user.php
@@ -716,21 +716,28 @@ class User extends \Opencart\System\Engine\Controller {
 
 		$this->load->model('user/user');
 
-		$login_info = $this->model_user_user->getAuthorize($user_authorize_id);
+		$login_infos = $this->model_user_user->getAuthorizes($user_authorize_id);
 
-		if (!$login_info) {
+		if (!$login_infos) {
 			$json['error'] = $this->language->get('error_authorize');
 		}
 
 		if (!$json) {
 			$this->model_user_user->deleteAuthorize($user_authorize_id);
 
-			// If the token is still present, then we enforce the user to log out automatically.
-			if ($login_info['token'] == $token) {
-				$this->session->data['success'] = $this->language->get('text_success');
+			$tokenExists = false;
+			foreach ($login_infos as $login_info) {
+				// If the token is still present, then we enforce the user to log out automatically.
+				if ($login_info['token'] == $token) {
+					$this->session->data['success'] = $this->language->get('text_success');
 
-				$json['redirect'] = $this->url->link('common/login', '', true);
-			} else {
+					$json['redirect'] = $this->url->link('common/login', '', true);
+					$tokenExists = true;
+					break;
+				}
+			}
+
+			if (!$tokenExists) {
 				$json['success'] = $this->language->get('text_success');
 			}
 		}


### PR DESCRIPTION
`getAuthorize()` doesn't exist, use `getAuthorizes()`. Correct use of the array was detected after applying https://github.com/opencart/opencart/pull/13428 locally.

Issue introduced in https://github.com/opencart/opencart/commit/bdc79c4db07f170c1a41add4566cfe2c0f529f20 and https://github.com/opencart/opencart/commit/56f257e024d4ee54f6e8b9ec8b776a1ab082c67a