### PR TITLE
Remove redundant check on request->get

### DIFF
--- a/upload/admin/controller/common/login.php
+++ b/upload/admin/controller/common/login.php
@@ -61,9 +61,7 @@ class Login extends \Opencart\System\Engine\Controller {
 
 			$url = '';
 
-			if ($this->request->get) {
-				$url .= http_build_query($args);
-			}
+			$url .= http_build_query($args);
 
 			$data['redirect'] = $this->url->link($route, $url);
 		} else {


### PR DESCRIPTION
This section is already guarded by a `isset($this->request->get['route'])` check, so this will always be true.