### PR TITLE
Fix dropping primary key when upgrading

### DIFF
--- a/upload/install/controller/upgrade/upgrade_3.php
+++ b/upload/install/controller/upgrade/upgrade_3.php
@@ -119,7 +119,7 @@ class Upgrade3 extends \Opencart\System\Engine\Controller {
 					}
 
 					foreach ($keys as $key) {
-						if ($result['Key_name'] == 'PRIMARY') {
+						if ($key == 'PRIMARY') {
 							$this->db->query("ALTER TABLE `" . DB_PREFIX . $table['name'] . "` DROP PRIMARY KEY");
 						} else {
 							$this->db->query("ALTER TABLE `" . DB_PREFIX . $table['name'] . "` DROP INDEX `" . $key . "`");


### PR DESCRIPTION
$result['Key_name'] is gathered in the previous step, so this would only evaluate correctly if there is only one key and it is the last result.