### PR TITLE
extensions uninstall fixes: remove permissions, + fixes for phpstan.neon

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,7 +9,9 @@ parameters:
         - ./upload/
     excludePaths:
         - ./system/storage/vendor/
+        - ./system/storage/cache/template/
         - ./upload/system/storage/vendor/
+        - ./upload/system/storage/cache/template/
     tmpDir: .cache
     ignoreErrors:
         - '#Class Event constructor invoked with 1 parameter, 4-5 required\.#'

--- a/upload/admin/controller/extension/extension/advertise.php
+++ b/upload/admin/controller/extension/extension/advertise.php
@@ -1,134 +1,138 @@
 <?php
 class ControllerExtensionExtensionAdvertise extends Controller {
-    private $error = array();
+	private $error = array();
 
-    public function index() {
-        $this->load->language('extension/extension/advertise');
+	public function index() {
+		$this->load->language('extension/extension/advertise');
 
-        $this->load->model('setting/extension');
+		$this->load->model('setting/extension');
 
-        $this->getList();
-    }
+		$this->getList();
+	}
 
-    public function install() {
-        $this->load->language('extension/extension/advertise');
+	public function install() {
+		$this->load->language('extension/extension/advertise');
 
-        $this->load->model('setting/extension');
+		$this->load->model('setting/extension');
 
-        if ($this->validate()) {
-            $this->model_setting_extension->install('advertise', $this->request->get['extension']);
+		if ($this->validate()) {
+			$this->model_setting_extension->install('advertise', $this->request->get['extension']);
 
-            $this->load->model('user/user_group');
+			$this->load->model('user/user_group');
 
-            $this->model_user_user_group->addPermission($this->user->getGroupId(), 'access', 'extension/advertise/' . $this->request->get['extension']);
-            $this->model_user_user_group->addPermission($this->user->getGroupId(), 'modify', 'extension/advertise/' . $this->request->get['extension']);
-            
-            // Compatibility
-            $this->model_user_user_group->addPermission($this->user->getGroupId(), 'access', 'advertise/' . $this->request->get['extension']);
-            $this->model_user_user_group->addPermission($this->user->getGroupId(), 'modify', 'advertise/' . $this->request->get['extension']);
+			$this->model_user_user_group->addPermission($this->user->getGroupId(), 'access', 'extension/advertise/' . $this->request->get['extension']);
+			$this->model_user_user_group->addPermission($this->user->getGroupId(), 'modify', 'extension/advertise/' . $this->request->get['extension']);
+			
+			// Compatibility
+			$this->model_user_user_group->addPermission($this->user->getGroupId(), 'access', 'advertise/' . $this->request->get['extension']);
+			$this->model_user_user_group->addPermission($this->user->getGroupId(), 'modify', 'advertise/' . $this->request->get['extension']);
 
-            // Call install method if it exsits
-            $this->load->controller('extension/advertise/' . $this->request->get['extension'] . '/install');
+			// Call install method if it exsits
+			$this->load->controller('extension/advertise/' . $this->request->get['extension'] . '/install');
 
-            $this->session->data['success'] = $this->language->get('text_success');
-        }
+			$this->session->data['success'] = $this->language->get('text_success');
+		}
 
-        $this->getList();
-    }
+		$this->getList();
+	}
 
-    public function uninstall() {
-        $this->load->language('extension/extension/advertise');
+	public function uninstall() {
+		$this->load->language('extension/extension/advertise');
 
-        $this->load->model('setting/extension');
+		$this->load->model('setting/extension');
 
-        if ($this->validate()) {
-            $this->model_setting_extension->uninstall('advertise', $this->request->get['extension']);
+		if ($this->validate()) {
+			$this->model_setting_extension->uninstall('advertise', $this->request->get['extension']);
 
-            // Call uninstall method if it exsits
-            $this->load->controller('extension/advertise/' . $this->request->get['extension'] . '/uninstall');
+			// Call uninstall method if it exsits
+			$this->load->controller('extension/advertise/' . $this->request->get['extension'] . '/uninstall');
 
-            $this->session->data['success'] = $this->language->get('text_success');
-        }
+			$this->load->model('user/user_group');
+			$this->model_user_user_group->removePermissions('extension/advertise/' . $this->request->get['extension']);
+			$this->model_user_user_group->removePermissions('advertise/' . $this->request->get['extension']);
 
-        $this->getList();
-    }
+			$this->session->data['success'] = $this->language->get('text_success');
+		}
 
-    protected function getList() {
-        if (isset($this->error['warning'])) {
-            $data['error_warning'] = $this->error['warning'];
-        } else {
-            $data['error_warning'] = '';
-        }
+		$this->getList();
+	}
 
-        if (isset($this->session->data['success'])) {
-            $data['success'] = $this->session->data['success'];
+	protected function getList() {
+		if (isset($this->error['warning'])) {
+			$data['error_warning'] = $this->error['warning'];
+		} else {
+			$data['error_warning'] = '';
+		}
 
-            unset($this->session->data['success']);
-        } else {
-            $data['success'] = '';
-        }
+		if (isset($this->session->data['success'])) {
+			$data['success'] = $this->session->data['success'];
 
-        $extensions = $this->model_setting_extension->getInstalled('advertise');
+			unset($this->session->data['success']);
+		} else {
+			$data['success'] = '';
+		}
 
-        foreach ($extensions as $key => $value) {
-            if (!is_file(DIR_APPLICATION . 'controller/extension/advertise/' . $value . '.php') && !is_file(DIR_APPLICATION . 'controller/advertise/' . $value . '.php')) {
-                $this->model_setting_extension->uninstall('advertise', $value);
+		$extensions = $this->model_setting_extension->getInstalled('advertise');
 
-                unset($extensions[$key]);
-            }
-        }
-        
-        $this->load->model('setting/store');
-        $this->load->model('setting/setting');
+		foreach ($extensions as $key => $value) {
+			if (!is_file(DIR_APPLICATION . 'controller/extension/advertise/' . $value . '.php') && !is_file(DIR_APPLICATION . 'controller/advertise/' . $value . '.php')) {
+				$this->model_setting_extension->uninstall('advertise', $value);
 
-        $stores = $this->model_setting_store->getStores();
-        
-        $data['extensions'] = array();
+				unset($extensions[$key]);
+			}
+		}
+		
+		$this->load->model('setting/store');
+		$this->load->model('setting/setting');
 
-        // Compatibility code for old extension folders
-        $files = glob(DIR_APPLICATION . 'controller/extension/advertise/*.php');
+		$stores = $this->model_setting_store->getStores();
+		
+		$data['extensions'] = array();
 
-        if ($files) {
-            foreach ($files as $file) {
-                $extension = basename($file, '.php');
-                
-                // Compatibility code for old extension folders
-                $this->load->language('extension/advertise/' . $extension, 'extension');
-                
-                $store_data = array();
+		// Compatibility code for old extension folders
+		$files = glob(DIR_APPLICATION . 'controller/extension/advertise/*.php');
 
-                $store_data[] = array(
-                    'name'   => $this->config->get('config_name'),
-                    'edit'   => $this->url->link('extension/advertise/' . $extension, 'user_token=' . $this->session->data['user_token'] . '&store_id=0', true),
-                    'status' => $this->config->get('advertise_' . $extension . '_status') ? $this->language->get('text_enabled') : $this->language->get('text_disabled')
-                );
-                
-                foreach ($stores as $store) {
-                    $store_data[] = array(
-                        'name'   => $store['name'],
-                        'edit'   => $this->url->link('extension/advertise/' . $extension, 'user_token=' . $this->session->data['user_token'] . '&store_id=' . $store['store_id'], true),
-                        'status' => $this->model_setting_setting->getSettingValue('advertise_' . $extension . '_status', $store['store_id']) ? $this->language->get('text_enabled') : $this->language->get('text_disabled')
-                    );
-                }
+		if ($files) {
+			foreach ($files as $file) {
+				$extension = basename($file, '.php');
+				
+				// Compatibility code for old extension folders
+				$this->load->language('extension/advertise/' . $extension, 'extension');
+				
+				$store_data = array();
 
-                $data['extensions'][] = array(
-                    'name'      => $this->language->get('extension')->get('heading_title'),
-                    'install'   => $this->url->link('extension/extension/advertise/install', 'user_token=' . $this->session->data['user_token'] . '&extension=' . $extension, true),
-                    'uninstall' => $this->url->link('extension/extension/advertise/uninstall', 'user_token=' . $this->session->data['user_token'] . '&extension=' . $extension, true),
-                    'installed' => in_array($extension, $extensions),
-                    'store'     => $store_data
-                );
-            }
-        }
+				$store_data[] = array(
+					'name'   => $this->config->get('config_name'),
+					'edit'   => $this->url->link('extension/advertise/' . $extension, 'user_token=' . $this->session->data['user_token'] . '&store_id=0', true),
+					'status' => $this->config->get('advertise_' . $extension . '_status') ? $this->language->get('text_enabled') : $this->language->get('text_disabled')
+				);
+				
+				foreach ($stores as $store) {
+					$store_data[] = array(
+						'name'   => $store['name'],
+						'edit'   => $this->url->link('extension/advertise/' . $extension, 'user_token=' . $this->session->data['user_token'] . '&store_id=' . $store['store_id'], true),
+						'status' => $this->model_setting_setting->getSettingValue('advertise_' . $extension . '_status', $store['store_id']) ? $this->language->get('text_enabled') : $this->language->get('text_disabled')
+					);
+				}
 
-        $this->response->setOutput($this->load->view('extension/extension/advertise', $data));
-    }
+				$data['extensions'][] = array(
+					'name'      => $this->language->get('extension')->get('heading_title'),
+					'install'   => $this->url->link('extension/extension/advertise/install', 'user_token=' . $this->session->data['user_token'] . '&extension=' . $extension, true),
+					'uninstall' => $this->url->link('extension/extension/advertise/uninstall', 'user_token=' . $this->session->data['user_token'] . '&extension=' . $extension, true),
+					'installed' => in_array($extension, $extensions),
+					'store'     => $store_data
+				);
+			}
+		}
 
-    protected function validate() {
-        if (!$this->user->hasPermission('modify', 'extension/extension/advertise')) {
-            $this->error['warning'] = $this->language->get('error_permission');
-        }
+		$this->response->setOutput($this->load->view('extension/extension/advertise', $data));
+	}
 
-        return !$this->error;
-    }
+	protected function validate() {
+		if (!$this->user->hasPermission('modify', 'extension/extension/advertise')) {
+			$this->error['warning'] = $this->language->get('error_permission');
+		}
+
+		return !$this->error;
+	}
 }

--- a/upload/admin/controller/extension/extension/analytics.php
+++ b/upload/admin/controller/extension/extension/analytics.php
@@ -47,6 +47,10 @@ class ControllerExtensionExtensionAnalytics extends Controller {
 			// Call uninstall method if it exsits
 			$this->load->controller('extension/analytics/' . $this->request->get['extension'] . '/uninstall');
 
+			$this->load->model('user/user_group');
+			$this->model_user_user_group->removePermissions('extension/analytics/' . $this->request->get['extension']);
+			$this->model_user_user_group->removePermissions('analytics/' . $this->request->get['extension']);
+
 			$this->session->data['success'] = $this->language->get('text_success');
 		}
 

--- a/upload/admin/controller/extension/extension/captcha.php
+++ b/upload/admin/controller/extension/extension/captcha.php
@@ -47,6 +47,10 @@ class ControllerExtensionExtensionCaptcha extends Controller {
 			// Call uninstall method if it exsits
 			$this->load->controller('extension/captcha/' . $this->request->get['extension'] . '/uninstall');
 
+			$this->load->model('user/user_group');
+			$this->model_user_user_group->removePermissions('extension/captcha/' . $this->request->get['extension']);
+			$this->model_user_user_group->removePermissions('captcha/' . $this->request->get['extension']);
+
 			$this->session->data['success'] = $this->language->get('text_success');
 		}
 		

--- a/upload/admin/controller/extension/extension/currency.php
+++ b/upload/admin/controller/extension/extension/currency.php
@@ -43,6 +43,9 @@ class ControllerExtensionExtensionCurrency extends Controller {
 			// Call uninstall method if it exsits
 			$this->load->controller('extension/currency/' . $this->request->get['extension'] . '/uninstall');
 
+			$this->load->model('user/user_group');
+			$this->model_user_user_group->removePermissions('extension/currency/' . $this->request->get['extension']);
+
 			$this->session->data['success'] = $this->language->get('text_success');
 		}
 		

--- a/upload/admin/controller/extension/extension/dashboard.php
+++ b/upload/admin/controller/extension/extension/dashboard.php
@@ -43,6 +43,9 @@ class ControllerExtensionExtensionDashboard extends Controller {
 			// Call uninstall method if it exsits
 			$this->load->controller('extension/dashboard/' . $this->request->get['extension'] . '/uninstall');
 
+			$this->load->model('user/user_group');
+			$this->model_user_user_group->removePermissions('extension/dashboard/' . $this->request->get['extension']);
+
 			$this->session->data['success'] = $this->language->get('text_success');
 		}
 

--- a/upload/admin/controller/extension/extension/feed.php
+++ b/upload/admin/controller/extension/extension/feed.php
@@ -43,6 +43,9 @@ class ControllerExtensionExtensionFeed extends Controller {
 			// Call uninstall method if it exsits
 			$this->load->controller('extension/feed/' . $this->request->get['extension'] . '/uninstall');
 
+			$this->load->model('user/user_group');
+			$this->model_user_user_group->removePermissions('extension/feed/' . $this->request->get['extension']);
+
 			$this->session->data['success'] = $this->language->get('text_success');
 		}
 		

--- a/upload/admin/controller/extension/extension/fraud.php
+++ b/upload/admin/controller/extension/extension/fraud.php
@@ -43,6 +43,9 @@ class ControllerExtensionExtensionFraud extends Controller {
 			// Call uninstall method if it exsits
 			$this->load->controller('extension/fraud/' . $this->request->get['extension'] . '/uninstall');
 
+			$this->load->model('user/user_group');
+			$this->model_user_user_group->removePermissions('extension/fraud/' . $this->request->get['extension']);
+
 			$this->session->data['success'] = $this->language->get('text_success');
 		}
 		

--- a/upload/admin/controller/extension/extension/menu.php
+++ b/upload/admin/controller/extension/extension/menu.php
@@ -43,6 +43,9 @@ class ControllerExtensionExtensionMenu extends Controller {
 			// Call uninstall method if it exsits
 			$this->load->controller('extension/menu/' . $this->request->get['extension'] . '/uninstall');
 
+			$this->load->model('user/user_group');
+			$this->model_user_user_group->removePermissions('extension/menu/' . $this->request->get['extension']);
+
 			$this->session->data['success'] = $this->language->get('text_success');
 		}
 

--- a/upload/admin/controller/extension/extension/module.php
+++ b/upload/admin/controller/extension/extension/module.php
@@ -53,6 +53,9 @@ class ControllerExtensionExtensionModule extends Controller {
 			// Call uninstall method if it exsits
 			$this->load->controller('extension/module/' . $this->request->get['extension'] . '/uninstall');
 
+			$this->load->model('user/user_group');
+			$this->model_user_user_group->removePermissions('extension/module/' . $this->request->get['extension']);
+
 			$this->session->data['success'] = $this->language->get('text_success');
 		}
 

--- a/upload/admin/controller/extension/extension/payment.php
+++ b/upload/admin/controller/extension/extension/payment.php
@@ -43,6 +43,9 @@ class ControllerExtensionExtensionPayment extends Controller {
 			// Call uninstall method if it exsits
 			$this->load->controller('extension/payment/' . $this->request->get['extension'] . '/uninstall');
 
+			$this->load->model('user/user_group');
+			$this->model_user_user_group->removePermissions('extension/payment/' . $this->request->get['extension']);
+
 			$this->session->data['success'] = $this->language->get('text_success');
 		}
 

--- a/upload/admin/controller/extension/extension/report.php
+++ b/upload/admin/controller/extension/extension/report.php
@@ -41,6 +41,9 @@ class ControllerExtensionExtensionReport extends Controller {
 
 			$this->load->controller('extension/report/' . $this->request->get['extension'] . '/uninstall');
 
+			$this->load->model('user/user_group');
+			$this->model_user_user_group->removePermissions('extension/report/' . $this->request->get['extension']);
+
 			$this->session->data['success'] = $this->language->get('text_success');
 		}
 

--- a/upload/admin/controller/extension/extension/shipping.php
+++ b/upload/admin/controller/extension/extension/shipping.php
@@ -43,6 +43,9 @@ class ControllerExtensionExtensionShipping extends Controller {
 			// Call uninstall method if it exsits
 			$this->load->controller('extension/shipping/' . $this->request->get['extension'] . '/uninstall');
 
+			$this->load->model('user/user_group');
+			$this->model_user_user_group->removePermissions('extension/shipping/' . $this->request->get['extension']);
+
 			$this->session->data['success'] = $this->language->get('text_success');
 		}
 

--- a/upload/admin/controller/extension/extension/theme.php
+++ b/upload/admin/controller/extension/extension/theme.php
@@ -43,6 +43,9 @@ class ControllerExtensionExtensionTheme extends Controller {
 			// Call uninstall method if it exsits
 			$this->load->controller('extension/theme/' . $this->request->get['extension'] . '/uninstall');
 
+			$this->load->model('user/user_group');
+			$this->model_user_user_group->removePermissions('extension/theme/' . $this->request->get['extension']);
+
 			$this->session->data['success'] = $this->language->get('text_success');
 		}
 		

--- a/upload/admin/controller/extension/extension/total.php
+++ b/upload/admin/controller/extension/extension/total.php
@@ -41,6 +41,9 @@ class ControllerExtensionExtensionTotal extends Controller {
 
 			$this->load->controller('extension/total/' . $this->request->get['extension'] . '/uninstall');
 
+			$this->load->model('user/user_group');
+			$this->model_user_user_group->removePermissions('extension/total/' . $this->request->get['extension']);
+
 			$this->session->data['success'] = $this->language->get('text_success');
 		}
 

--- a/upload/admin/model/user/user_group.php
+++ b/upload/admin/model/user/user_group.php
@@ -82,4 +82,21 @@ class ModelUserUserGroup extends Model {
 			$this->db->query("UPDATE " . DB_PREFIX . "user_group SET permission = '" . $this->db->escape(json_encode($data)) . "' WHERE user_group_id = '" . (int)$user_group_id . "'");
 		}
 	}
+
+	function removePermissions( string $route ): void {
+		$user_groups = $this->getUserGroups();
+		foreach ($user_groups as $user_group) {
+			$user_group_id = $user_group['user_group_id'];
+			$permission = $user_group['permission'];
+			if (!empty($permission)) {
+				$permission = json_decode($permission,true);
+				if (!empty($permission['access'])) {
+					$this->removePermission($user_group_id, 'access', $route);
+				}
+				if (!empty($permission['modify'])) {
+					$this->removePermission($user_group_id, 'modify', $route);
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
When an extension gets uninstalled, the access/modify permissions are now removed from the oc_user_group DB table, too.