### PR TITLE
[3.0.x.x] Add missing escape to filter moule

### DIFF
--- a/upload/catalog/view/theme/default/template/extension/module/filter.twig
+++ b/upload/catalog/view/theme/default/template/extension/module/filter.twig
@@ -27,6 +27,6 @@ $('#button-filter').on('click', function() {
 		filter.push(this.value);
 	});
 
-	location = '{{ action }}&filter=' + filter.join(',');
+	location = '{{ action|escape('js') }}&filter=' + filter.join(',');
 });
 //--></script> 


### PR DESCRIPTION
A possible safer way, given that third party themes are not likely to be updated, would be to change the controller to.
```php
$data['action'] = str_replace('&amp;', '&', $this->url->link('product/category', '&path=' . preg_replace('/[^0-9_]/', '', $this->request->get['path']) . preg_replace('/[^a-zA-Z0-9_\.&=]/', '', $url)));
```