### PR TITLE
Update PayPal version number

### DIFF
--- a/upload/system/config/paypal.php
+++ b/upload/system/config/paypal.php
@@ -1,6 +1,6 @@
 <?php 
 $_['paypal_setting'] = array(
-	'version' => '3.0.0',
+	'version' => '3.0.0.1',
 	'partner' => array(
 		'production' => array(
 			'partner_id' => 'TY2Q25KP2PX9L',


### PR DESCRIPTION
Update PayPal version number to reflect recent bugfixes, using V3.0.0.1, was V3.0.0