### PR TITLE
Add 'status' field to customer affiliate query

### DIFF
--- a/upload/admin/model/marketing/affiliate.php
+++ b/upload/admin/model/marketing/affiliate.php
@@ -62,7 +62,7 @@ class Affiliate extends \Opencart\System\Engine\Model {
 	 * @return array<string, mixed>
 	 */
 	public function getAffiliate(int $customer_id): array {
-		$query = $this->db->query("SELECT DISTINCT *, CONCAT(`c`.`firstname`, ' ', `c`.`lastname`) AS `customer`, `ca`.`custom_field` FROM `" . DB_PREFIX . "customer_affiliate` `ca` LEFT JOIN `" . DB_PREFIX . "customer` `c` ON (`ca`.`customer_id` = `c`.`customer_id`) WHERE `ca`.`customer_id` = '" . (int)$customer_id . "'");
+		$query = $this->db->query("SELECT DISTINCT *, CONCAT(`c`.`firstname`, ' ', `c`.`lastname`) AS `customer`, `ca`.`custom_field`, `ca`.`status` FROM `" . DB_PREFIX . "customer_affiliate` `ca` LEFT JOIN `" . DB_PREFIX . "customer` `c` ON (`ca`.`customer_id` = `c`.`customer_id`) WHERE `ca`.`customer_id` = '" . (int)$customer_id . "'");
 
 		if ($query->num_rows) {
 			return $query->row + ['custom_field' => json_decode($query->row['custom_field'], true)];


### PR DESCRIPTION
Update query to include 'status' field in customer affiliate data

- Added the 'status' field to the SELECT statement in the customer affiliate query.
- This ensures that the affiliate status is retrieved along with other customer details.