### PR TITLE
Use DTO instead of scalar types to avoid issues with passing things by reference

### DIFF
--- a/upload/catalog/controller/api/sale/cart.php
+++ b/upload/catalog/controller/api/sale/cart.php
@@ -19,13 +19,11 @@ class Cart extends \Opencart\System\Engine\Controller {
 			$json['error']['stock'] = $this->language->get('error_stock');
 		}
 
-		$totals = [];
-		$taxes = $this->cart->getTaxes();
-		$total = 0;
+		$counter = new \Opencart\System\Engine\Counter($this->cart->getTaxes());
 
 		$this->load->model('checkout/cart');
 
-		($this->model_checkout_cart->getTotals)($totals, $taxes, $total);
+		$this->model_checkout_cart->getTotals($counter);
 
 		$json['products'] = [];
 
@@ -86,7 +84,7 @@ class Cart extends \Opencart\System\Engine\Controller {
 
 		$json['totals'] = [];
 
-		foreach ($totals as $total) {
+		foreach ($counter->totals as $total) {
 			$json['totals'][] = [
 				'title' => $total['title'],
 				'text'  => $this->currency->format($total['value'], $this->session->data['currency'])

--- a/upload/catalog/controller/api/sale/order.php
+++ b/upload/catalog/controller/api/sale/order.php
@@ -434,18 +434,16 @@ class Order extends \Opencart\System\Engine\Controller {
 			}
 
 			// Order Totals
-			$totals = [];
-			$taxes = $this->cart->getTaxes();
-			$total = 0;
+			$counter = new \Opencart\System\Engine\Counter($this->cart->getTaxes());
 
 			$this->load->model('checkout/cart');
 
-			($this->model_checkout_cart->getTotals)($totals, $taxes, $total);
+			$this->model_checkout_cart->getTotals($counter);
 
 			$total_data = [
-				'totals' => $totals,
-				'taxes'  => $taxes,
-				'total'  => $total
+				'totals' => $counter->totals,
+				'taxes'  => $counter->taxes,
+				'total'  => $counter->total
 			];
 
 			$order_data = array_merge($order_data, $total_data);

--- a/upload/catalog/controller/checkout/cart.php
+++ b/upload/catalog/controller/checkout/cart.php
@@ -208,15 +208,13 @@ class Cart extends \Opencart\System\Engine\Controller {
 
 		$data['totals'] = [];
 
-		$totals = [];
-		$taxes = $this->cart->getTaxes();
-		$total = 0;
+		$counter = new \Opencart\System\Engine\Counter($this->cart->getTaxes());
 
 		// Display prices
 		if ($this->customer->isLogged() || !$this->config->get('config_customer_price')) {
-			($this->model_checkout_cart->getTotals)($totals, $taxes, $total);
+			$this->model_checkout_cart->getTotals($counter->totals);
 
-			foreach ($totals as $result) {
+			foreach ($counter->totals as $result) {
 				$data['totals'][] = [
 					'title' => $result['title'],
 					'text'  => $price_status ? $this->currency->format($result['value'], $this->session->data['currency']) : ''

--- a/upload/catalog/controller/checkout/confirm.php
+++ b/upload/catalog/controller/checkout/confirm.php
@@ -13,13 +13,11 @@ class Confirm extends \Opencart\System\Engine\Controller {
 		$this->load->language('checkout/confirm');
 
 		// Order Totals
-		$totals = [];
-		$taxes = $this->cart->getTaxes();
-		$total = 0;
+		$counter = new \Opencart\System\Engine\Counter($this->cart->getTaxes());
 
 		$this->load->model('checkout/cart');
 
-		($this->model_checkout_cart->getTotals)($totals, $taxes, $total);
+		$this->model_checkout_cart->getTotals($counter);
 
 		$status = ($this->customer->isLogged() || !$this->config->get('config_customer_price'));
 
@@ -175,9 +173,9 @@ class Confirm extends \Opencart\System\Engine\Controller {
 			}
 
 			$total_data = [
-				'totals' => $totals,
-				'taxes'  => $taxes,
-				'total'  => $total
+				'totals' => $counter->totals,
+				'taxes'  => $counter->taxes,
+				'total'  => $counter->total
 			];
 
 			$order_data = array_merge($order_data, $total_data);
@@ -389,7 +387,7 @@ class Confirm extends \Opencart\System\Engine\Controller {
 
 		$data['totals'] = [];
 
-		foreach ($totals as $total) {
+		foreach ($counter->totals as $total) {
 			$data['totals'][] = [
 				'title' => $total['title'],
 				'text'  => $this->currency->format($total['value'], $this->session->data['currency'])

--- a/upload/catalog/controller/common/cart.php
+++ b/upload/catalog/controller/common/cart.php
@@ -12,17 +12,15 @@ class Cart extends \Opencart\System\Engine\Controller {
 	public function index(): string {
 		$this->load->language('common/cart');
 
-		$totals = [];
-		$taxes = $this->cart->getTaxes();
-		$total = 0;
+		$counter = new \Opencart\System\Engine\Counter($this->cart->getTaxes());
 
 		$this->load->model('checkout/cart');
 
 		if ($this->customer->isLogged() || !$this->config->get('config_customer_price')) {
-			($this->model_checkout_cart->getTotals)($totals, $taxes, $total);
+			$this->model_checkout_cart->getTotals($counter);
 		}
 
-		$data['text_items'] = sprintf($this->language->get('text_items'), $this->cart->countProducts() + (isset($this->session->data['vouchers']) ? count($this->session->data['vouchers']) : 0), $this->currency->format($total, $this->session->data['currency']));
+		$data['text_items'] = sprintf($this->language->get('text_items'), $this->cart->countProducts() + (isset($this->session->data['vouchers']) ? count($this->session->data['vouchers']) : 0), $this->currency->format($counter->total, $this->session->data['currency']));
 
 		// Products
 		$data['products'] = [];
@@ -105,7 +103,7 @@ class Cart extends \Opencart\System\Engine\Controller {
 		// Totals
 		$data['totals'] = [];
 
-		foreach ($totals as $total) {
+		foreach ($counter->totals as $total) {
 			$data['totals'][] = [
 				'title' => $total['title'],
 				'text'  => $this->currency->format($total['value'], $this->session->data['currency'])

--- a/upload/catalog/controller/cron/subscription.php
+++ b/upload/catalog/controller/cron/subscription.php
@@ -286,18 +286,16 @@ class Subscription extends \Opencart\System\Engine\Controller {
 					$order_data['vouchers'] = [];
 
 					// Order Totals
-					$totals = [];
-					$taxes = $store->cart->getTaxes();
-					$total = 0;
+					$counter = new \Opencart\System\Engine\Counter($store->cart->getTaxes());
 
 					$store->load->model('checkout/cart');
 
-					($store->model_checkout_cart->getTotals)($totals, $taxes, $total);
+					$store->model_checkout_cart->getTotals($counter);
 
 					$total_data = [
-						'totals' => $totals,
-						'taxes'  => $taxes,
-						'total'  => $total
+						'totals' => $counter->totals,
+						'taxes'  => $counter->taxes,
+						'total'  => $counter->total
 					];
 
 					$order_data = array_merge($order_data, $total_data);

--- a/upload/catalog/model/checkout/cart.php
+++ b/upload/catalog/model/checkout/cart.php
@@ -122,13 +122,11 @@ class Cart extends \Opencart\System\Engine\Model {
 	/**
 	 * Get Totals
 	 *
-	 * @param array $totals
-	 * @param array $taxes
-	 * @param int   $total
+	 * @param \Opencart\System\Engine\Counter $counter
 	 *
 	 * @return void
 	 */
-	public function getTotals(array &$totals, array &$taxes, int &$total): void {
+	public function getTotals(\Opencart\System\Engine\Counter $counter): void {
 		$sort_order = [];
 
 		$this->load->model('setting/extension');
@@ -145,17 +143,16 @@ class Cart extends \Opencart\System\Engine\Model {
 			if ($this->config->get('total_' . $result['code'] . '_status')) {
 				$this->load->model('extension/' . $result['extension'] . '/total/' . $result['code']);
 
-				// __call magic method cannot pass-by-reference so we get PHP to call it as an anonymous function.
-				($this->{'model_extension_' . $result['extension'] . '_total_' . $result['code']}->getTotal)($totals, $taxes, $total);
+				$this->{'model_extension_' . $result['extension'] . '_total_' . $result['code']}->getTotal($counter);
 			}
 		}
 
 		$sort_order = [];
 
-		foreach ($totals as $key => $value) {
+		foreach ($counter->totals as $key => $value) {
 			$sort_order[$key] = $value['sort_order'];
 		}
 
-		array_multisort($sort_order, SORT_ASC, $totals);
+		array_multisort($sort_order, SORT_ASC, $counter->totals);
 	}
 }

--- a/upload/extension/opencart/catalog/model/total/coupon.php
+++ b/upload/extension/opencart/catalog/model/total/coupon.php
@@ -7,13 +7,11 @@ namespace Opencart\Catalog\Model\Extension\Opencart\Total;
  */
 class Coupon extends \Opencart\System\Engine\Model {
 	/**
-	 * @param array $totals
-	 * @param array $taxes
-	 * @param float $total
+	 * @param \Opencart\System\Engine\Counter $counter
 	 *
 	 * @return void
 	 */
-	public function getTotal(array &$totals, array &$taxes, float &$total): void {
+	public function getTotal(\Opencart\System\Engine\Counter $counter): void {
 		if (isset($this->session->data['coupon'])) {
 			$this->load->language('extension/opencart/total/coupon', 'coupon');
 
@@ -63,7 +61,7 @@ class Coupon extends \Opencart\System\Engine\Model {
 
 							foreach ($tax_rates as $tax_rate) {
 								if ($tax_rate['type'] == 'P') {
-									$taxes[$tax_rate['tax_rate_id']] -= $tax_rate['amount'];
+									$counter->taxes[$tax_rate['tax_rate_id']] -= $tax_rate['amount'];
 								}
 							}
 						}
@@ -78,7 +76,7 @@ class Coupon extends \Opencart\System\Engine\Model {
 
 						foreach ($tax_rates as $tax_rate) {
 							if ($tax_rate['type'] == 'P') {
-								$taxes[$tax_rate['tax_rate_id']] -= $tax_rate['amount'];
+								$counter->taxes[$tax_rate['tax_rate_id']] -= $tax_rate['amount'];
 							}
 						}
 					}
@@ -87,12 +85,12 @@ class Coupon extends \Opencart\System\Engine\Model {
 				}
 
 				// If discount greater than total
-				if ($discount_total > $total) {
-					$discount_total = $total;
+				if ($discount_total > $counter->total) {
+					$discount_total = $counter->total;
 				}
 
 				if ($discount_total > 0) {
-					$totals[] = [
+					$counter->totals[] = [
 						'extension'  => 'opencart',
 						'code'       => 'coupon',
 						'title'      => sprintf($this->language->get('coupon_text_coupon'), $this->session->data['coupon']),
@@ -100,7 +98,7 @@ class Coupon extends \Opencart\System\Engine\Model {
 						'sort_order' => (int)$this->config->get('total_coupon_sort_order')
 					];
 
-					$total -= $discount_total;
+					$counter->total -= $discount_total;
 				}
 			}
 		}

--- a/upload/extension/opencart/catalog/model/total/credit.php
+++ b/upload/extension/opencart/catalog/model/total/credit.php
@@ -7,22 +7,20 @@ namespace Opencart\Catalog\Model\Extension\Opencart\Total;
  */
 class Credit extends \Opencart\System\Engine\Model {
 	/**
-	 * @param array $totals
-	 * @param array $taxes
-	 * @param float $total
+	 * @param \Opencart\System\Engine\Counter $counter
 	 *
 	 * @return void
 	 */
-	public function getTotal(array &$totals, array &$taxes, float &$total): void {
+	public function getTotal(\Opencart\System\Engine\Counter $counter): void {
 		$this->load->language('extension/opencart/total/credit');
 
 		$balance = $this->customer->getBalance();
 
 		if ((float)$balance) {
-			$credit = min($balance, $total);
+			$credit = min($balance, $counter->total);
 
 			if ((float)$credit > 0) {
-				$totals[] = [
+				$counter->totals[] = [
 					'extension'  => 'opencart',
 					'code'       => 'credit',
 					'title'      => $this->language->get('text_credit'),
@@ -30,7 +28,7 @@ class Credit extends \Opencart\System\Engine\Model {
 					'sort_order' => (int)$this->config->get('total_credit_sort_order')
 				];
 
-				$total -= $credit;
+				$counter->total -= $credit;
 			}
 		}
 	}

--- a/upload/extension/opencart/catalog/model/total/handling.php
+++ b/upload/extension/opencart/catalog/model/total/handling.php
@@ -7,17 +7,15 @@ namespace Opencart\Catalog\Model\Extension\Opencart\Total;
  */
 class Handling extends \Opencart\System\Engine\Model {
 	/**
-	 * @param array $totals
-	 * @param array $taxes
-	 * @param float $total
+	 * @param \Opencart\System\Engine\Counter $counter
 	 *
 	 * @return void
 	 */
-	public function getTotal(array &$totals, array &$taxes, float &$total): void {
+	public function getTotal(\Opencart\System\Engine\Counter $counter): void {
 		if (($this->cart->getSubTotal() > (float)$this->config->get('total_handling_total')) && ($this->cart->getSubTotal() > 0)) {
 			$this->load->language('extension/opencart/total/handling');
 
-			$totals[] = [
+			$counter->totals[] = [
 				'extension'  => 'opencart',
 				'code'       => 'handling',
 				'title'      => $this->language->get('text_handling'),
@@ -29,15 +27,15 @@ class Handling extends \Opencart\System\Engine\Model {
 				$tax_rates = $this->tax->getRates((float)$this->config->get('total_handling_fee'), (int)$this->config->get('total_handling_tax_class_id'));
 
 				foreach ($tax_rates as $tax_rate) {
-					if (!isset($taxes[$tax_rate['tax_rate_id']])) {
-						$taxes[$tax_rate['tax_rate_id']] = $tax_rate['amount'];
+					if (!isset($counter->taxes[$tax_rate['tax_rate_id']])) {
+						$counter->taxes[$tax_rate['tax_rate_id']] = $tax_rate['amount'];
 					} else {
-						$taxes[$tax_rate['tax_rate_id']] += $tax_rate['amount'];
+						$counter->taxes[$tax_rate['tax_rate_id']] += $tax_rate['amount'];
 					}
 				}
 			}
 
-			$total += (float)$this->config->get('total_handling_fee');
+			$counter->total += (float)$this->config->get('total_handling_fee');
 		}
 	}
 }

--- a/upload/extension/opencart/catalog/model/total/low_order_fee.php
+++ b/upload/extension/opencart/catalog/model/total/low_order_fee.php
@@ -7,17 +7,15 @@ namespace Opencart\Catalog\Model\Extension\Opencart\Total;
  */
 class LowOrderFee extends \Opencart\System\Engine\Model {
 	/**
-	 * @param array $totals
-	 * @param array $taxes
-	 * @param float $total
+	 * @param \Opencart\System\Engine\Counter $counter
 	 *
 	 * @return void
 	 */
-	public function getTotal(array &$totals, array &$taxes, float &$total): void {
+	public function getTotal(\Opencart\System\Engine\Counter $counter): void {
 		if ($this->cart->getSubTotal() && ($this->cart->getSubTotal() < (float)$this->config->get('total_low_order_fee_total'))) {
 			$this->load->language('extension/opencart/total/low_order_fee');
 
-			$totals[] = [
+			$counter->totals[] = [
 				'extension'  => 'opencart',
 				'code'       => 'low_order_fee',
 				'title'      => $this->language->get('text_low_order_fee'),
@@ -29,15 +27,15 @@ class LowOrderFee extends \Opencart\System\Engine\Model {
 				$tax_rates = $this->tax->getRates($this->config->get('total_low_order_fee_fee'), $this->config->get('total_low_order_fee_tax_class_id'));
 
 				foreach ($tax_rates as $tax_rate) {
-					if (!isset($taxes[$tax_rate['tax_rate_id']])) {
-						$taxes[$tax_rate['tax_rate_id']] = $tax_rate['amount'];
+					if (!isset($counter->taxes[$tax_rate['tax_rate_id']])) {
+						$counter->taxes[$tax_rate['tax_rate_id']] = $tax_rate['amount'];
 					} else {
-						$taxes[$tax_rate['tax_rate_id']] += $tax_rate['amount'];
+						$counter->taxes[$tax_rate['tax_rate_id']] += $tax_rate['amount'];
 					}
 				}
 			}
 
-			$total += $this->config->get('total_low_order_fee_fee');
+			$counter->total += $this->config->get('total_low_order_fee_fee');
 		}
 	}
 }

--- a/upload/extension/opencart/catalog/model/total/reward.php
+++ b/upload/extension/opencart/catalog/model/total/reward.php
@@ -7,13 +7,11 @@ namespace Opencart\Catalog\Model\Extension\Opencart\Total;
  */
 class Reward extends \Opencart\System\Engine\Model {
 	/**
-	 * @param array $totals
-	 * @param array $taxes
-	 * @param float $total
+	 * @param \Opencart\System\Engine\Counter $counter
 	 *
 	 * @return void
 	 */
-	public function getTotal(array &$totals, array &$taxes, float &$total): void {
+	public function getTotal(\Opencart\System\Engine\Counter $counter): void {
 		if (isset($this->session->data['reward'])) {
 			$this->load->language('extension/opencart/total/reward', 'reward');
 
@@ -43,7 +41,7 @@ class Reward extends \Opencart\System\Engine\Model {
 
 							foreach ($tax_rates as $tax_rate) {
 								if ($tax_rate['type'] == 'P') {
-									$taxes[$tax_rate['tax_rate_id']] -= $tax_rate['amount'];
+									$counter->taxes[$tax_rate['tax_rate_id']] -= $tax_rate['amount'];
 								}
 							}
 						}
@@ -52,7 +50,7 @@ class Reward extends \Opencart\System\Engine\Model {
 					$discount_total += $discount;
 				}
 
-				$totals[] = [
+				$counter->totals[] = [
 					'extension'  => 'opencart',
 					'code'       => 'reward',
 					'title'      => sprintf($this->language->get('reward_text_reward'), $this->session->data['reward']),
@@ -60,7 +58,7 @@ class Reward extends \Opencart\System\Engine\Model {
 					'sort_order' => (int)$this->config->get('total_reward_sort_order')
 				];
 
-				$total -= $discount_total;
+				$counter->total -= $discount_total;
 			}
 		}
 	}

--- a/upload/extension/opencart/catalog/model/total/shipping.php
+++ b/upload/extension/opencart/catalog/model/total/shipping.php
@@ -7,15 +7,13 @@ namespace Opencart\Catalog\Model\Extension\Opencart\Total;
  */
 class Shipping extends \Opencart\System\Engine\Model {
 	/**
-	 * @param array $totals
-	 * @param array $taxes
-	 * @param float $total
+	 * @param \Opencart\System\Engine\Counter $counter
 	 *
 	 * @return void
 	 */
-	public function getTotal(array &$totals, array &$taxes, float &$total): void {
+	public function getTotal(\Opencart\System\Engine\Counter $counter): void {
 		if ($this->cart->hasShipping() && isset($this->session->data['shipping_method'])) {
-			$totals[] = [
+			$counter->totals[] = [
 				'extension'  => 'opencart',
 				'code'       => 'shipping',
 				'title'      => $this->session->data['shipping_method']['name'],
@@ -27,15 +25,15 @@ class Shipping extends \Opencart\System\Engine\Model {
 				$tax_rates = $this->tax->getRates($this->session->data['shipping_method']['cost'], $this->session->data['shipping_method']['tax_class_id']);
 
 				foreach ($tax_rates as $tax_rate) {
-					if (!isset($taxes[$tax_rate['tax_rate_id']])) {
-						$taxes[$tax_rate['tax_rate_id']] = $tax_rate['amount'];
+					if (!isset($counter->taxes[$tax_rate['tax_rate_id']])) {
+						$counter->taxes[$tax_rate['tax_rate_id']] = $tax_rate['amount'];
 					} else {
-						$taxes[$tax_rate['tax_rate_id']] += $tax_rate['amount'];
+						$counter->taxes[$tax_rate['tax_rate_id']] += $tax_rate['amount'];
 					}
 				}
 			}
 
-			$total += $this->session->data['shipping_method']['cost'];
+			$counter->total += $this->session->data['shipping_method']['cost'];
 		}
 	}
 }

--- a/upload/extension/opencart/catalog/model/total/sub_total.php
+++ b/upload/extension/opencart/catalog/model/total/sub_total.php
@@ -7,13 +7,11 @@ namespace Opencart\Catalog\Model\Extension\Opencart\Total;
  */
 class SubTotal extends \Opencart\System\Engine\Model {
 	/**
-	 * @param array $totals
-	 * @param array $taxes
-	 * @param float $total
+	 * @param \Opencart\System\Engine\Counter $counter
 	 *
 	 * @return void
 	 */
-	public function getTotal(array &$totals, array &$taxes, float &$total): void {
+	public function getTotal(\Opencart\System\Engine\Counter $counter): void {
 		$this->load->language('extension/opencart/total/sub_total');
 
 		$sub_total = $this->cart->getSubTotal();
@@ -24,7 +22,7 @@ class SubTotal extends \Opencart\System\Engine\Model {
 			}
 		}
 
-		$totals[] = [
+		$counter->totals[] = [
 			'extension'  => 'opencart',
 			'code'       => 'sub_total',
 			'title'      => $this->language->get('text_sub_total'),
@@ -32,6 +30,6 @@ class SubTotal extends \Opencart\System\Engine\Model {
 			'sort_order' => (int)$this->config->get('total_sub_total_sort_order')
 		];
 
-		$total += $sub_total;
+		$counter->total += $sub_total;
 	}
 }

--- a/upload/extension/opencart/catalog/model/total/tax.php
+++ b/upload/extension/opencart/catalog/model/total/tax.php
@@ -7,16 +7,14 @@ namespace Opencart\Catalog\Model\Extension\Opencart\Total;
  */
 class Tax extends \Opencart\System\Engine\Model {
 	/**
-	 * @param array $totals
-	 * @param array $taxes
-	 * @param float $total
+	 * @param \Opencart\System\Engine\Counter $counter
 	 *
 	 * @return void
 	 */
-	public function getTotal(array &$totals, array &$taxes, float &$total): void {
-		foreach ($taxes as $key => $value) {
+	public function getTotal(\Opencart\System\Engine\Counter $counter): void {
+		foreach ($counter->taxes as $key => $value) {
 			if ($value > 0) {
-				$totals[] = [
+				$counter->totals[] = [
 					'extension'  => 'opencart',
 					'code'       => 'tax',
 					'title'      => $this->tax->getRateName($key),
@@ -24,7 +22,7 @@ class Tax extends \Opencart\System\Engine\Model {
 					'sort_order' => (int)$this->config->get('total_tax_sort_order')
 				];
 
-				$total += $value;
+				$counter->total += $value;
 			}
 		}
 	}

--- a/upload/extension/opencart/catalog/model/total/total.php
+++ b/upload/extension/opencart/catalog/model/total/total.php
@@ -7,20 +7,18 @@ namespace Opencart\Catalog\Model\Extension\Opencart\Total;
  */
 class Total extends \Opencart\System\Engine\Model {
 	/**
-	 * @param array $totals
-	 * @param array $taxes
-	 * @param float $total
+	 * @param \Opencart\System\Engine\Counter $counter
 	 *
 	 * @return void
 	 */
-	public function getTotal(array &$totals, array &$taxes, float &$total): void {
+	public function getTotal(\Opencart\System\Engine\Counter $counter): void {
 		$this->load->language('extension/opencart/total/total');
 
-		$totals[] = [
+		$counter->totals[] = [
 			'extension'  => 'opencart',
 			'code'       => 'total',
 			'title'      => $this->language->get('text_total'),
-			'value'      => $total,
+			'value'      => $counter->total,
 			'sort_order' => (int)$this->config->get('total_total_sort_order')
 		];
 	}

--- a/upload/extension/opencart/catalog/model/total/voucher.php
+++ b/upload/extension/opencart/catalog/model/total/voucher.php
@@ -7,13 +7,11 @@ namespace Opencart\Catalog\Model\Extension\Opencart\Total;
  */
 class Voucher extends \Opencart\System\Engine\Model {
 	/**
-	 * @param array $totals
-	 * @param array $taxes
-	 * @param float $total
+	 * @param \Opencart\System\Engine\Counter $counter
 	 *
 	 * @return void
 	 */
-	public function getTotal(array &$totals, array &$taxes, float &$total): void {
+	public function getTotal(\Opencart\System\Engine\Counter $counter): void {
 		if (isset($this->session->data['voucher'])) {
 			$this->load->language('extension/opencart/total/voucher', 'voucher');
 
@@ -22,10 +20,10 @@ class Voucher extends \Opencart\System\Engine\Model {
 			$voucher_info = $this->model_checkout_voucher->getVoucher($this->session->data['voucher']);
 
 			if ($voucher_info) {
-				$amount = min($voucher_info['amount'], $total);
+				$amount = min($voucher_info['amount'], $counter->total);
 
 				if ($amount > 0) {
-					$totals[] = [
+					$counter->totals[] = [
 						'extension'  => 'opencart',
 						'code'       => 'voucher',
 						'title'      => sprintf($this->language->get('voucher_text_voucher'), $this->session->data['voucher']),
@@ -33,7 +31,7 @@ class Voucher extends \Opencart\System\Engine\Model {
 						'sort_order' => (int)$this->config->get('total_voucher_sort_order')
 					];
 
-					$total -= $amount;
+					$counter->total -= $amount;
 				} else {
 					unset($this->session->data['voucher']);
 				}

--- a/upload/system/engine/counter.php
+++ b/upload/system/engine/counter.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @package		OpenCart
+ *
+ * @author		Daniel Kerr
+ * @copyright	Copyright (c) 2005 - 2022, OpenCart, Ltd. (https://www.opencart.com/)
+ * @license		https://opensource.org/licenses/GPL-3.0
+ *
+ * @see		https://www.opencart.com
+ */
+namespace Opencart\System\Engine;
+/**
+ * Class Counter
+ */
+class Counter {
+	/**
+	 * @var array<string, mixed>
+	 */
+	public array $totals = [];
+	/**
+	 * @var array<int, float>
+	 */
+	public array $taxes;
+	/**
+	 * @var float
+	 */
+	public float $total = 0.0;
+
+	/**
+	 * Constructor
+	 *
+	 * @param array<int, float> $taxes
+	 */
+	public function __construct(array $taxes) {
+		$this->taxes = $taxes;
+	}
+}


### PR DESCRIPTION
Here is an implementation of using a DTO for tracking the totals rather then doing it using scaler type and having to work around limits of assigning arguments by refere, as talked about here https://github.com/opencart/opencart/pull/13410#issuecomment-1879502757

This could be a breaking change for mods that implement this function so the benefits have to be weight against that.