### PR TITLE
Fix time for quickly dipslayed notifications

### DIFF
--- a/upload/admin/controller/tool/notification.php
+++ b/upload/admin/controller/tool/notification.php
@@ -92,6 +92,9 @@ class Notification extends \Opencart\System\Engine\Controller {
 				'year'   => floor($second / 31556926)
 			];
 
+			$date_added = 0;
+			$code = 'seconds';
+
 			foreach ($ranges as $range => $value) {
 				if ($value) {
 					$date_added = $value;


### PR DESCRIPTION
If less then 1 sec has passed the values would not be set, so set defaults for that case.