### PR TITLE
fix convert from string to object problems of "custom_field" in customer.php

### DIFF
--- a/upload/admin/model/customer/customer.php
+++ b/upload/admin/model/customer/customer.php
@@ -99,7 +99,8 @@ class Customer extends \Opencart\System\Engine\Model {
 		$query = $this->db->query("SELECT DISTINCT * FROM `" . DB_PREFIX . "customer` WHERE `customer_id` = '" . (int)$customer_id . "'");
 
 		if ($query->num_rows) {
-			return $query->row + ['custom_field' => json_decode($query->row['custom_field'], true)];
+			$query->row['custom_field'] = json_decode($query->row['custom_field'], true);
+			return $query->row;
 		} else {
 			return [];
 		}
@@ -116,7 +117,8 @@ class Customer extends \Opencart\System\Engine\Model {
 		$query = $this->db->query("SELECT DISTINCT * FROM `" . DB_PREFIX . "customer` WHERE LCASE(`email`) = '" . $this->db->escape(oc_strtolower($email)) . "'");
 
 		if ($query->num_rows) {
-			return $query->row + ['custom_field' => json_decode($query->row['custom_field'], true)];
+			$query->row['custom_field'] = json_decode($query->row['custom_field'], true);
+			return $query->row;
 		} else {
 			return [];
 		}
@@ -202,7 +204,8 @@ class Customer extends \Opencart\System\Engine\Model {
 		$query = $this->db->query($sql);
 
 		foreach ($query->rows as $result) {
-			$customer_data[] = $result + ['custom_field' => json_decode($result['custom_field'], true)];
+			$result['custom_field'] = json_decode($result['custom_field'], true);
+			$customer_data[] = $result;
 		}
 
 		return $customer_data;

--- a/upload/catalog/model/account/customer.php
+++ b/upload/catalog/model/account/customer.php
@@ -151,7 +151,8 @@ class Customer extends \Opencart\System\Engine\Model {
 		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "customer` WHERE `customer_id` = '" . (int)$customer_id . "'");
 
 		if ($query->num_rows) {
-			return $query->row + ['custom_field' => json_decode($query->row['custom_field'], true)];
+			$query->row['custom_field'] = json_decode($query->row['custom_field'], true);
+			return $query->row;
 		} else {
 			return [];
 		}
@@ -168,7 +169,8 @@ class Customer extends \Opencart\System\Engine\Model {
 		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "customer` WHERE LCASE(`email`) = '" . $this->db->escape(oc_strtolower($email)) . "'");
 
 		if ($query->num_rows) {
-			return $query->row + ['custom_field' => json_decode($query->row['custom_field'], true)];
+			$query->row['custom_field'] = json_decode($query->row['custom_field'], true);
+			return $query->row;
 		} else {
 			return [];
 		}
@@ -185,7 +187,8 @@ class Customer extends \Opencart\System\Engine\Model {
 		$query = $this->db->query("SELECT `customer_id`, `firstname`, `lastname`, `email` FROM `" . DB_PREFIX . "customer` WHERE `code` = '" . $this->db->escape($code) . "' AND `code` != ''");
 
 		if ($query->num_rows) {
-			return $query->row + ['custom_field' => json_decode($query->row['custom_field'], true)];
+			$query->row['custom_field'] = json_decode($query->row['custom_field'], true);
+			return $query->row;
 		} else {
 			return [];
 		}
@@ -204,7 +207,8 @@ class Customer extends \Opencart\System\Engine\Model {
 		if ($query->num_rows) {
 			$this->db->query("UPDATE `" . DB_PREFIX . "customer` SET `token` = '' WHERE `customer_id` = '" . (int)$query->row['customer_id'] . "'");
 
-			return $query->row + ['custom_field' => json_decode($query->row['custom_field'], true)];
+			$query->row['custom_field'] = json_decode($query->row['custom_field'], true);
+			return $query->row;
 		} else {
 			return [];
 		}


### PR DESCRIPTION

current code 
`$query->row + ['custom_field' => json_decode($query->row['custom_field'], true)];`
is not work,   the 'custom_field'  still  string.

please refer to the article:  https://stitcher.io/blog/array-merge-vs+
-  the + operator will only add the elements of the rightside operand, if their key doesn't exist in the leftside operand, 
- while array_merge will override existing keys.

As I found there has samilar codes in upload/admin/model/catalog/product.php line 844 ~849:
`
		if ($query->num_rows) {
			$product_data = $query->row;

			$product_data['variant'] = json_decode($product_data['variant'], true);
			$product_data['override'] = json_decode($product_data['override'], true);
		}
`
so we fix this problem like the follow
`
		if ($query->num_rows) {
			$query->row['custom_field'] = json_decode($query->row['custom_field'], true);
			return $query->row;
		}
`