### PR TITLE
[3.0.x.x] Add cache control headers

### DIFF
--- a/upload/system/framework.php
+++ b/upload/system/framework.php
@@ -72,6 +72,9 @@ $registry->set('request', new Request());
 // Response
 $response = new Response();
 $response->addHeader('Content-Type: text/html; charset=utf-8');
+header('Expires: Thu, 19 Nov 1981 08:52:00 GMT', true);
+header('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0', true);
+header('Pragma: no-cache', true);
 $response->setCompression($config->get('config_compression'));
 $registry->set('response', $response);
 


### PR DESCRIPTION
Still regular posts on the forum with issues cause by lack of cache control headers, which have never been added to 3.0.x.x.

Use header instead of $response->addHeader to prevent redirects being cached. Which can be a problem on hosting with an ExpiresDefault set. A better way would be to modify the response library to include headers on redirects and only send when a session is started.

Also probably needed to comply with data protection regulations.