### PR TITLE
Correct types given to mkdir()

### DIFF
--- a/upload/install/controller/upgrade/upgrade_1.php
+++ b/upload/install/controller/upgrade/upgrade_1.php
@@ -362,7 +362,7 @@ class Upgrade1 extends \Opencart\System\Engine\Controller {
 
 		foreach ($directories as $directory) {
 			if (!is_dir($storage . $directory)) {
-				mkdir($storage . $directory, '0644');
+				mkdir($storage . $directory, 0644);
 
 				$handle = fopen($storage . $directory . '/index.html', 'w');
 


### PR DESCRIPTION
secound argument of mkdir() should be an int and not a string: https://www.php.net/manual/en/function.mkdir.php