### PR TITLE
Fix HTTP response status codes on download

### DIFF
--- a/upload/catalog/controller/account/download.php
+++ b/upload/catalog/controller/account/download.php
@@ -122,7 +122,7 @@ class Download extends \Opencart\System\Engine\Controller {
 		if (!$this->customer->isLogged() || (!isset($this->request->get['customer_token']) || !isset($this->session->data['customer_token']) || ($this->request->get['customer_token'] != $this->session->data['customer_token']))) {
 			$this->session->data['redirect'] = $this->url->link('account/download', 'language=' . $this->config->get('config_language'));
 
-			$this->response->redirect($this->url->link('account/login', 'language=' . $this->config->get('config_language')), true);
+			$this->response->redirect($this->url->link('account/login', 'language=' . $this->config->get('config_language')));
 		}
 
 		$this->load->model('account/download');


### PR DESCRIPTION
The secound argument is the HTTP redirect code, true would have resulted in a 1 as the redirect code, leaving it out defaults to a 302