### PR TITLE
fix: unable to uninstall module setting

### DIFF
--- a/upload/admin/model/setting/extension.php
+++ b/upload/admin/model/setting/extension.php
@@ -89,7 +89,7 @@ class Extension extends \Opencart\System\Engine\Model {
 
 		$this->load->model('setting/setting');
 
-		$this->model_setting_setting->deleteSettingByCode($type . '_' . $code);
+		$this->model_setting_setting->deleteSettingsByCode($type . '_' . $code);
 	}
 
 	/**


### PR DESCRIPTION
I found that I can't uninstall any module setting. pls check it
![image](https://github.com/opencart/opencart/assets/48819065/f9d68970-20a6-4365-b62d-7b05bc220e69)
