### PR TITLE
Docker Compose based developer environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '3'
+services:
+  opencart:
+    build: tools
+    user: 1000:1000
+    ports:
+      - "80:80"
+    volumes:
+      - ./upload:/var/www/html
+    depends_on:
+      - mysql
+    command: >
+      bash -c "if [ ! -f /var/www/html/install.lock ]; then
+                 wait-for-it mysql:3306 -t 60 &&
+                 cp config-dist.php config.php
+                 cp admin/config-dist.php admin/config.php
+                 php /var/www/html/install/cli_install.php install --username admin --password mexico --email email@example.com --http_server http://localhost/ --db_driver mysqli --db_hostname mysql --db_username root --db_password opencart --db_database opencart --db_port 3306 --db_prefix oc_;
+                 touch /var/www/html/install.lock;
+               fi &&
+               apache2-foreground"
+
+  mysql:
+    image: mysql:5.7
+    ports:
+      - "3306:3306"
+    environment:
+      - MYSQL_ROOT_PASSWORD=opencart
+      - MYSQL_DATABASE=opencart
+
+  redis:
+    image: redis:latest
+
+  memcached:
+    image: memcached:latest
+
+  postgres:
+    image: postgres:latest
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=opencart
+      - POSTGRES_DB=opencart

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,0 +1,16 @@
+FROM php:8.2-apache
+
+RUN apt-get update \
+  && apt-get install -y \
+                     wait-for-it \
+                     unzip \
+                     libfreetype6-dev \
+                     libjpeg62-turbo-dev \
+                     libpng-dev \
+                     libzip-dev \
+                     libcurl3-dev \
+  && docker-php-ext-configure gd --with-freetype --with-jpeg \
+  && docker-php-ext-install -j$(nproc) gd zip mysqli curl \
+  && docker-php-ext-enable gd zip mysqli curl
+
+RUN a2enmod rewrite


### PR DESCRIPTION
This fully automates the process of setting up a developer environment for testing for OC, the only requirement is that you have [Docker Compose](https://docs.docker.com/compose/install/) installed.

You will then be able to start the shop by either pressing play in Docker Desktop (or you IDE if it supports it), or by running this command `docker-compose up`.

The setup also provides a redis, memcached, and postgres server for anyone wanting to test with them.
You can use [docker-compose.override.yml](https://devilbox.readthedocs.io/en/latest/configuration-files/docker-compose-override-yml.html) to change versions of various services as well to test things on PHP 7.4 and MySQL 8.0 etc