### PR TITLE
More updates for currency refresh

### DIFF
--- a/upload/admin/controller/extension/currency/ecb.php
+++ b/upload/admin/controller/extension/currency/ecb.php
@@ -105,64 +105,8 @@ class ControllerExtensionCurrencyEcb extends Controller {
 
 
 	public function currency() {
-		if ($this->config->get('currency_ecb_status')) {
-			if ($this->config->get('config_currency_engine')=='ecb') {
-				$curl = curl_init();
-
-				curl_setopt($curl, CURLOPT_URL, 'https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml');
-				curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-				curl_setopt($curl, CURLOPT_HEADER, false);
-				curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 0);
-				curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 30);
-				curl_setopt($curl, CURLOPT_TIMEOUT, 30);
-
-				$response = curl_exec($curl);
-
-				curl_close($curl);
-
-				if ($response) {
-					$dom = new \DOMDocument('1.0', 'UTF-8');
-					$dom->loadXml($response);
-
-					$cube = $dom->getElementsByTagName('Cube')->item(0);
-
-					$currencies = [];
-
-					$currencies['EUR'] = 1.0000;
-
-					foreach ($cube->getElementsByTagName('Cube') as $currency) {
-						if ($currency->getAttribute('currency')) {
-							$currencies[$currency->getAttribute('currency')] = $currency->getAttribute('rate');
-						}
-					}
-
-					if ($currencies) {
-						$this->load->model('localisation/currency');
-						$this->load->model('extension/currency/ecb');
-
-						$default = $this->config->get('config_currency');
-
-						$results = $this->model_localisation_currency->getCurrencies();
-
-						foreach ($results as $result) {
-							if (isset($currencies[$result['code']])) {
-								$from = $currencies['EUR'];
-
-								$to = $currencies[$result['code']];
-
-								$this->model_extension_currency_ecb->editValueByCode($result['code'], 1 / ($currencies[$default] * ($from / $to)));
-							}
-						}
-					}
-
-					$this->model_extension_currency_ecb->editValueByCode($default, '1.00000');
-
-					$this->cache->delete('currency');
-				}
-				return true;
-			}
-		}
-
+		$this->load->model('extension/currency/ecb');
+		$this->model_extension_currency_ecb->refresh();
 		return null;
 	}
 }

--- a/upload/admin/controller/localisation/currency.php
+++ b/upload/admin/controller/localisation/currency.php
@@ -118,8 +118,7 @@ class ControllerLocalisationCurrency extends Controller {
 		$this->load->model('localisation/currency');
 
 		if ($this->validateRefresh()) {
-			$config_currency_engine = $this->config->get('config_currency_engine');
-			$this->load->controller('extension/currency/'.$config_currency_engine.'/currency');
+			$this->model_localisation_currency->refresh();
 
 			$this->session->data['success'] = $this->language->get('text_success');
 
@@ -136,8 +135,6 @@ class ControllerLocalisationCurrency extends Controller {
 			if (isset($this->request->get['page'])) {
 				$url .= '&page=' . $this->request->get['page'];
 			}
-
-			//$this->response->redirect($this->url->link('localisation/currency', 'user_token=' . $this->session->data['user_token'] . $url, true));
 		}
 
 		$this->getList();

--- a/upload/admin/controller/setting/setting.php
+++ b/upload/admin/controller/setting/setting.php
@@ -12,11 +12,11 @@ class ControllerSettingSetting extends Controller {
 		if (($this->request->server['REQUEST_METHOD'] == 'POST') && $this->validate()) {
 			$this->model_setting_setting->editSetting('config', $this->request->post);
 
-			if ($this->config->get('config_currency_auto')) {
-				$this->load->model('localisation/currency');
-
-				$this->model_localisation_currency->refresh();
-			}
+//			if ($this->config->get('config_currency_auto')) {
+//				$this->load->model('localisation/currency');
+//
+//				$this->model_localisation_currency->refresh();
+//			}
 
 			$this->session->data['success'] = $this->language->get('text_success');
 

--- a/upload/admin/model/extension/currency/ecb.php
+++ b/upload/admin/model/extension/currency/ecb.php
@@ -5,4 +5,62 @@ class ModelExtensionCurrencyEcb extends Model {
 		$this->db->query("UPDATE `" . DB_PREFIX . "currency` SET `value` = '" . (float)$value . "', `date_modified` = NOW() WHERE `code` = '" . $this->db->escape((string)$code) . "'");
 		$this->cache->delete('currency');
 	}
+
+	public function refresh() {
+		if ($this->config->get('currency_ecb_status')) {
+			if ($this->config->get('config_currency_engine')=='ecb') {
+				$curl = curl_init();
+
+				curl_setopt($curl, CURLOPT_URL, 'https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml');
+				curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+				curl_setopt($curl, CURLOPT_HEADER, false);
+				curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 0);
+				curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 30);
+				curl_setopt($curl, CURLOPT_TIMEOUT, 30);
+
+				$response = curl_exec($curl);
+
+				curl_close($curl);
+
+				if ($response) {
+					$dom = new \DOMDocument('1.0', 'UTF-8');
+					$dom->loadXml($response);
+
+					$cube = $dom->getElementsByTagName('Cube')->item(0);
+
+					$currencies = [];
+
+					$currencies['EUR'] = 1.0000;
+
+					foreach ($cube->getElementsByTagName('Cube') as $currency) {
+						if ($currency->getAttribute('currency')) {
+							$currencies[$currency->getAttribute('currency')] = $currency->getAttribute('rate');
+						}
+					}
+
+					if ($currencies) {
+						$this->load->model('localisation/currency');
+
+						$default = $this->config->get('config_currency');
+
+						$results = $this->model_localisation_currency->getCurrencies();
+
+						foreach ($results as $result) {
+							if (isset($currencies[$result['code']])) {
+								$from = $currencies['EUR'];
+
+								$to = $currencies[$result['code']];
+
+								$this->editValueByCode($result['code'], 1 / ($currencies[$default] * ($from / $to)));
+							}
+						}
+					}
+
+					$this->editValueByCode($default, '1.00000');
+				}
+				return true;
+			}
+		}
+		return false;
+	}
 }

--- a/upload/admin/model/localisation/currency.php
+++ b/upload/admin/model/localisation/currency.php
@@ -6,7 +6,7 @@ class ModelLocalisationCurrency extends Model {
 		$currency_id = $this->db->getLastId();
 
 		if ($this->config->get('config_currency_auto')) {
-			$this->refresh(true);
+			$this->refresh();
 		}
 
 		$this->cache->delete('currency');
@@ -99,54 +99,12 @@ class ModelLocalisationCurrency extends Model {
 		}
 	}
 
-	public function refresh($force = false) {
-		$currency_data = array();
-
-		if ($force) {
-			$query = $this->db->query("SELECT * FROM " . DB_PREFIX . "currency WHERE code != '" . $this->db->escape($this->config->get('config_currency')) . "'");
-		} else {
-			$query = $this->db->query("SELECT * FROM " . DB_PREFIX . "currency WHERE code != '" . $this->db->escape($this->config->get('config_currency')) . "' AND date_modified < '" .  $this->db->escape(date('Y-m-d H:i:s', strtotime('-1 day'))) . "'");
+	public function refresh() {
+		$config_currency_engine = $this->config->get('config_currency_engine');
+		if ($config_currency_engine) {
+			$this->load->model('extension/currency/'.$config_currency_engine);
+			$this->{'model_extension_currency_'.$config_currency_engine}->refresh();
 		}
-
-		foreach ($query->rows as $result) {
-			$currency_data[] = $this->config->get('config_currency') . $result['code'] . '=X';
-			$currency_data[] = $result['code'] . $this->config->get('config_currency') . '=X';
-		}
-
-		$curl = curl_init();
-
-		curl_setopt($curl, CURLOPT_URL, 'http://download.finance.yahoo.com/d/quotes.csv?s=' . implode(',', $currency_data) . '&f=sl1&e=.json');
-		curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-		curl_setopt($curl, CURLOPT_HEADER, false);
-		curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 30);
-		curl_setopt($curl, CURLOPT_TIMEOUT, 30);
-
-		$content = curl_exec($curl);
-		
-		curl_close($curl);
-
-		$line = explode("\n", trim($content));
-
-		for ($i = 0; $i < count($line); $i = $i + 2) {
-			$currency = utf8_substr($line[$i], 4, 3);
-			$value = utf8_substr($line[$i], 11, 6);
-			
-			if ((float)$value < 1 && isset($line[$i + 1])) {
-				if ((float)utf8_substr($line[$i + 1], 11, 6) > 0) {
-					$value = (1 / (float)utf8_substr($line[$i + 1], 11, 6));
-				} else {
-					$value = 0;
-				}
-			}	
-						
-			if ((float)$value) {
-				$this->db->query("UPDATE " . DB_PREFIX . "currency SET value = '" . (float)$value . "', date_modified = '" .  $this->db->escape(date('Y-m-d H:i:s')) . "' WHERE code = '" . $this->db->escape($currency) . "'");
-			}
-		}
-
-		$this->db->query("UPDATE " . DB_PREFIX . "currency SET value = '1.00000', date_modified = '" .  $this->db->escape(date('Y-m-d H:i:s')) . "' WHERE code = '" . $this->db->escape($this->config->get('config_currency')) . "'");
-
-		$this->cache->delete('currency');
 	}
 
 	public function getTotalCurrencies() {

--- a/upload/catalog/controller/extension/currency/ecb.php
+++ b/upload/catalog/controller/extension/currency/ecb.php
@@ -9,9 +9,11 @@ class ControllerExtensionCurrencyEcb extends Controller {
 		}
 
 		$config_currency_engine = $this->config->get('config_currency_engine');
+
 		if (!$config_currency_engine) {
 			return false;
 		}
+
 		if ($config_currency_engine != 'ecb') {
 			return false;
 		}
@@ -22,58 +24,8 @@ class ControllerExtensionCurrencyEcb extends Controller {
 			}
 		}
 
-		$curl = curl_init();
-
-		curl_setopt($curl, CURLOPT_URL, 'https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml');
-		curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-		curl_setopt($curl, CURLOPT_HEADER, false);
-		curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 0);
-		curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 30);
-		curl_setopt($curl, CURLOPT_TIMEOUT, 30);
-
-		$response = curl_exec($curl);
-
-		curl_close($curl);
-
-		if ($response) {
-			$dom = new \DOMDocument('1.0', 'UTF-8');
-			$dom->loadXml($response);
-
-			$cube = $dom->getElementsByTagName('Cube')->item(0);
-
-			$currencies = [];
-
-			$currencies['EUR'] = 1.0000;
-
-			foreach ($cube->getElementsByTagName('Cube') as $currency) {
-				if ($currency->getAttribute('currency')) {
-					$currencies[$currency->getAttribute('currency')] = $currency->getAttribute('rate');
-				}
-			}
-
-			if ($currencies) {
-				$this->load->model('localisation/currency');
-				$this->load->model('extension/currency/ecb');
-
-				$default = $this->config->get('config_currency');
-
-				$results = $this->model_localisation_currency->getCurrencies();
-
-				foreach ($results as $result) {
-					if (isset($currencies[$result['code']])) {
-						$from = $currencies['EUR'];
-
-						$to = $currencies[$result['code']];
-
-						$this->model_extension_currency_ecb->editValueByCode($result['code'], 1 / ($currencies[$default] * ($from / $to)));
-					}
-				}
-			}
-
-			$this->model_extension_currency_ecb->editValueByCode($default, '1.00000');
-
-			$this->cache->delete('currency');
-		}
+		$this->load->model('extension/currency/ecb');
+		$this->model_extension_currency_ecb->refresh();
 
 		return true;
 	}

--- a/upload/catalog/model/extension/currency/ecb.php
+++ b/upload/catalog/model/extension/currency/ecb.php
@@ -5,4 +5,59 @@ class ModelExtensionCurrencyEcb extends Model {
 		$this->db->query("UPDATE `" . DB_PREFIX . "currency` SET `value` = '" . (float)$value . "', `date_modified` = NOW() WHERE `code` = '" . $this->db->escape((string)$code) . "'");
 		$this->cache->delete('currency');
 	}
+
+	public function refresh() {
+		$curl = curl_init();
+
+		curl_setopt($curl, CURLOPT_URL, 'https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml');
+		curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+		curl_setopt($curl, CURLOPT_HEADER, false);
+		curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 0);
+		curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 30);
+		curl_setopt($curl, CURLOPT_TIMEOUT, 30);
+
+		$response = curl_exec($curl);
+
+		curl_close($curl);
+
+		if ($response) {
+			$dom = new \DOMDocument('1.0', 'UTF-8');
+			$dom->loadXml($response);
+
+			$cube = $dom->getElementsByTagName('Cube')->item(0);
+
+			$currencies = [];
+
+			$currencies['EUR'] = 1.0000;
+
+			foreach ($cube->getElementsByTagName('Cube') as $currency) {
+				if ($currency->getAttribute('currency')) {
+					$currencies[$currency->getAttribute('currency')] = $currency->getAttribute('rate');
+				}
+			}
+
+			if ($currencies) {
+				$this->load->model('localisation/currency');
+				$this->load->model('extension/currency/ecb');
+
+				$default = $this->config->get('config_currency');
+
+				$results = $this->model_localisation_currency->getCurrencies();
+
+				foreach ($results as $result) {
+					if (isset($currencies[$result['code']])) {
+						$from = $currencies['EUR'];
+
+						$to = $currencies[$result['code']];
+
+						$this->model_extension_currency_ecb->editValueByCode($result['code'], 1 / ($currencies[$default] * ($from / $to)));
+					}
+				}
+			}
+
+			$this->model_extension_currency_ecb->editValueByCode($default, '1.00000');
+
+			$this->cache->delete('currency');
+		}
+	}
 }


### PR DESCRIPTION
Move calls to ECB API to model files.
Make sure all calls to model/localisation/currency/refresh are now done to the selected currency engine's API, e.g. ECB.