### PR TITLE
fix issue: can't delete order from order-list

### DIFF
--- a/upload/admin/view/template/sale/order.twig
+++ b/upload/admin/view/template/sale/order.twig
@@ -184,7 +184,7 @@ $('#button-delete').on('click', function(e) {
 
     if (confirm('{{ text_confirm }}')) {
         $.ajax({
-            url: 'index.php?route=sale/order.call&user_token={{ user_token }}&action=sale/order.delete',
+            url: 'index.php?route=sale/order.call&user_token={{ user_token }}&call=order.delete',
             type: 'post',
             data: $('#form-order').serialize(),
             dataType: 'json',


### PR DESCRIPTION
at "sales" ---"orders" page, when select an order, then client "delete" button at top-right corner, there is no response, and can't delete the order.

the reason is the url for "button-delete" click event is wrong, at line 187 of admin/view/template/sale/order.twig current is
`
url: 'index.php?route=sale/order.call&user_token={{ user_token }}&action=sale/order.delete'
`
should change "action=sale/order.delete"  to "call=order.delete", that is should change to 
`
url: 'index.php?route=sale/order.call&user_token={{ user_token }}&call=order.delete'
`

we can reference to admin/view/template/sale/order_info.twig, for example
`
url: 'index.php?route=sale/order.call&user_token={{ user_token }}&call=order.addHistory&store_id=' + $('#input-store').val() + '&language=' + $('#input-language').val() + '&currency=' + $('#input-currency').val() + '&order_id=' + $('#input-order-id').val(),
`
