### PR TITLE
Add missing attribute to getTotalFilters()

### DIFF
--- a/upload/admin/model/catalog/filter.php
+++ b/upload/admin/model/catalog/filter.php
@@ -133,9 +133,11 @@ class Filter extends \Opencart\System\Engine\Model {
 	/**
 	 * Get Total Filters
 	 *
+	 * @param array<string, mixed> $data
+	 *
 	 * @return int
 	 */
-	public function getTotalFilters(): int {
+	public function getTotalFilters(array $data = []): int {
 		$sql = "SELECT COUNT(*) AS `total` FROM `" . DB_PREFIX . "filter` `f` LEFT JOIN `" . DB_PREFIX . "filter_description` `fd` ON (`f`.`filter_id` = `fd`.`filter_id`) WHERE `fd`.`language_id` = '" . (int)$this->config->get('config_language_id') . "'";
 
 		if (!empty($data['filter_name'])) {


### PR DESCRIPTION
It seems there was an omission in commit https://github.com/opencart/opencart/commit/6819abe710b64b1202aaa04ee3e07a96dee86ced where logic to read from `$data` was added. Alternatively, considering it's not currently utilized, the code using it could be removed instead.

Given recent similar issues, it might help to conduct a quick check for lint errors before or after making code changes to prevent similar issues.