### PR TITLE
Remove redundant ceil() calls

### DIFF
--- a/upload/extension/opencart/catalog/controller/captcha/basic.php
+++ b/upload/extension/opencart/catalog/controller/captcha/basic.php
@@ -48,9 +48,9 @@ class Basic extends \Opencart\System\Engine\Controller {
 		$blue   = imagecolorallocatealpha($image, 0, 0, 255, 75);
 
 		imagefilledrectangle($image, 0, 0, $width, $height, $white);
-		imagefilledellipse($image, ceil(mt_rand(5, 145)), ceil(mt_rand(0, 35)), 30, 30, $red);
-		imagefilledellipse($image, ceil(mt_rand(5, 145)), ceil(mt_rand(0, 35)), 30, 30, $green);
-		imagefilledellipse($image, ceil(mt_rand(5, 145)), ceil(mt_rand(0, 35)), 30, 30, $blue);
+		imagefilledellipse($image, mt_rand(5, 145), mt_rand(0, 35), 30, 30, $red);
+		imagefilledellipse($image, mt_rand(5, 145), mt_rand(0, 35), 30, 30, $green);
+		imagefilledellipse($image, mt_rand(5, 145), mt_rand(0, 35), 30, 30, $blue);
 		imagefilledrectangle($image, 0, 0, $width, 0, $black);
 		imagefilledrectangle($image, $width - 1, 0, $width - 1, $height - 1, $black);
 		imagefilledrectangle($image, 0, 0, 0, $height - 1, $black);


### PR DESCRIPTION
mt_rand() will always return an int so nothing to rund: https://www.php.net/manual/en/function.mt-rand.php