### PR TITLE
Fix Tax::calculate()

### DIFF
--- a/upload/system/library/cart/tax.php
+++ b/upload/system/library/cart/tax.php
@@ -98,13 +98,13 @@ class Tax {
 	/**
 	 * Calculate
 	 *
-	 * @param float $value
-	 * @param int   $tax_class_id
-	 * @param bool  $calculate
+	 * @param float       $value
+	 * @param int         $tax_class_id
+	 * @param bool|string $calculate
 	 *
 	 * @return float
 	 */
-	public function calculate(float $value, int $tax_class_id, bool $calculate = true): float {
+	public function calculate(float $value, int $tax_class_id, $calculate = true): float {
 		if ($tax_class_id && $calculate) {
 			$amount = 0;
 


### PR DESCRIPTION
The $calculate value can either be a string (like `P` or `F`, but probably also other values), `true`, or `false`. But the signature had been changed to limit it to `bool` types. This would result in the function to never skip unmatched P or F types.

Issue introduced here: https://github.com/opencart/opencart/commit/977710c5ba995d49261f20273e971482c584970b