### PR TITLE
Accept type forced to bool

### DIFF
--- a/upload/system/library/cart/tax.php
+++ b/upload/system/library/cart/tax.php
@@ -111,11 +111,7 @@ class Tax {
 			$tax_rates = $this->getRates($value, $tax_class_id);
 
 			foreach ($tax_rates as $tax_rate) {
-				if ($calculate != 'P' && $calculate != 'F') {
-					$amount += $tax_rate['amount'];
-				} elseif ($tax_rate['type'] == $calculate) {
-					$amount += $tax_rate['amount'];
-				}
+				$amount += $tax_rate['amount'];
 			}
 
 			return $value + $amount;


### PR DESCRIPTION
Since $calculate is being forced to a boolean and both branches here are the same, only in the event that the value is false and $tax_rate['type'] is an empty string would it skip both branches. Since a none strict compare will match true and any none empty non-zero string.

Note: I'm not in favor of this, but it appears the only other solution based on the comment here: https://github.com/opencart/opencart/pull/13512