### PR TITLE
Do not escape integer

### DIFF
--- a/upload/catalog/model/localisation/currency.php
+++ b/upload/catalog/model/localisation/currency.php
@@ -28,7 +28,7 @@ class Currency extends \Opencart\System\Engine\Model {
 	 * @return array<string, mixed>
 	 */
 	public function getCurrency(int $currency_id): array {
-		$query = $this->db->query("SELECT DISTINCT * FROM `" . DB_PREFIX . "currency` WHERE `currency_id` = '" . $this->db->escape($currency_id) . "'");
+		$query = $this->db->query("SELECT DISTINCT * FROM `" . DB_PREFIX . "currency` WHERE `currency_id` = '" . $currency_id . "'");
 
 		return $query->row;
 	}


### PR DESCRIPTION
Since it is known to be an int we do not need to escape it. The same pattern is followed everywhere else