### PR TITLE
Update log.php (Replaced string with mixed to accept array)

### DIFF
--- a/upload/system/library/log.php
+++ b/upload/system/library/log.php
@@ -30,11 +30,11 @@ class Log {
 	/**
 	 * Write
 	 *
-	 * @param string $message
+	 * @param mixed $message
 	 *
 	 * @return void
 	 */
-	public function write(string $message): void {
+	public function write(mixed $message): void {
 		file_put_contents($this->file, date('Y-m-d H:i:s') . ' - ' . print_r($message, true) . "\n", FILE_APPEND);
 	}
 }

--- a/upload/system/library/log.php
+++ b/upload/system/library/log.php
@@ -34,7 +34,7 @@ class Log {
 	 *
 	 * @return void
 	 */
-	public function write(mixed $message): void {
+	public function write($message): void {
 		file_put_contents($this->file, date('Y-m-d H:i:s') . ' - ' . print_r($message, true) . "\n", FILE_APPEND);
 	}
 }


### PR DESCRIPTION
With commit [https://github.com/opencart/opencart/commit/6440e653694b92da4c3fa7ead794bd915f6995ec](https://github.com/opencart/opencart/commit/6440e653694b92da4c3fa7ead794bd915f6995ec) made on Oct 14, 2023,  
`$this->log->write()` method no longer support _'array'_
However, it is required to add error log with **arrays** also.

so replaced 'string' type with 'mixed' type for `write()` method, so as it can support string as well as array