### PR TITLE
Update smtp.php

### DIFF
--- a/upload/system/library/mail/smtp.php
+++ b/upload/system/library/mail/smtp.php
@@ -251,10 +251,6 @@ class Smtp {
 
 			$this->handleReply($handle, 250, 'Error: DATA not accepted from server!');
 
-			fwrite($handle, 'QUIT' . "\r\n");
-
-			$this->handleReply($handle, 221, 'Error: QUIT not accepted from server!');
-
 			fclose($handle);
 
 			return true;


### PR DESCRIPTION
delete the useless 'QUIT', or it will lead to all new orders sent to missing orders,paypal payment being returned automatically after paying, fail to update admin order status and comment, sending  email, lots of duplicate new order email notifications being sent to store owner. etc.
[#14139](https://github.com/opencart/opencart/issues/14139)