### PR TITLE
Fix check for imag type

### DIFF
--- a/upload/system/library/image.php
+++ b/upload/system/library/image.php
@@ -185,7 +185,7 @@ class Image {
 			$scale = min($scale_w, $scale_h);
 		}
 
-		if ($scale == 1 && $scale_h == $scale_w && ($this->mime != 'image/png' || $this->mime != 'image/webp')) {
+		if ($scale == 1 && $scale_h == $scale_w && !in_array($this->mime, ['image/png', 'image/webp'])) {
 			return;
 		}
 


### PR DESCRIPTION
The logic here is incorrect, a string will always be different from at least one of two others.

The intent here appears to make sure that it is at least one of the two, for which it should have been `&&` instead of `||`, but to simplify the logic and make it more extensive (and shorter) I have switched it to use an `in_array()` check instead.

This was broken here, and was actually correct before the change: https://github.com/opencart/opencart/commit/5d361b97932b77a6ac9dc2321c4f3354bc16d292