### PR TITLE
Fix plural form in notifications

### DIFF
--- a/upload/admin/controller/tool/notification.php
+++ b/upload/admin/controller/tool/notification.php
@@ -95,7 +95,7 @@ class Notification extends \Opencart\System\Engine\Controller {
 			foreach ($ranges as $range => $value) {
 				if ($value) {
 					$date_added = $value;
-					$code = $range . ($value > 1) ? $range . 's' : '';
+					$code = ($value > 1) ? $range . 's' : $range;
 				}
 			}
 


### PR DESCRIPTION
Since `.` takes precedence over `?` the code would execute as:
```php
					$code = ($range . ($value > 1)) ? ($range . 's') : '';
```

Meaning it would always return the plural form.

This was introduced here https://github.com/opencart/opencart/commit/b5884f048e1c38b38fb6c87759da7c3b26e4bd10 and improperly fixed here https://github.com/opencart/opencart/commit/d61ea04a79904a68c56bb4968e531cd5132ca908 despite the issue being pointed out https://github.com/opencart/opencart/pull/13121#pullrequestreview-1785429347