### PR TITLE
Filter empty result from explode()

### DIFF
--- a/upload/admin/model/sale/order.php
+++ b/upload/admin/model/sale/order.php
@@ -565,6 +565,7 @@ class Order extends \Opencart\System\Engine\Model {
 			$implode = [];
 
 			$order_statuses = explode(',', $data['filter_order_status']);
+			$order_statuses = array_filter($order_statuses);
 
 			foreach ($order_statuses as $order_status_id) {
 				$implode[] = "`order_status_id` = '" . (int)$order_status_id . "'";

--- a/upload/catalog/model/cms/article.php
+++ b/upload/catalog/model/cms/article.php
@@ -33,6 +33,7 @@ class Article extends \Opencart\System\Engine\Model {
 			$implode = [];
 
 			$words = explode(' ', trim(preg_replace('/\s+/', ' ', $data['filter_search'])));
+			$words = array_filter($words);
 
 			foreach ($words as $word) {
 				$implode[] = "`ad`.`name` LIKE '" . $this->db->escape('%' . $word . '%') . "'";
@@ -123,6 +124,7 @@ class Article extends \Opencart\System\Engine\Model {
 			$implode = [];
 
 			$words = explode(' ', trim(preg_replace('/\s+/', ' ', $data['filter_search'])));
+			$words = array_filter($words);
 
 			foreach ($words as $word) {
 				$implode[] = "`ad`.`name` LIKE '" . $this->db->escape('%' . $word . '%') . "'";


### PR DESCRIPTION
The result of explode() is always true as even empty values will result in at least once string pice

`explode(',', null) === [''] == true`

But we can use array_filter() to remove empty elements which would result in an empty array instead and have the later operations and checks on the result behave as intended.