### PR TITLE
enable "Print Shipping List" button at  "sale/order.info" page

### DIFF
--- a/upload/admin/view/template/sale/order_info.twig
+++ b/upload/admin/view/template/sale/order_info.twig
@@ -2,7 +2,7 @@
 <div id="content">
   <div class="page-header">
     <div class="container-fluid">
-      <div class="float-end"><a href="{{ invoice }}" target="_blank" data-bs-toggle="tooltip" title="{{ button_invoice_print }}" class="btn btn-info{% if not order_id %} disabled{% endif %}"><i class="fa-solid fa-print"></i></a> <a href="{{ shipping }}" target="_blank" data-bs-toggle="tooltip" title="{{ button_shipping_print }}" class="btn btn-info{% if not shipping_code %} disabled{% endif %}"><i class="fa-solid fa-truck"></i></a> <a href="{{ back }}" data-bs-toggle="tooltip" title="{{ button_back }}" class="btn btn-light"><i class="fa-solid fa-reply"></i></a></div>
+      <div class="float-end"><a href="{{ invoice }}" target="_blank" data-bs-toggle="tooltip" title="{{ button_invoice_print }}" class="btn btn-info{% if not order_id %} disabled{% endif %}"><i class="fa-solid fa-print"></i></a> <a href="{{ shipping }}" target="_blank" data-bs-toggle="tooltip" title="{{ button_shipping_print }}" class="btn btn-info{% if not order_id %} disabled{% endif %}"><i class="fa-solid fa-truck"></i></a> <a href="{{ back }}" data-bs-toggle="tooltip" title="{{ button_back }}" class="btn btn-light"><i class="fa-solid fa-reply"></i></a></div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">
         {% for breadcrumb in breadcrumbs %}


### PR DESCRIPTION
problems to fix:   at order detail page "admin/index.php?route=sale/order.info", current version  can't click top-right button "Print Shipping List" 

 from  file "upload/install/controller/upgrade/upgrade_9.php" we can see "order" table's  `shipping_method`, `shipping_code`  has merge to one new field "shipping_method", and save as json string

as  "enable" check condition of  top-right "Print Invoice" button is  
`{% if not order_id %} disabled{% endif %}"`

so for  "Print Shipping List" , we  change "shipping_code" to "order_id", that is  the same check condition with "Print Invoice" button
`{% if not order_id %} disabled{% endif %}"`


