### PR TITLE
Only process currencies if there are more then one

### DIFF
--- a/upload/extension/opencart/admin/controller/currency/ecb.php
+++ b/upload/extension/opencart/admin/controller/currency/ecb.php
@@ -116,7 +116,7 @@ class ECB extends \Opencart\System\Engine\Controller {
 					$value = $currencies['EUR'];
 				}
 
-				if ($currencies) {
+				if (count($currencies) > 1) {
 					$this->load->model('localisation/currency');
 
 					$results = $this->model_localisation_currency->getCurrencies();

--- a/upload/extension/opencart/catalog/controller/currency/ecb.php
+++ b/upload/extension/opencart/catalog/controller/currency/ecb.php
@@ -42,7 +42,7 @@ class ECB extends \Opencart\System\Engine\Controller {
 					}
 				}
 
-				if ($currencies) {
+				if (count($currencies) > 1) {
 					$this->load->model('localisation/currency');
 
 					$results = $this->model_localisation_currency->getCurrencies();


### PR DESCRIPTION
The check would always trigger as the table would always contain `EUR => 1`, instead only run the conversion if more then one currency conversion is known.