### PR TITLE
change "account_custom_field" from string to object by json_decode

### DIFF
--- a/upload/admin/controller/customer/customer.php
+++ b/upload/admin/controller/customer/customer.php
@@ -598,7 +598,7 @@ class Customer extends \Opencart\System\Engine\Controller {
 		}
 
 		if (!empty($customer_info)) {
-			$data['account_custom_field'] = $customer_info['custom_field'];
+			$data['account_custom_field'] = json_decode($customer_info['custom_field'], true);
 		} else {
 			$data['account_custom_field'] = [];
 		}

--- a/upload/admin/controller/sale/order.php
+++ b/upload/admin/controller/sale/order.php
@@ -632,7 +632,7 @@ class Order extends \Opencart\System\Engine\Controller {
 		}
 
 		if (!empty($order_info)) {
-			$data['account_custom_field'] = $order_info['custom_field'];
+			$data['account_custom_field'] = json_decode($order_info['custom_field'], true);
 		} else {
 			$data['account_custom_field'] = [];
 		}

--- a/upload/catalog/controller/account/edit.php
+++ b/upload/catalog/controller/account/edit.php
@@ -71,7 +71,7 @@ class Edit extends \Opencart\System\Engine\Controller {
 			}
 		}
 
-		$data['account_custom_field'] = $customer_info['custom_field'];
+		$data['account_custom_field'] = json_decode($customer_info['custom_field'], true);
 
 		$data['back'] = $this->url->link('account/account', 'language=' . $this->config->get('config_language') . '&customer_token=' . $this->session->data['customer_token']);
 


### PR DESCRIPTION
 from the usage in the follow codes, we can know  $data['account_custom_field'] is object
-    admin\view\template\customer\customer_form.twig
-    admin\view\template\sale\order_info.twig
-    catalog\view\template\account\edit.twig

as $customer_info['custom_field'] is read from mysql, so it's string, so we should change the type from string to object  in the follow 3 files by json_decode($customer_info['custom_field'], true):
-   upload/admin/controller/customer/customer.php
-   upload/admin/controller/sale/order.php
-   upload/catalog/controller/account/edit.php

the fix code is reference to version "3.0.3.9". in version  "3.0.3.9"  also use json_decode to convert string to object 
`
$data['account_custom_field']` = json_decode($customer_info['custom_field'], true);
`


 
