### PR TITLE
Remove space from returns_form.twig

### DIFF
--- a/upload/catalog/view/template/account/returns_form.twig
+++ b/upload/catalog/view/template/account/returns_form.twig
@@ -2,7 +2,7 @@
 <div id="account-return" class="container">
   <ul class="breadcrumb">
     {% for breadcrumb in breadcrumbs %}
-      <li class="breadcrumb-item"><a href="{{ breadcrumb.href }}"> {{ breadcrumb.text }}</a></li>
+      <li class="breadcrumb-item"><a href="{{ breadcrumb.href }}">{{ breadcrumb.text }}</a></li>
     {% endfor %}
   </ul>
   <div class="row">{{ column_left }}


### PR DESCRIPTION
Remove space from the breadcrumb line in order to be the same with the other .twig files in account folder.