### PR TITLE
[3.0.x.x] Hint classes loaded during framework bootup

### DIFF
--- a/upload/system/engine/controller.php
+++ b/upload/system/engine/controller.php
@@ -9,6 +9,8 @@
 
 /**
 * Controller class
+ *
+ * @mixin Registry
 */
 abstract class Controller {
 	protected $registry;

--- a/upload/system/engine/model.php
+++ b/upload/system/engine/model.php
@@ -9,6 +9,8 @@
 
 /**
 * Model class
+ *
+ * @mixin Registry
 */
 abstract class Model {
 	protected $registry;

--- a/upload/system/engine/proxy.php
+++ b/upload/system/engine/proxy.php
@@ -9,6 +9,10 @@
 
 /**
 * Proxy class
+ *
+ * @template TWraps of Model
+ *
+ * @mixin TWraps
 */
 class Proxy extends \stdClass {
     /**

--- a/upload/system/engine/registry.php
+++ b/upload/system/engine/registry.php
@@ -9,9 +9,46 @@
 
 /**
 * Registry class
+ *
+ * @property Cache                         $cache
+ * @property Cart\Cart                     $cart
+ * @property Cart\Currency                 $currency
+ * @property Cart\Customer                 $customer
+ * @property Cart\Length                   $length
+ * @property Cart\Tax                      $tax
+ * @property ?Cart\User                    $user
+ * @property Cart\Weight                   $weight
+ * @property Config                        $config
+ * @property Config                        $setting
+ * @property DB                            $db
+ * @property Document                      $document
+ * @property Encryption                    $encryption
+ * @property Event                         $event
+ * @property googleshopping\Googleshopping $googleshopping
+ * @property Language                      $language
+ * @property Loader                        $load
+ * @property Log                           $log
+ * @property Request                       $request
+ * @property Response                      $response
+ * @property Session                       $session
+ * @property ?Squareup                     $squareup
+ * @property Url                           $url
 */
 final class Registry {
 	private $data = array();
+
+	/**
+	 * __get
+	 *
+	 * https://www.php.net/manual/en/language.oop5.overloading.php#object.get
+	 *
+	 * @param string $key
+	 *
+	 * @return ?object
+	 */
+	public function __get(string $key): ?object {
+		return $this->get($key);
+	}
 
 	/**
      * 


### PR DESCRIPTION
This lets PHPStan better reason about object relations in OC.

This works by using `@mixin`to document that the `Controller`, `Model`, and `Proxy` class has magic properties where for any none local will fetch them from the `Registry`, and there for allows calling it's properties directly on them.
And of cause document the classes that are commonly loaded into the registry during startup.