### PR TITLE
fix removing attributes in admin panel:

### DIFF
--- a/upload/admin/controller/catalog/attribute.php
+++ b/upload/admin/controller/catalog/attribute.php
@@ -324,7 +324,7 @@ class Attribute extends \Opencart\System\Engine\Controller {
 		$this->load->model('catalog/product');
 
 		foreach ($selected as $attribute_id) {
-			$product_total = $this->model_catalog_product->getTotalProductsByAttributeId($attribute_id);
+			$product_total = $this->model_catalog_product->getTotalAttributesByAttributeId($attribute_id);
 
 			if ($product_total) {
 				$json['error'] = sprintf($this->language->get('error_product'), $product_total);


### PR DESCRIPTION
rename called method
getTotalProductsByAttributeId -> getTotalAttributesByAttributeId 
"getTotalProductsByAttributeId" no longer exists