### PR TITLE
CKEditor disable version check

### DIFF
--- a/upload/admin/view/javascript/ckeditor/config.js
+++ b/upload/admin/view/javascript/ckeditor/config.js
@@ -27,6 +27,7 @@ CKEDITOR.editorConfig = function( config ) {
 	config.browserContextMenuOnCtrl = true;
 	config.resize_enabled = true;
 	config.resize_dir = 'vertical';
+	config.versionCheck = false;
 
 	config.toolbar_Custom = [
 		['Source'],


### PR DESCRIPTION
Remove version warning. 4.22.1 is the last free opensource version.
This annoying message have no relation to security.
![image](https://github.com/opencart/opencart/assets/6297070/5ee52b8d-a8c1-4c25-bb92-b617ecdcde8b)
