### PR TITLE
Check that rewrite() method exists before calling it

### DIFF
--- a/upload/system/library/url.php
+++ b/upload/system/library/url.php
@@ -68,7 +68,9 @@ class Url {
 		}
 
 		foreach ($this->rewrite as $rewrite) {
-			$url = $rewrite->rewrite($url);
+			if (method_exists($rewrite, 'rewrite')) {
+				$url = $rewrite->rewrite($url);
+			}
 		}
 
 		if (!$js) {


### PR DESCRIPTION
$rewrite can contain classes that do not implement a rewrite function, check that the function exists to avoid crashing on a bad extension.