### PR TITLE
currency_id wrongly escaped in getCurrency method

### DIFF
--- a/upload/catalog/model/localisation/currency.php
+++ b/upload/catalog/model/localisation/currency.php
@@ -28,7 +28,7 @@ class Currency extends \Opencart\System\Engine\Model {
 	 * @return array<string, mixed>
 	 */
 	public function getCurrency(int $currency_id): array {
-		$query = $this->db->query("SELECT DISTINCT * FROM `" . DB_PREFIX . "currency` WHERE `currency_id` = '" . $this->db->escape($currency_id) . "'");
+		$query = $this->db->query("SELECT DISTINCT * FROM `" . DB_PREFIX . "currency` WHERE `currency_id` = '" . (int)$currency_id . "'");
 
 		return $query->row;
 	}


### PR DESCRIPTION
currency_id should not be escaped but casted instead, because it is supposed to always be an integrer.