### PR TITLE
Remove redundant check for debug config

### DIFF
--- a/upload/system/library/template/twig.php
+++ b/upload/system/library/template/twig.php
@@ -112,9 +112,7 @@ class Twig {
 
 			$twig = new \Twig\Environment($loader, $config);
 
-			if ($config['debug']) {
-				$twig->addExtension(new \Twig\Extension\DebugExtension());
-			}
+			$twig->addExtension(new \Twig\Extension\DebugExtension());
 
 			return $twig->render($file, $data);
 		} catch (\Twig\Error\SyntaxError $e) {


### PR DESCRIPTION
The debug parameter is set top true right above so there is no need to check this here.