### PR TITLE
Avoid to fill up log with notices about unlink is not possible

### DIFF
--- a/upload/system/library/cache/file.php
+++ b/upload/system/library/cache/file.php
@@ -15,6 +15,7 @@ class File {
 				if ($time < time()) {
 					if (file_exists($file)) {
 						unlink($file);
+						clearstatcache(false, $file);
 					}
 				}
 			}
@@ -70,6 +71,7 @@ class File {
 			foreach ($files as $file) {
 				if (file_exists($file)) {
 					unlink($file);
+					clearstatcache(false, $file);
 				}
 			}
 		}


### PR DESCRIPTION
Added clearstatcache() to avoid notices in log file