### PR TITLE
Adjusting the appearance of admin panel forms

### DIFF
--- a/upload/admin/view/stylesheet/stylesheet.css
+++ b/upload/admin/view/stylesheet/stylesheet.css
@@ -429,25 +429,6 @@ a {
     }
 }
 
-.row.mb-3 {
-    position: relative;
-}
-
-.row.mb-3 + .row.mb-3 {
-    padding-top: 1rem;
-}
-
-.row.mb-3 + .row.mb-3:before {
-    display: block;
-    content: '';
-    position: absolute;
-    width: calc(100% - calc(var(--bs-gutter-x) / 1));
-    height: 0px;
-    left: calc(var(--bs-gutter-x) / 2);
-    top: 0;
-    border-bottom: 1px solid #ededed;
-}
-
 .form-control:hover {
     border: 1px solid #b9b9b9;
     border-top-color: #a0a0a0;


### PR DESCRIPTION
In the forms of the admin panel, since the time of the old Bootstrap, visual artifacts have remained in the form of dividing lines between the elements of forms. In this refinement, I brought the appearance of the forms according to Bootstrap 5, where only Fieldset has a separation line. The forms began to look cleaner and more compact.

![form_r1_c1](https://github.com/opencart/opencart/assets/10770779/a22a38a9-fc15-4885-88db-6e956897782f)
