### PR TITLE
Improve check for wrapper

### DIFF
--- a/upload/admin/controller/sale/order.php
+++ b/upload/admin/controller/sale/order.php
@@ -886,10 +886,11 @@ class Order extends \Opencart\System\Engine\Controller {
 
 			foreach ($order_totals as $order_total) {
 				// If coupon, voucher or reward points
-				$start = strpos($order_total['title'], '(') + 1;
+				$start = strpos($order_total['title'], '(');
 				$end = strrpos($order_total['title'], ')');
 
-				if ($start && $end) {
+				if ($start !== false && $end !== false) {
+					$start++;
 					$data['total_' . $order_total['code']] = substr($order_total['title'], $start, $end - $start);
 				}
 			}

--- a/upload/catalog/controller/api/sale/order.php
+++ b/upload/catalog/controller/api/sale/order.php
@@ -161,10 +161,11 @@ class Order extends \Opencart\System\Engine\Controller {
 
 			foreach ($order_totals as $order_total) {
 				// If coupon, voucher or reward points
-				$start = strpos($order_total['title'], '(') + 1;
+				$start = strpos($order_total['title'], '(');
 				$end = strrpos($order_total['title'], ')');
 
-				if ($start && $end) {
+				if ($start !== false && $end !== false) {
+					$start++;
 					$this->session->data[$order_total['code']] = substr($order_total['title'], $start, $end - $start);
 				}
 			}

--- a/upload/extension/opencart/catalog/model/total/coupon.php
+++ b/upload/extension/opencart/catalog/model/total/coupon.php
@@ -115,10 +115,11 @@ class Coupon extends \Opencart\System\Engine\Model {
 	public function confirm(array $order_info, array $order_total): int {
 		$code = '';
 
-		$start = strpos($order_total['title'], '(') + 1;
+		$start = strpos($order_total['title'], '(');
 		$end = strrpos($order_total['title'], ')');
 
-		if ($start && $end) {
+		if ($start !== false && $end !== false) {
+			$start++;
 			$code = substr($order_total['title'], $start, $end - $start);
 		}
 

--- a/upload/extension/opencart/catalog/model/total/reward.php
+++ b/upload/extension/opencart/catalog/model/total/reward.php
@@ -76,10 +76,11 @@ class Reward extends \Opencart\System\Engine\Model {
 
 		$points = 0.0;
 
-		$start = strpos($order_total['title'], '(') + 1;
+		$start = strpos($order_total['title'], '(');
 		$end = strrpos($order_total['title'], ')');
 
-		if ($start && $end) {
+		if ($start !== false && $end !== false) {
+			$start++;
 			$points = (float)substr($order_total['title'], $start, $end - $start);
 		}
 

--- a/upload/extension/opencart/catalog/model/total/voucher.php
+++ b/upload/extension/opencart/catalog/model/total/voucher.php
@@ -52,10 +52,11 @@ class Voucher extends \Opencart\System\Engine\Model {
 	public function confirm(array $order_info, array $order_total): int {
 		$code = '';
 
-		$start = strpos($order_total['title'], '(') + 1;
+		$start = strpos($order_total['title'], '(');
 		$end = strrpos($order_total['title'], ')');
 
-		if ($start && $end) {
+		if ($start !== false && $end !== false) {
+			$start++;
 			$code = substr($order_total['title'], $start, $end - $start);
 		}
 


### PR DESCRIPTION
The `+ 1` would result in `$start` always being true in the following check. Instead check for a none false value and only increase $start after.