### PR TITLE
Emmit error on unknown position

### DIFF
--- a/upload/system/library/image.php
+++ b/upload/system/library/image.php
@@ -270,6 +270,8 @@ class Image {
 				$watermark_pos_x = ($this->width - $watermark->getWidth());
 				$watermark_pos_y = ($this->height - $watermark->getHeight());
 				break;
+			default:
+				throw new \Exception('Unknown position');
 		}
 
 		imagealphablending($this->image, true);


### PR DESCRIPTION
Emit an exception if `watermark()` is being used incorrectly, previously it would have acted the same as if `topleft` had been selected, possibly with error notices in the output, which may have broken the image if sent directly to the output.