### PR TITLE
The "unlink" option for links in Summernote

### DIFF
--- a/upload/admin/view/javascript/summernote/opencart.js
+++ b/upload/admin/view/javascript/summernote/opencart.js
@@ -37,6 +37,7 @@ $(document).ready(function() {
 					['float', ['floatLeft', 'floatRight', 'floatNone']],
 					['remove', ['removeMedia']]
 				],
+				link: [['link', ['linkDialogShow', 'unlink']]],
 				table: [
 					['add', ['addRowDown', 'addRowUp', 'addColLeft', 'addColRight']],
 					['delete', ['deleteRow', 'deleteCol', 'deleteTable']]


### PR DESCRIPTION
The "unlink" option for links in Summernote is lost, it must be returned. 
[https://i.imgur.com/nD8sFZs.jpg](https://i.imgur.com/nD8sFZs.jpg)