### PR TITLE
Remove redundant check in payment_method::comment()

### DIFF
--- a/upload/catalog/controller/checkout/payment_method.php
+++ b/upload/catalog/controller/checkout/payment_method.php
@@ -191,27 +191,23 @@ class PaymentMethod extends \Opencart\System\Engine\Controller {
 	public function comment(): void {
 		$this->load->language('checkout/payment_method');
 
-		$json = [];
-
 		if (isset($this->session->data['order_id'])) {
 			$order_id = (int)$this->session->data['order_id'];
 		} else {
 			$order_id = 0;
 		}
 
-		if (!$json) {
-			$this->session->data['comment'] = $this->request->post['comment'];
+		$this->session->data['comment'] = $this->request->post['comment'];
 
-			$this->load->model('checkout/order');
+		$this->load->model('checkout/order');
 
-			$order_info = $this->model_checkout_order->getOrder($order_id);
+		$order_info = $this->model_checkout_order->getOrder($order_id);
 
-			if ($order_info) {
-				$this->model_checkout_order->editComment($order_id, $this->request->post['comment']);
-			}
-
-			$json['success'] = $this->language->get('text_comment');
+		if ($order_info) {
+			$this->model_checkout_order->editComment($order_id, $this->request->post['comment']);
 		}
+
+		$json = ['success' => $this->language->get('text_comment')];
 
 		$this->response->addHeader('Content-Type: application/json');
 		$this->response->setOutput(json_encode($json));


### PR DESCRIPTION
There is nothing that will populate $json, so no need to check it