### PR TITLE
Correctly create subscription from Opayo

### DIFF
--- a/upload/extension/opencart/catalog/model/payment/opayo.php
+++ b/upload/extension/opencart/catalog/model/payment/opayo.php
@@ -266,7 +266,7 @@ class Opayo extends \Opencart\System\Engine\Model {
 		$item['subscription']['description'] = $subscription_description;
 
 		// Create new subscription and set to pending status as no payment has been made yet.
-		$subscription_id = $this->model_checkout_subscription->addSubscription($this->session->data['order_id'], $item['subscription']);
+		$subscription_id = $this->model_checkout_subscription->addSubscription(['order_id' => $this->session->data['order_id']] + $item['subscription']);
 
 		$this->model_checkout_subscription->editReference($subscription_id, $vendor_tx_code);
 


### PR DESCRIPTION
`order_id` should be an array element, not a separate argument:

https://github.com/opencart/opencart/blob/16951fba3886c7a7d241fecac9ee5a7533c800a4/upload/catalog/model/checkout/subscription.php#L16