### PR TITLE
Remove incorect input for readfile()

### DIFF
--- a/upload/admin/controller/catalog/download.php
+++ b/upload/admin/controller/catalog/download.php
@@ -547,7 +547,7 @@ class Download extends \Opencart\System\Engine\Controller {
 				header('Pragma: public');
 				header('Content-Length: ' . filesize($file));
 
-				readfile($file, 'rb');
+				readfile($file);
 				exit;
 			} else {
 				exit($this->language->get('error_headers_sent'));

--- a/upload/admin/controller/tool/backup.php
+++ b/upload/admin/controller/tool/backup.php
@@ -413,7 +413,7 @@ class Backup extends \Opencart\System\Engine\Controller {
 				ob_end_clean();
 			}
 
-			readfile($file, 'rb');
+			readfile($file);
 
 			exit();
 		} else {

--- a/upload/admin/controller/tool/upload.php
+++ b/upload/admin/controller/tool/upload.php
@@ -308,7 +308,7 @@ class Upload extends \Opencart\System\Engine\Controller {
 					header('Pragma: public');
 					header('Content-Length: ' . filesize($file));
 
-					readfile($file, 'rb');
+					readfile($file);
 					exit;
 				} else {
 					exit(sprintf($this->language->get('error_not_found'), basename($file)));

--- a/upload/catalog/controller/account/download.php
+++ b/upload/catalog/controller/account/download.php
@@ -146,7 +146,7 @@ class Download extends \Opencart\System\Engine\Controller {
 						ob_end_clean();
 					}
 
-					readfile($file, 'rb');
+					readfile($file);
 
 					$this->model_account_download->addReport($download_id, $this->request->server['REMOTE_ADDR']);
 


### PR DESCRIPTION
This looks like someone thought readfile() takes the same arguments as fopen(), but that is not the case: https://www.php.net/manual/en/function.readfile.php