### PR TITLE
Fix check for image type

### DIFF
--- a/upload/system/library/image.php
+++ b/upload/system/library/image.php
@@ -185,7 +185,7 @@ class Image {
 			$scale = min($scale_w, $scale_h);
 		}
 
-		if ($scale == 1 && $scale_h == $scale_w && ($this->mime != 'image/png' || $this->mime != 'image/webp')) {
+		if ($scale == 1 && $scale_h == $scale_w && ($this->mime != 'image/png' && $this->mime != 'image/webp')) {
 			return;
 		}
 


### PR DESCRIPTION
This code was wrong and would always result in true:

`('image/png' != 'image/png' || 'image/png' != 'image/webp')`

There is no value you can set `$this->mime` to that would ever result in the expression evaluating to false since it will always be unequal the first or second value.