### PR TITLE
Fix Opayo::calculateSchedule()

### DIFF
--- a/upload/extension/opencart/catalog/model/payment/opayo.php
+++ b/upload/extension/opencart/catalog/model/payment/opayo.php
@@ -474,16 +474,14 @@ class Opayo extends \Opencart\System\Engine\Model {
 	 *
 	 * @param string    $frequency
 	 * @param \Datetime $next_payment
-	 * @param string    $cycle
+	 * @param int       $cycle
 	 *
 	 * @return \Datetime
 	 */
-	private function calculateSchedule(string $frequency, string $next_payment, string $cycle) {
+	private function calculateSchedule(string $frequency, \DateTime $next_payment, int $cycle) {
+		$next_payment = clone $next_payment;
 		if ($frequency == 'semi_month') {
-			// https://stackoverflow.com/a/35473574
-			$day = date_create_from_format('j M, Y', $next_payment->date);
-			$day = date_create($day);
-			$day = date_format($day, 'd');
+			$day = $next_payment->format('d');
 			$value = 15 - $day;
 			$is_even = false;
 


### PR DESCRIPTION
The signature of `calculateSchedule()` was was causing `$next_payment` to be cast to a string which was worked around with some string parsing, but the function would still fail when trying to call `->modify()` and so would any function that tried to use the return value.
Also `$cycle` should have been an `int` and not a string.