### PR TITLE
Fix null operator used on bool expression

### DIFF
--- a/upload/catalog/controller/checkout/cart.php
+++ b/upload/catalog/controller/checkout/cart.php
@@ -189,7 +189,7 @@ class Cart extends \Opencart\System\Engine\Controller {
 				'subscription' => $description,
 				'quantity'     => $product['quantity'],
 				'stock'        => $product['stock'] ? true : !(!$this->config->get('config_stock_checkout') || $this->config->get('config_stock_warning')),
-				'minimum'      => !$product['minimum'] ?? sprintf($this->language->get('error_minimum'), $product['name'], $product['minimum']),
+				'minimum'      => $product['minimum'] ? $product['minimum'] : sprintf($this->language->get('error_minimum'), $product['name'], $product['minimum']),
 				'reward'       => $product['reward'],
 				'price'        => $price_status ? $this->currency->format($this->tax->calculate($product['price'], $product['tax_class_id'], $this->config->get('config_tax')), $this->session->data['currency']) : '',
 				'total'        => $price_status ? $this->currency->format($this->tax->calculate($product['total'], $product['tax_class_id'], $this->config->get('config_tax')), $this->session->data['currency']) : '',


### PR DESCRIPTION
`!` is evaluated before `??` and turns the value in to a boolean, `??` will do the same for both `true` and `false` meaning the error message will never be displayed.

Issue introduced in https://github.com/opencart/opencart/commit/4c6925db6ff0f55641ce1809e408a685c3ed3a83