### PR TITLE
Fix Cache/file.php - …

### DIFF
--- a/upload/system/library/cache/file.php
+++ b/upload/system/library/cache/file.php
@@ -30,11 +30,19 @@ class File {
 	public function get(string $key) {
 		$files = glob(DIR_CACHE . 'cache.' . preg_replace('/[^A-Z0-9\._-]/i', '', $key) . '.*');
 
-		if ($files) {
-			return json_decode(file_get_contents($files[0]), true);
-		} else {
-			return [];
-		}
+        foreach ($files as $file) {
+            $time = substr(strrchr($file, '.'), 1);
+
+            if ($time < time()) {
+                if (!@unlink($file)) {
+                    clearstatcache(false, $file);
+                }
+            } else {
+                return json_decode(file_get_contents($file), true);
+            }
+        }
+
+        return [];
 	}
 
 	/**


### PR DESCRIPTION
in many cases, expired cache was returned, because __destructor is executed randomly (100:1).

Before return content of file, check if is valid, otherwise expired file is unlinked and check another file.