### PR TITLE
fix error about validate_length for telephone

### DIFF
--- a/upload/admin/controller/customer/customer.php
+++ b/upload/admin/controller/customer/customer.php
@@ -690,7 +690,7 @@ class Customer extends \Opencart\System\Engine\Controller {
 			}
 		}
 
-		if ($this->config->get('config_telephone_required') && oc_validate_length($this->request->post['telephone'], 3, 32)) {
+		if ($this->config->get('config_telephone_required') && !oc_validate_length($this->request->post['telephone'], 3, 32)) {
 			$json['error']['telephone'] = $this->language->get('error_telephone');
 		}
 


### PR DESCRIPTION
in upload/admin/controller/customer/customer.php should change 
`oc_validate_length($this->request->post['telephone'], 3, 32) `

to 
`!oc_validate_length($this->request->post['telephone'], 3, 32)
`

because  telephone's length betwee  3 and 32 is not error.  
it's error when length is less than 3, or bigger than 32