### PR TITLE
Fix error handeling for PHP 8.0+

### DIFF
--- a/upload/admin/controller/startup/error.php
+++ b/upload/admin/controller/startup/error.php
@@ -21,14 +21,14 @@ class Error extends \Opencart\System\Engine\Controller {
 	/**
 	 * Error
 	 *
-	 * @param string $code
+	 * @param int    $code
 	 * @param string $message
 	 * @param string $file
-	 * @param string $line
+	 * @param int    $line
 	 *
 	 * @return bool
 	 */
-	public function error(string $code, string $message, string $file, string $line): bool {
+	public function error(int $code, string $message, string $file, int $line): bool {
 		switch ($code) {
 			case E_NOTICE:
 			case E_USER_NOTICE:

--- a/upload/catalog/controller/startup/error.php
+++ b/upload/catalog/controller/startup/error.php
@@ -19,14 +19,14 @@ class Error extends \Opencart\System\Engine\Controller {
 	/**
 	 * Error
 	 *
-	 * @param string $code
+	 * @param int    $code
 	 * @param string $message
 	 * @param string $file
-	 * @param string $line
+	 * @param int    $line
 	 *
 	 * @return bool
 	 */
-	public function error(string $code, string $message, string $file, string $line): bool {
+	public function error(int $code, string $message, string $file, int $line): bool {
 		switch ($code) {
 			case E_NOTICE:
 			case E_USER_NOTICE:

--- a/upload/cron.php
+++ b/upload/cron.php
@@ -43,7 +43,7 @@ $log = new \Opencart\System\Library\Log($config->get('error_filename'));
 $registry->set('log', $log);
 
 // Error Handler
-set_error_handler(function(string $code, string $message, string $file, string $line) use ($log, $config) {
+set_error_handler(function(int $code, string $message, string $file, int $line) use ($log, $config) {
 	// error suppressed with @
 	if (@error_reporting() === 0) {
 		return false;

--- a/upload/install/cli_cloud.php
+++ b/upload/install/cli_cloud.php
@@ -52,16 +52,15 @@ $response->addHeader('Content-Type: text/plain; charset=utf-8');
 $registry->set('response', $response);
 
 set_error_handler(/**
- * @param int                  $code
- * @param string               $message
- * @param string               $file
- * @param int                  $line
- * @param array<string, mixed> $errcontext
+ * @param int    $code
+ * @param string $message
+ * @param string $file
+ * @param int    $line
  *
  * @throws \ErrorException
  *
  * @return false
- */ function($code, $message, $file, $line, array $errcontext): bool {
+ */ function(int $code, string $message, string $file, int $line): bool {
 	// error was suppressed with the @-operator
 	if (error_reporting() === 0) {
 		return false;

--- a/upload/install/cli_install.php
+++ b/upload/install/cli_install.php
@@ -79,7 +79,7 @@ $response = new \Opencart\System\Library\Response();
 $response->addHeader('Content-Type: text/plain; charset=utf-8');
 $registry->set('response', $response);
 
-set_error_handler(function($code, $message, $file, $line, array $errcontext) {
+set_error_handler(function(int $code, string $message, string $file, int $line) {
 	// error was suppressed with the @-operator
 	if (error_reporting() === 0) {
 		return false;

--- a/upload/system/framework.php
+++ b/upload/system/framework.php
@@ -31,7 +31,7 @@ $log = new \Opencart\System\Library\Log($config->get('error_filename'));
 $registry->set('log', $log);
 
 // Error Handler
-set_error_handler(function(string $code, string $message, string $file, string $line) use ($log, $config) {
+set_error_handler(function(int $code, string $message, string $file, int $line) use ($log, $config) {
 	switch ($code) {
 		case E_NOTICE:
 		case E_USER_NOTICE:


### PR DESCRIPTION
The 5th parameter was deprecated in PHP 7.2 and is unused by OC. Since it does not have a default this will also cause an error in 8.0+: https://www.php.net/manual/en/function.set-error-handler.php

![image](https://github.com/opencart/opencart/assets/204594/48716c1a-003d-45f3-93a1-e741c3442313)
