### PR TITLE
TWIG use_yield options

### DIFF
--- a/upload/system/library/template/twig.php
+++ b/upload/system/library/template/twig.php
@@ -107,7 +107,8 @@ class Twig {
 				'autoescape'  => false,
 				'debug'       => true,
 				'auto_reload' => true,
-				'cache'       => DIR_CACHE . 'template/'
+				'cache'       => DIR_CACHE . 'template/',
+				'use_yield'   => true
 			];
 
 			$twig = new \Twig\Environment($loader, $config);


### PR DESCRIPTION
this option is not in the documentation for version 3 of TWIG, but it is already in use: https://github.com/twigphp/Twig/blob/efc527ea65f0b12c6afda0a1e57e2f220e69afd2/src/Environment.php#L106

In version 4 of TWIG, the option will be true by default, but you can use it now

With this option, memory consumption is much lower and rendering is faster.