### PR TITLE
Updates to  seo_url.php

### DIFF
--- a/upload/catalog/controller/startup/seo_url.php
+++ b/upload/catalog/controller/startup/seo_url.php
@@ -33,6 +33,19 @@ class SeoUrl extends \Opencart\System\Engine\Controller {
 					if ($seo_url_info) {
 						$this->request->get[$seo_url_info['key']] = html_entity_decode($seo_url_info['value'], ENT_QUOTES, 'UTF-8');
 
+						// If product_id is found, set the route to product/product
+                        if ($seo_url_info['key'] == 'product_id') {
+                            $this->request->get['route'] = 'product/product';
+                        }
+                        // If category_id is found, set the route to product/category
+                        if ($seo_url_info['key'] == 'category_id') {
+                            $this->request->get['route'] = 'product/category';
+                        }
+                        // If information_id is found, set the route to information/information
+                        if ($seo_url_info['key'] == 'information_id') {
+                            $this->request->get['route'] = 'information/information';
+                        }
+						
 						unset($parts[$key]);
 					}
 				}
@@ -98,12 +111,12 @@ class SeoUrl extends \Opencart\System\Engine\Controller {
 				$value = '';
 			}
 
-			if (!isset($this->data[$key])) {
-				$this->data[$key] = $this->model_design_seo_url->getSeoUrlByKeyValue((string)$key, (string)$value);
+			if (!isset($this->data[$key][$value])) {
+				$this->data[$key][$value] = $this->model_design_seo_url->getSeoUrlByKeyValue((string)$key, (string)$value);
 			}
 
-			if ($this->data[$key]) {
-				$paths[] = $this->data[$key];
+			if ($this->data[$key][$value]) {
+				$paths[] = $this->data[$key][$value];
 
 				unset($query[$key]);
 			}

--- a/upload/catalog/controller/startup/seo_url.php
+++ b/upload/catalog/controller/startup/seo_url.php
@@ -32,26 +32,27 @@ class SeoUrl extends \Opencart\System\Engine\Controller {
 
 					if ($seo_url_info) {
 						$this->request->get[$seo_url_info['key']] = html_entity_decode($seo_url_info['value'], ENT_QUOTES, 'UTF-8');
-
-						// If product_id is found, set the route to product/product
-                        if ($seo_url_info['key'] == 'product_id') {
-                            $this->request->get['route'] = 'product/product';
-                        }
-                        // If category_id is found, set the route to product/category
-                        if ($seo_url_info['key'] == 'category_id') {
-                            $this->request->get['route'] = 'product/category';
-                        }
-                        // If information_id is found, set the route to information/information
-                        if ($seo_url_info['key'] == 'information_id') {
-                            $this->request->get['route'] = 'information/information';
-                        }
 						
 						unset($parts[$key]);
 					}
 				}
 
 				if (!isset($this->request->get['route'])) {
-					$this->request->get['route'] = $this->config->get('action_default');
+					switch (true) {
+						case isset($this->request->get['product_id']):
+							$this->request->get['route'] = 'product/product';
+							break;
+						case isset($this->request->get['category_id']):
+							$this->request->get['route'] = 'product/category';
+							break;
+						case isset($this->request->get['information_id']):
+							$this->request->get['route'] = 'information/information';
+							break;
+						default:
+							// Set the default route if no specific key matches
+							$this->request->get['route'] = $this->config->get('action_default');
+							break;
+					}
 				}
 
 				if ($parts) {


### PR DESCRIPTION
Updated route-setting logic in `index()` where if a route is not set, but a product_id / category_id / information_id has been pulled from the database, set the route accordingly. 

Updated rewrite so that if getSeoURLByKeyValue is ran, the value is stored in the array to prevent duplicate lookups