### PR TITLE
Compatibility with php 7.4 (storage moving, security.php)

### DIFF
--- a/upload/admin/controller/common/security.php
+++ b/upload/admin/controller/common/security.php
@@ -220,7 +220,7 @@ class Security extends \Opencart\System\Engine\Controller {
 				$json['error'] = $this->language->get('error_storage_root');
 			}
 
-			if (!str_starts_with($name, 'storage')) {
+			if (substr($name, 0, 7) != 'storage') {
 				$json['error'] = $this->language->get('error_storage_name');
 			}
 


### PR DESCRIPTION
str_starts_with() is php 8 function, it does not allow to move the storage dir, on php 7.4 we get an error: 'Warning: Storage directory name must start with `storage`! e.g. `storage_`.'