### PR TITLE
Use a closure when assining the autoloader

### DIFF
--- a/upload/system/engine/autoloader.php
+++ b/upload/system/engine/autoloader.php
@@ -22,7 +22,7 @@ class Autoloader {
 	 * Constructor
 	 */
 	public function __construct() {
-		spl_autoload_register([$this, 'load']);
+		spl_autoload_register(function(string $class): void { $this->load($class); });
 		spl_autoload_extensions('.php');
 	}
 


### PR DESCRIPTION
This makes sure that the signature matches the expectation