### PR TITLE
Fix for language switching in the admin

### DIFF
--- a/upload/admin/controller/startup/language.php
+++ b/upload/admin/controller/startup/language.php
@@ -60,7 +60,11 @@ class Language extends \Opencart\System\Engine\Controller {
 	 */
 	public function after(string &$route, string &$prefix, string &$code, array &$output): void {
 		if (!$code) {
-			$code = $this->config->get('config_language_admin');
+			if (isset($this->request->cookie['language'])) {
+				$code = $this->request->cookie['language'];
+			} else {
+				$code = $this->config->get('config_language_admin');
+			}
 		}
 
 		// Use $this->language->load so it's not triggering infinite loops


### PR DESCRIPTION
The language in the admin does not switch, although in version 4.0.2.3 it was finally solved. But now again.