### PR TITLE
Simplify getting URL key value

### DIFF
--- a/upload/catalog/controller/startup/seo_url.php
+++ b/upload/catalog/controller/startup/seo_url.php
@@ -86,15 +86,8 @@ class SeoUrl extends \Opencart\System\Engine\Controller {
 		foreach ($parts as $part) {
 			$pair = explode('=', $part);
 
-			if (isset($pair[0])) {
-				$key = (string)$pair[0];
-			}
-
-			if (isset($pair[1])) {
-				$value = (string)$pair[1];
-			} else {
-				$value = '';
-			}
+			$key = $pair[0];
+			$value = $pair[1] ?? '';
 
 			$result = $this->model_design_seo_url->getSeoUrlByKeyValue((string)$key, (string)$value);
 


### PR DESCRIPTION
`$pair` will always contain at least one element (the full $part value as a string if there is no = present).

Also we can use null coalescing to also simplify the value part. 