### PR TITLE
Correct port type for mysqli

### DIFF
--- a/upload/system/library/db/mysqli.php
+++ b/upload/system/library/db/mysqli.php
@@ -18,14 +18,14 @@ class MySQLi {
 	 * @param string $username
 	 * @param string $password
 	 * @param string $database
-	 * @param string $port
+	 * @param int    $port
 	 * @param string $ssl_key
 	 * @param string $ssl_cert
 	 * @param string $ssl_ca
 	 */
-	public function __construct(string $hostname, string $username, string $password, string $database, string $port = '', string $ssl_key = '', string $ssl_cert = '', string $ssl_ca = '') {
+	public function __construct(string $hostname, string $username, string $password, string $database, int $port = 0, string $ssl_key = '', string $ssl_cert = '', string $ssl_ca = '') {
 		if (!$port) {
-			$port = '3306';
+			$port = 3306;
 		}
 
 		// MSQL SSL connection


### PR DESCRIPTION
real_connect() expects the port to be an int and not a string.