### PR TITLE
[3.0.x.x] Remove domain from language and currency cookies

### DIFF
--- a/upload/catalog/controller/startup/startup.php
+++ b/upload/catalog/controller/startup/startup.php
@@ -116,7 +116,7 @@ class ControllerStartupStartup extends Controller {
 		}
 				
 		if (!isset($this->request->cookie['language']) || $this->request->cookie['language'] != $code) {
-			setcookie('language', $code, time() + 60 * 60 * 24 * 30, '/', $this->request->server['HTTP_HOST']);
+			setcookie('language', $code, time() + 60 * 60 * 24 * 30, '/');
 		}
 				
 		// Overwrite the default language object
@@ -176,7 +176,7 @@ class ControllerStartupStartup extends Controller {
 		}
 		
 		if (!isset($this->request->cookie['currency']) || $this->request->cookie['currency'] != $code) {
-			setcookie('currency', $code, time() + 60 * 60 * 24 * 30, '/', $this->request->server['HTTP_HOST']);
+			setcookie('currency', $code, time() + 60 * 60 * 24 * 30, '/');
 		}		
 		
 		$this->registry->set('currency', new Cart\Currency($this->registry));


### PR DESCRIPTION
An invalid domain will now cause a fatal error in PHP 8. Don't use HTTP_HOST as it could be set to anything. Also fixes #7872.