### PR TITLE
Fix getting error messages for pgsql

### DIFF
--- a/upload/system/library/db/pgsql.php
+++ b/upload/system/library/db/pgsql.php
@@ -51,7 +51,7 @@ class PgSQL {
 		$resource = pg_query($this->connection, $sql);
 
 		if ($resource === false) {
-			throw new \Exception('Error: ' . pg_result_error($resource) . '<br/>' . $sql);
+			throw new \Exception('Error: ' . pg_last_error($this->connection) . '<br/>' . $sql);
 		}
 
 		$data = [];


### PR DESCRIPTION
There isn't a proper context to give `pg_result_error()` when `pg_query()` fails, see https://www.php.net/manual/en/function.pg-result-error.php