### PR TITLE
Fix missing paramter when calling cart->add() in cron subscription

### DIFF
--- a/upload/catalog/controller/cron/subscription.php
+++ b/upload/catalog/controller/cron/subscription.php
@@ -90,7 +90,7 @@ class Subscription extends \Opencart\System\Engine\Controller {
 							$price = $result['trial_price'];
 						}
 
-						$store->cart->add($result['product_id'], $result['quantity'], $result['option'], $result['subscription_plan_id'], $price);
+						$store->cart->add($result['product_id'], $result['quantity'], $result['option'], $result['subscription_plan_id'], true, $price);
 					} else {
 						$error = $this->language->get('error_product');
 					}

--- a/upload/catalog/controller/cron/subscription.php
+++ b/upload/catalog/controller/cron/subscription.php
@@ -90,7 +90,7 @@ class Subscription extends \Opencart\System\Engine\Controller {
 							$price = $result['trial_price'];
 						}
 
-						$store->cart->add($result['product_id'], $result['quantity'], $result['option'], true, $price);
+						$store->cart->add($result['product_id'], $result['quantity'], $result['option'], $result['subscription_plan_id'], $price);
 					} else {
 						$error = $this->language->get('error_product');
 					}


### PR DESCRIPTION
4th argument should be subscription_plan_id:

https://github.com/opencart/opencart/blob/406a3fe1133856ff9ec16df153ac8d085fa0ac37/upload/system/library/cart/cart.php#L373