### PR TITLE
Make model class properties visible via proxy

### DIFF
--- a/upload/system/engine/loader.php
+++ b/upload/system/engine/loader.php
@@ -150,14 +150,13 @@ class Loader {
 
 		$proxy = new \Opencart\System\Engine\Proxy();
 
+		// pass the object to proxy in order to provide access to public properties
+		$proxy->setObject($object);
+		
 		foreach (get_class_methods($object) as $method) {
 			if (substr($method, 0, 2) != '__') {
 				$proxy->{$method} = $this->callback($route . '.' . $method);
 			}
-		}
-
-		foreach (get_class_vars($class) as $name => $value) {
-			$proxy->{$name} = $value;
 		}
 
 		// Store proxy object

--- a/upload/system/engine/loader.php
+++ b/upload/system/engine/loader.php
@@ -156,6 +156,10 @@ class Loader {
 			}
 		}
 
+		foreach (get_class_vars($class) as $name => $value) {
+			$proxy->{$name} = $value;
+		}
+
 		// Store proxy object
 		$this->registry->set($key, $proxy);
 	}

--- a/upload/system/engine/proxy.php
+++ b/upload/system/engine/proxy.php
@@ -23,6 +23,22 @@ class Proxy {
 	protected array $data = [];
 
 	/**
+	 * @var object
+	 */
+	protected $object;
+
+	/**
+	 * setObject
+	 *
+	 * @param object $object
+	 *
+	 * @return void
+	 */
+	public function setObject(object $object): void {
+		$this->object = $object;
+	}
+
+	/**
 	 * __get
 	 *
 	 * @param string $key
@@ -32,6 +48,8 @@ class Proxy {
 	public function &__get(string $key) {
 		if (isset($this->data[$key])) {
 			return $this->data[$key];
+		} else if (isset($this->object->$key)) {
+			return $this->object->$key;
 		} else {
 			throw new \Exception('Error: Could not call proxy key ' . $key . '!');
 		}
@@ -41,12 +59,16 @@ class Proxy {
 	 * __set
 	 *
 	 * @param string $key
-	 * @param object $value
+	 * @param mixed $value
 	 *
 	 * @return void
 	 */
-	public function __set(string $key, object $value): void {
-		$this->data[$key] = $value;
+	public function __set(string $key, mixed $value): void {
+		if (is_object($value)) {
+			$this->data[$key] = $value;
+		} else {
+			$this->object->$key = $value;
+		}
 	}
 
 	/**


### PR DESCRIPTION
Model class properties are not visible via proxy. If they are declared public, this commit makes them visible:
```
extension/opencart/catalog/model/module/example.php
```
```php
namespace Opencart\Catalog\Model\Extension\Opencart\Module;
class Example extends \Opencart\System\Engine\Model {
	public $my_public_prop = 100;
	private $my_private_prop = 200;
}
```
```
extension/opencart/catalog/controller/module/example.php
```
```php
namespace Opencart\Catalog\Controller\Extension\Opencart\Module;
class BestSeller extends \Opencart\System\Engine\Controller {
	public function test_properties() {
		$this->load->model('extension/opencart/module/example');

		// publicly visible
		$data['my_public_prop'] = $this->model_extension_opencart_module_example->my_public_prop;

		// not visible so result will still be null
		$data['my_private_prop'] = $this->model_extension_opencart_module_example->my_private_prop;
	}
}
```