### PR TITLE
[3.0.x.x] Make identically identified functions have the same signature

### DIFF
--- a/upload/admin/model/extension/payment/opayo.php
+++ b/upload/admin/model/extension/payment/opayo.php
@@ -247,7 +247,7 @@ class ModelExtensionPaymentOpayo extends Model {
 		$this->db->query("UPDATE `" . DB_PREFIX . "order_recurring` SET `status` = '" . (int)$status . "' WHERE `order_recurring_id` = '" . (int)$order_recurring_id . "'");
 	}
 
-	public function sendCurl($url, $payment_data) {
+	public function sendCurl($url, $payment_data, $i = null) {
 		$curl = curl_init($url);
 
 		curl_setopt($curl, CURLOPT_PORT, 443);

--- a/upload/catalog/model/extension/payment/worldpay.php
+++ b/upload/catalog/model/extension/payment/worldpay.php
@@ -78,7 +78,7 @@ class ModelExtensionPaymentWorldpay extends Model {
 
 		if ($qry->num_rows) {
 			$order = $qry->row;
-			$order['transactions'] = $this->getTransactions($order['worldpay_order_id']);
+			$order['transactions'] = $this->getTransactions($order['worldpay_order_id'], null);
 
 			return $order;
 		} else {
@@ -90,7 +90,7 @@ class ModelExtensionPaymentWorldpay extends Model {
 		$this->db->query("INSERT INTO `" . DB_PREFIX . "worldpay_order_transaction` SET `worldpay_order_id` = '" . (int)$worldpay_order_id . "', `date_added` = now(), `type` = '" . $this->db->escape($type) . "', `amount` = '" . $this->currency->format($order_info['total'], $order_info['currency_code'], false, false) . "'");
 	}
 
-	public function getTransactions($worldpay_order_id) {
+	public function getTransactions($worldpay_order_id, $currency_code) {
 		$qry = $this->db->query("SELECT * FROM `" . DB_PREFIX . "worldpay_order_transaction` WHERE `worldpay_order_id` = '" . (int)$worldpay_order_id . "'");
 
 		if ($qry->num_rows) {


### PR DESCRIPTION
@mhcwebdesign nice progress on the PHPStan issues. This PR should make the branch pass the check fully.

The reason it's failing is that there are multiple classes with the same name and namespace, coatning method with the same name but different signatures.

This is just a proposed solution, idk if you prefer to solve it by renaming them or some other way.