### PR TITLE
Remove redundant checks in authorize

### DIFF
--- a/upload/admin/controller/startup/authorize.php
+++ b/upload/admin/controller/startup/authorize.php
@@ -47,7 +47,7 @@ class Authorize extends \Opencart\System\Engine\Controller {
 				return new \Opencart\System\Engine\Action('common/authorize');
 			}
 
-			if ($token_info && !$token_info['status'] && $token_info['attempts'] > 2) {
+			if (!$token_info['status'] && $token_info['attempts'] > 2) {
 				return new \Opencart\System\Engine\Action('common/authorize.unlock');
 			}
 		}

--- a/upload/catalog/controller/startup/authorize.php
+++ b/upload/catalog/controller/startup/authorize.php
@@ -45,7 +45,7 @@ class Authorize extends \Opencart\System\Engine\Controller {
 				return new \Opencart\System\Engine\Action('common/authorize');
 			}
 
-			if ($token_info && !$token_info['status'] && $token_info['attempts'] > 2) {
+			if (!$token_info['status'] && $token_info['attempts'] > 2) {
 				return new \Opencart\System\Engine\Action('common/authorize.unlock');
 			}
 		}


### PR DESCRIPTION
`$token_info` has already been checked not to be empty on the previous clause.