### PR TITLE
Correct type of arguments given to md5

### DIFF
--- a/upload/system/library/mail/mail.php
+++ b/upload/system/library/mail/mail.php
@@ -38,7 +38,7 @@ class Mail {
 			$eol = PHP_EOL;
 		}
 
-		$boundary = '----=_NextPart_' . md5(time());
+		$boundary = '----=_NextPart_' . md5((string)time());
 
 		$header  = 'MIME-Version: 1.0' . $eol;
 		$header .= 'Date: ' . date('D, d M Y H:i:s O') . $eol;

--- a/upload/system/library/mail/smtp.php
+++ b/upload/system/library/mail/smtp.php
@@ -68,7 +68,7 @@ class Smtp {
 			$to = $this->option['to'];
 		}
 
-		$boundary = '----=_NextPart_' . md5(time());
+		$boundary = '----=_NextPart_' . md5((string)time());
 
 		$header = 'MIME-Version: 1.0' . PHP_EOL;
 		$header .= 'To: <' . $to . '>' . PHP_EOL;


### PR DESCRIPTION
md5() expects a string, time() returns an int.