### PR TITLE
Fix SEO URLs

### DIFF
--- a/upload/system/library/url.php
+++ b/upload/system/library/url.php
@@ -42,9 +42,7 @@ class Url {
 	 * @return void
 	 */
 	public function addRewrite(\Opencart\System\Engine\Controller $rewrite): void {
-		if (is_callable($rewrite, 'rewrite')) {
-			$this->rewrite[] = $rewrite;
-		}
+		$this->rewrite[] = $rewrite;
 	}
 
 	/**


### PR DESCRIPTION
The issue was introduced here because of an improper use of `is_callable()` https://github.com/opencart/opencart/commit/8e9fb071f2d52d422cc7fe2ad8c505881a95f131 (see comments on commit)