### PR TITLE
Remove redundant check for registry

### DIFF
--- a/upload/system/library/session.php
+++ b/upload/system/library/session.php
@@ -36,12 +36,7 @@ class Session {
 		$class = 'Opencart\System\Library\Session\\' . $adaptor;
 
 		if (class_exists($class)) {
-			if ($registry) {
-				$this->adaptor = new $class($registry);
-			} else {
-				$this->adaptor = new $class();
-			}
-
+			$this->adaptor = new $class($registry);
 			register_shutdown_function([&$this, 'close']);
 			register_shutdown_function([&$this, 'gc']);
 		} else {


### PR DESCRIPTION
$registry is not nullable so will always be provided, no need to check if it was.