### PR TITLE
Fix undefined function error during installation

### DIFF
--- a/upload/catalog/controller/checkout/voucher.php
+++ b/upload/catalog/controller/checkout/voucher.php
@@ -123,7 +123,7 @@ class Voucher extends \Opencart\System\Engine\Controller {
 			$json['error']['amount'] = sprintf($this->language->get('error_amount'), $this->currency->format($this->config->get('config_voucher_min'), $this->session->data['currency']), $this->currency->format($this->config->get('config_voucher_max'), $this->session->data['currency']));
 		}
 
-		if (!isset($this->request->post['agree'])) {
+		if (empty($this->request->post['agree'])) {
 			$json['error']['warning'] = $this->language->get('error_agree');
 		}
 

--- a/upload/system/startup.php
+++ b/upload/system/startup.php
@@ -60,3 +60,4 @@ require_once(DIR_SYSTEM . 'engine/config.php');
 
 // Helper
 require_once(DIR_SYSTEM . 'helper/general.php');
+require_once(DIR_SYSTEM . 'helper/validation.php');


### PR DESCRIPTION
- Added missing helper include for email validation in `startup.php`.
- Resolved the "Call to undefined function oc_validate_email()" error that was occurring on step 3 of the installation process (step_3.php, line 393).
- Successful installation verified after the inclusion of `validation.php`.