### PR TITLE
Email IDN validation

### DIFF
--- a/upload/admin/controller/customer/customer.php
+++ b/upload/admin/controller/customer/customer.php
@@ -672,7 +672,7 @@ class Customer extends \Opencart\System\Engine\Controller {
 			$json['error']['lastname'] = $this->language->get('error_lastname');
 		}
 
-		if ((oc_strlen($this->request->post['email']) > 96) || !filter_var($this->request->post['email'], FILTER_VALIDATE_EMAIL)) {
+		if ((oc_strlen($this->request->post['email']) > 96) || !oc_filter_email($this->request->post['email'])) {
 			$json['error']['email'] = $this->language->get('error_email');
 		}
 

--- a/upload/admin/controller/mail/authorize.php
+++ b/upload/admin/controller/mail/authorize.php
@@ -33,7 +33,7 @@ class Authorize extends \Opencart\System\Engine\Controller {
 			$code = '';
 		}
 
-		if ($email && $code && ($route == 'common/authorize.send') && filter_var($email, FILTER_VALIDATE_EMAIL)) {
+		if ($email && $code && ($route == 'common/authorize.send') && oc_filter_email($email)) {
 			$this->load->language('mail/authorize');
 
 			$data['username'] = $this->user->getUsername();
@@ -94,7 +94,7 @@ class Authorize extends \Opencart\System\Engine\Controller {
 			$code = '';
 		}
 
-		if ($email && $code && ($route == 'common/authorize.confirm') && filter_var($email, FILTER_VALIDATE_EMAIL)) {
+		if ($email && $code && ($route == 'common/authorize.confirm') && oc_filter_email($email)) {
 			$this->load->language('mail/authorize_reset');
 
 			$data['username'] = $this->user->getUsername();

--- a/upload/admin/controller/mail/forgotten.php
+++ b/upload/admin/controller/mail/forgotten.php
@@ -38,7 +38,7 @@ class Forgotten extends \Opencart\System\Engine\Controller {
 			$code = '';
 		}
 
-		if ($email && $code && ($route == 'common/forgotten.confirm') && filter_var($email, FILTER_VALIDATE_EMAIL)) {
+		if ($email && $code && ($route == 'common/forgotten.confirm') && oc_filter_email($email)) {
 			$this->load->language('mail/forgotten');
 
 			$store_name = html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8');

--- a/upload/admin/controller/marketing/affiliate.php
+++ b/upload/admin/controller/marketing/affiliate.php
@@ -744,7 +744,7 @@ class Affiliate extends \Opencart\System\Engine\Controller {
 
 		if ($this->request->post['payment_method'] == 'cheque' && $this->request->post['cheque'] == '') {
 			$json['error']['cheque'] = $this->language->get('error_cheque');
-		} elseif ($this->request->post['payment_method'] == 'paypal' && ((oc_strlen($this->request->post['paypal']) > 96) || !filter_var($this->request->post['paypal'], FILTER_VALIDATE_EMAIL))) {
+		} elseif ($this->request->post['payment_method'] == 'paypal' && ((oc_strlen($this->request->post['paypal']) > 96) || !oc_filter_email($this->request->post['paypal']))) {
 			$json['error']['paypal'] = $this->language->get('error_paypal');
 		} elseif ($this->request->post['payment_method'] == 'bank') {
 			if ($this->request->post['bank_account_name'] == '') {

--- a/upload/admin/controller/marketing/contact.php
+++ b/upload/admin/controller/marketing/contact.php
@@ -240,7 +240,7 @@ class Contact extends \Opencart\System\Engine\Controller {
 					$mail = new \Opencart\System\Library\Mail($this->config->get('config_mail_engine'), $mail_option);
 
 					foreach ($emails as $email) {
-						if (filter_var($email, FILTER_VALIDATE_EMAIL)) {
+						if (oc_filter_email($email)) {
 							$mail->setTo(trim($email));
 							$mail->setFrom($store_email);
 							$mail->setSender(html_entity_decode($store_name, ENT_QUOTES, 'UTF-8'));

--- a/upload/admin/controller/sale/returns.php
+++ b/upload/admin/controller/sale/returns.php
@@ -659,7 +659,7 @@ class Returns extends \Opencart\System\Engine\Controller {
 			$json['error']['lastname'] = $this->language->get('error_lastname');
 		}
 
-		if ((oc_strlen($this->request->post['email']) > 96) || !filter_var($this->request->post['email'], FILTER_VALIDATE_EMAIL)) {
+		if ((oc_strlen($this->request->post['email']) > 96) || !oc_filter_email($this->request->post['email'])) {
 			$json['error']['email'] = $this->language->get('error_email');
 		}
 

--- a/upload/admin/controller/sale/voucher.php
+++ b/upload/admin/controller/sale/voucher.php
@@ -340,7 +340,7 @@ class Voucher extends \Opencart\System\Engine\Controller {
 			$json['error']['to_name'] = $this->language->get('error_to_name');
 		}
 
-		if ((oc_strlen($this->request->post['to_email']) > 96) || !filter_var($this->request->post['to_email'], FILTER_VALIDATE_EMAIL)) {
+		if ((oc_strlen($this->request->post['to_email']) > 96) || !oc_filter_email($this->request->post['to_email'])) {
 			$json['error']['to_email'] = $this->language->get('error_email');
 		}
 
@@ -348,7 +348,7 @@ class Voucher extends \Opencart\System\Engine\Controller {
 			$json['error']['from_name'] = $this->language->get('error_from_name');
 		}
 
-		if ((oc_strlen($this->request->post['from_email']) > 96) || !filter_var($this->request->post['from_email'], FILTER_VALIDATE_EMAIL)) {
+		if ((oc_strlen($this->request->post['from_email']) > 96) || !oc_filter_email($this->request->post['from_email'])) {
 			$json['error']['from_email'] = $this->language->get('error_email');
 		}
 

--- a/upload/admin/controller/setting/setting.php
+++ b/upload/admin/controller/setting/setting.php
@@ -482,7 +482,7 @@ class Setting extends \Opencart\System\Engine\Controller {
 			$json['error']['address'] = $this->language->get('error_address');
 		}
 
-		if ((oc_strlen($this->request->post['config_email']) > 96) || !filter_var($this->request->post['config_email'], FILTER_VALIDATE_EMAIL)) {
+		if ((oc_strlen($this->request->post['config_email']) > 96) || !oc_filter_email($this->request->post['config_email'])) {
 			$json['error']['email'] = $this->language->get('error_email');
 		}
 

--- a/upload/admin/controller/setting/store.php
+++ b/upload/admin/controller/setting/store.php
@@ -651,7 +651,7 @@ class Store extends \Opencart\System\Engine\Controller {
 			$json['error']['address'] = $this->language->get('error_address');
 		}
 
-		if ((oc_strlen($this->request->post['config_email']) > 96) || !filter_var($this->request->post['config_email'], FILTER_VALIDATE_EMAIL)) {
+		if ((oc_strlen($this->request->post['config_email']) > 96) || !oc_filter_email($this->request->post['config_email'])) {
 			$json['error']['email'] = $this->language->get('error_email');
 		}
 

--- a/upload/admin/controller/user/profile.php
+++ b/upload/admin/controller/user/profile.php
@@ -116,7 +116,7 @@ class Profile extends \Opencart\System\Engine\Controller {
 			$json['error']['lastname'] = $this->language->get('error_lastname');
 		}
 
-		if ((oc_strlen($this->request->post['email']) > 96) || !filter_var($this->request->post['email'], FILTER_VALIDATE_EMAIL)) {
+		if ((oc_strlen($this->request->post['email']) > 96) || !oc_filter_email($this->request->post['email'])) {
 			$json['error']['email'] = $this->language->get('error_email');
 		}
 

--- a/upload/admin/controller/user/user.php
+++ b/upload/admin/controller/user/user.php
@@ -545,7 +545,7 @@ class User extends \Opencart\System\Engine\Controller {
 			$json['error']['lastname'] = $this->language->get('error_lastname');
 		}
 
-		if ((oc_strlen($this->request->post['email']) > 96) || !filter_var($this->request->post['email'], FILTER_VALIDATE_EMAIL)) {
+		if ((oc_strlen($this->request->post['email']) > 96) || !oc_filter_email($this->request->post['email'])) {
 			$json['error']['email'] = $this->language->get('error_email');
 		}
 

--- a/upload/catalog/controller/account/affiliate.php
+++ b/upload/catalog/controller/account/affiliate.php
@@ -209,7 +209,7 @@ class Affiliate extends \Opencart\System\Engine\Controller {
 
 			if ($this->request->post['payment_method'] == 'cheque' && !$this->request->post['cheque']) {
 				$json['error']['cheque'] = $this->language->get('error_cheque');
-			} elseif ($this->request->post['payment_method'] == 'paypal' && ((oc_strlen($this->request->post['paypal']) > 96) || !filter_var($this->request->post['paypal'], FILTER_VALIDATE_EMAIL))) {
+			} elseif ($this->request->post['payment_method'] == 'paypal' && ((oc_strlen($this->request->post['paypal']) > 96) || !oc_filter_email($this->request->post['paypal']))) {
 				$json['error']['paypal'] = $this->language->get('error_paypal');
 			} elseif ($this->request->post['payment_method'] == 'bank') {
 				if ($this->request->post['bank_account_name'] == '') {

--- a/upload/catalog/controller/account/edit.php
+++ b/upload/catalog/controller/account/edit.php
@@ -125,7 +125,7 @@ class Edit extends \Opencart\System\Engine\Controller {
 				$json['error']['lastname'] = $this->language->get('error_lastname');
 			}
 
-			if ((oc_strlen($this->request->post['email']) > 96) || !filter_var($this->request->post['email'], FILTER_VALIDATE_EMAIL)) {
+			if ((oc_strlen($this->request->post['email']) > 96) || !oc_filter_email($this->request->post['email'])) {
 				$json['error']['email'] = $this->language->get('error_email');
 			}
 

--- a/upload/catalog/controller/account/register.php
+++ b/upload/catalog/controller/account/register.php
@@ -169,7 +169,7 @@ class Register extends \Opencart\System\Engine\Controller {
 				$json['error']['lastname'] = $this->language->get('error_lastname');
 			}
 
-			if ((oc_strlen($this->request->post['email']) > 96) || !filter_var($this->request->post['email'], FILTER_VALIDATE_EMAIL)) {
+			if ((oc_strlen($this->request->post['email']) > 96) || !oc_filter_email($this->request->post['email'])) {
 				$json['error']['email'] = $this->language->get('error_email');
 			}
 

--- a/upload/catalog/controller/account/returns.php
+++ b/upload/catalog/controller/account/returns.php
@@ -369,7 +369,7 @@ class Returns extends \Opencart\System\Engine\Controller {
 				$json['error']['lastname'] = $this->language->get('error_lastname');
 			}
 
-			if ((oc_strlen($this->request->post['email']) > 96) || !filter_var($this->request->post['email'], FILTER_VALIDATE_EMAIL)) {
+			if ((oc_strlen($this->request->post['email']) > 96) || !oc_filter_email($this->request->post['email'])) {
 				$json['error']['email'] = $this->language->get('error_email');
 			}
 

--- a/upload/catalog/controller/api/sale/customer.php
+++ b/upload/catalog/controller/api/sale/customer.php
@@ -63,7 +63,7 @@ class Customer extends \Opencart\System\Engine\Controller {
 			$json['error']['lastname'] = $this->language->get('error_lastname');
 		}
 
-		if ((oc_strlen($this->request->post['email']) > 96) || !filter_var($this->request->post['email'], FILTER_VALIDATE_EMAIL)) {
+		if ((oc_strlen($this->request->post['email']) > 96) || !oc_filter_email($this->request->post['email'])) {
 			$json['error']['email'] = $this->language->get('error_email');
 		}
 

--- a/upload/catalog/controller/api/sale/voucher.php
+++ b/upload/catalog/controller/api/sale/voucher.php
@@ -79,7 +79,7 @@ class Voucher extends \Opencart\System\Engine\Controller {
 			$json['error']['from_name'] = $this->language->get('error_from_name');
 		}
 
-		if ((oc_strlen($this->request->post['from_email']) > 96) || !filter_var($this->request->post['from_email'], FILTER_VALIDATE_EMAIL)) {
+		if ((oc_strlen($this->request->post['from_email']) > 96) || !oc_filter_email($this->request->post['from_email'])) {
 			$json['error']['from_email'] = $this->language->get('error_email');
 		}
 
@@ -87,7 +87,7 @@ class Voucher extends \Opencart\System\Engine\Controller {
 			$json['error']['to_name'] = $this->language->get('error_to_name');
 		}
 
-		if ((oc_strlen($this->request->post['to_email']) > 96) || !filter_var($this->request->post['to_email'], FILTER_VALIDATE_EMAIL)) {
+		if ((oc_strlen($this->request->post['to_email']) > 96) || !oc_filter_email($this->request->post['to_email'])) {
 			$json['error']['to_email'] = $this->language->get('error_email');
 		}
 

--- a/upload/catalog/controller/checkout/register.php
+++ b/upload/catalog/controller/checkout/register.php
@@ -262,7 +262,7 @@ class Register extends \Opencart\System\Engine\Controller {
 				$json['error']['lastname'] = $this->language->get('error_lastname');
 			}
 
-			if ((oc_strlen($this->request->post['email']) > 96) || !filter_var($this->request->post['email'], FILTER_VALIDATE_EMAIL)) {
+			if ((oc_strlen($this->request->post['email']) > 96) || !oc_filter_email($this->request->post['email'])) {
 				$json['error']['email'] = $this->language->get('error_email');
 			}
 

--- a/upload/catalog/controller/checkout/voucher.php
+++ b/upload/catalog/controller/checkout/voucher.php
@@ -103,7 +103,7 @@ class Voucher extends \Opencart\System\Engine\Controller {
 			$json['error']['to_name'] = $this->language->get('error_to_name');
 		}
 
-		if ((oc_strlen($this->request->post['to_email']) > 96) || !filter_var($this->request->post['to_email'], FILTER_VALIDATE_EMAIL)) {
+		if ((oc_strlen($this->request->post['to_email']) > 96) || !oc_filter_email($this->request->post['to_email'])) {
 			$json['error']['to_email'] = $this->language->get('error_email');
 		}
 
@@ -111,7 +111,7 @@ class Voucher extends \Opencart\System\Engine\Controller {
 			$json['error']['from_name'] = $this->language->get('error_from_name');
 		}
 
-		if ((oc_strlen($this->request->post['from_email']) > 96) || !filter_var($this->request->post['from_email'], FILTER_VALIDATE_EMAIL)) {
+		if ((oc_strlen($this->request->post['from_email']) > 96) || !oc_filter_email($this->request->post['from_email'])) {
 			$json['error']['from_email'] = $this->language->get('error_email');
 		}
 

--- a/upload/catalog/controller/information/contact.php
+++ b/upload/catalog/controller/information/contact.php
@@ -123,7 +123,7 @@ class Contact extends \Opencart\System\Engine\Controller {
 			$json['error']['name'] = $this->language->get('error_name');
 		}
 
-		if (!filter_var($this->request->post['email'], FILTER_VALIDATE_EMAIL)) {
+		if (!oc_filter_email($this->request->post['email'])) {
 			$json['error']['email'] = $this->language->get('error_email');
 		}
 

--- a/upload/catalog/controller/information/gdpr.php
+++ b/upload/catalog/controller/information/gdpr.php
@@ -104,7 +104,7 @@ class Gdpr extends \Opencart\System\Engine\Controller {
 		}
 
 		// Validate E-Mail
-		if ((oc_strlen($email) > 96) || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+		if ((oc_strlen($email) > 96) || !oc_filter_email($email)) {
 			$json['error']['email'] = $this->language->get('error_email');
 		}
 

--- a/upload/catalog/controller/mail/affiliate.php
+++ b/upload/catalog/controller/mail/affiliate.php
@@ -145,7 +145,7 @@ class Affiliate extends \Opencart\System\Engine\Controller {
 				$emails = explode(',', $this->config->get('config_mail_alert_email'));
 
 				foreach ($emails as $email) {
-					if (oc_strlen($email) > 0 && filter_var($email, FILTER_VALIDATE_EMAIL)) {
+					if (oc_strlen($email) > 0 && oc_filter_email($email)) {
 						$mail->setTo(trim($email));
 						$mail->send();
 					}

--- a/upload/catalog/controller/mail/order.php
+++ b/upload/catalog/controller/mail/order.php
@@ -642,7 +642,7 @@ class Order extends \Opencart\System\Engine\Controller {
 				$emails = explode(',', $this->config->get('config_mail_alert_email'));
 
 				foreach ($emails as $email) {
-					if ($email && filter_var($email, FILTER_VALIDATE_EMAIL)) {
+					if ($email && oc_filter_email($email)) {
 						$mail->setTo(trim($email));
 						$mail->send();
 					}

--- a/upload/catalog/controller/mail/register.php
+++ b/upload/catalog/controller/mail/register.php
@@ -137,7 +137,7 @@ class Register extends \Opencart\System\Engine\Controller {
 				$emails = explode(',', (string)$this->config->get('config_mail_alert_email'));
 
 				foreach ($emails as $email) {
-					if (oc_strlen($email) > 0 && filter_var($email, FILTER_VALIDATE_EMAIL)) {
+					if (oc_strlen($email) > 0 && oc_filter_email($email)) {
 						$mail->setTo(trim($email));
 						$mail->send();
 					}

--- a/upload/catalog/controller/mail/review.php
+++ b/upload/catalog/controller/mail/review.php
@@ -59,7 +59,7 @@ class Review extends \Opencart\System\Engine\Controller {
 					$emails = explode(',', (string)$this->config->get('config_mail_alert_email'));
 
 					foreach ($emails as $email) {
-						if ($email && filter_var($email, FILTER_VALIDATE_EMAIL)) {
+						if ($email && oc_filter_email($email)) {
 							$mail->setTo(trim($email));
 							$mail->send();
 						}

--- a/upload/catalog/controller/mail/subscription.php
+++ b/upload/catalog/controller/mail/subscription.php
@@ -548,7 +548,7 @@ class Subscription extends \Opencart\System\Engine\Controller {
 				$emails = explode(',', $this->config->get('config_mail_alert_email'));
 
 				foreach ($emails as $email) {
-					if ($email && filter_var($email, FILTER_VALIDATE_EMAIL)) {
+					if ($email && oc_filter_email($email)) {
 						$mail->setTo(trim($email));
 						$mail->send();
 					}

--- a/upload/install/cli_cloud.php
+++ b/upload/install/cli_cloud.php
@@ -155,7 +155,7 @@ class CliCloud extends \Opencart\System\Engine\Controller {
 			$error .= 'ERROR: Username must be between 3 and 20 characters!' . "\n";
 		}
 
-		if ((oc_strlen($option['email']) > 96) || !filter_var($option['email'], FILTER_VALIDATE_EMAIL)) {
+		if ((oc_strlen($option['email']) > 96) || !oc_filter_email($option['email'])) {
 			$error .= 'ERROR: E-Mail Address does not appear to be valid!' . "\n";
 		}
 

--- a/upload/install/cli_install.php
+++ b/upload/install/cli_install.php
@@ -247,7 +247,7 @@ class CliInstall extends \Opencart\System\Engine\Controller {
 			$error .= 'ERROR: Username must be between 3 and 20 characters!' . "\n";
 		}
 
-		if ((oc_strlen($option['email']) > 96) || !filter_var($option['email'], FILTER_VALIDATE_EMAIL)) {
+		if ((oc_strlen($option['email']) > 96) || !oc_filter_email($option['email'])) {
 			$error .= 'ERROR: E-Mail Address does not appear to be valid!' . "\n";
 		}
 

--- a/upload/install/controller/install/step_3.php
+++ b/upload/install/controller/install/step_3.php
@@ -390,7 +390,7 @@ class Step3 extends \Opencart\System\Engine\Controller {
 			$this->error['username'] = $this->language->get('error_username');
 		}
 
-		if ((oc_strlen($this->request->post['email']) > 96) || !filter_var($this->request->post['email'], FILTER_VALIDATE_EMAIL)) {
+		if ((oc_strlen($this->request->post['email']) > 96) || !oc_filter_email($this->request->post['email'])) {
 			$this->error['email'] = $this->language->get('error_email');
 		}
 

--- a/upload/system/helper/general.php
+++ b/upload/system/helper/general.php
@@ -38,6 +38,24 @@ function oc_strtolower(string $string): string {
 	return mb_strtolower($string);
 }
 
+// Email
+function oc_filter_email(string $email): string {
+	if (oc_strrpos($email, '@') === false) return false;
+
+	$local = oc_substr($email, 0, oc_strrpos($email, '@'));
+
+	$domain = oc_substr($email, (oc_strrpos($email, '@') + 1));
+
+	$email = $local . '@' . oc_punycode($domain);
+
+	return filter_var($email, FILTER_VALIDATE_EMAIL, FILTER_FLAG_EMAIL_UNICODE);
+}
+
+// Url
+function oc_punycode(string $string): string {
+	return idn_to_ascii($string, IDNA_NONTRANSITIONAL_TO_ASCII, INTL_IDNA_VARIANT_UTS46);
+}
+
 // Other
 function oc_token(int $length = 32): string {
 	return substr(bin2hex(random_bytes($length)), 0, $length);

--- a/upload/system/helper/general.php
+++ b/upload/system/helper/general.php
@@ -39,7 +39,7 @@ function oc_strtolower(string $string): string {
 }
 
 // Email
-function oc_filter_email(string $email): string {
+function oc_filter_email(string $email): bool {
 	if (oc_strrpos($email, '@') === false) return false;
 
 	$local = oc_substr($email, 0, oc_strrpos($email, '@'));


### PR DESCRIPTION
https://github.com/opencart/opencart/issues/9755

Another attempt.

Validation still uses native PHP filter_var. But it encodes mail domain to punycode.

Perhaps Mail library must be also modified to encode domains with `oc_punycode()`.
However my external SMTP test to real `info@домен.укр` was successful even without this. 
Need more Mail/SMTP tests with different servers.


Here are validation results:
```
latin.email.com -> punycode: latin.email.com -> filter_var result: false

latin@email.com -> punycode: latin@email.com -> filter_var result: true

latin@email@example.com -> punycode: latin@email@example.com -> filter_var result: false

ghfh@renangonçalves.com -> punycode: ghfh@xn--renangonalves-pgb.com -> filter_var result: true

用户@例子.广告 -> punycode: 用户@xn--fsqu00a.xn--4rr70v -> filter_var result: true

ಬೆಂಬಲ@ಡೇಟಾಮೇಲ್.ಭಾರತ -> punycode: ಬೆಂಬಲ@xn--xscd4bq2d9bd3c.xn--2scrj9c -> filter_var result: false

अजय@डाटा.भारत -> punycode: अजय@xn--c2bd1gb.xn--h2brj9c -> filter_var result: true

квіточка@пошта.укр -> punycode: квіточка@xn--80a1acn3a.xn--j1amh -> filter_var result: true

χρήστης@παράδειγμα.ελ -> punycode: χρήστης@xn--hxajbheg2az3al.xn--qxam -> filter_var result: true

Dörte@Sörensen.example.com -> punycode: Dörte@xn--srensen-90a.example.com -> filter_var result: true

коля@пример.рф -> punycode: коля@xn--e1afmkfd.xn--p1ai -> filter_var result: true

support@ツッ.com -> punycode: support@xn--9ckb.com -> filter_var result: true

info@xn--80a1acn3a.xn--j1amh -> punycode: info@xn--80a1acn3a.xn--j1amh -> filter_var result: true

info%@пошта.укр -> punycode: info%@xn--80a1acn3a.xn--j1amh -> filter_var result: true

info(%)@пошта.укр -> punycode: info(%)@xn--80a1acn3a.xn--j1amh -> filter_var result: false

info[]@example.com -> punycode: info[]@example.com -> filter_var result: false
```