### PR TITLE
Fix URL encoding for product tags in OpenCart 3

### DIFF
--- a/upload/catalog/controller/product/product.php
+++ b/upload/catalog/controller/product/product.php
@@ -450,7 +450,7 @@ class ControllerProductProduct extends Controller {
 				foreach ($tags as $tag) {
 					$data['tags'][] = array(
 						'tag'  => trim($tag),
-						'href' => $this->url->link('product/search', 'tag=' . trim($tag))
+						'href' => $this->url->link('product/search', 'tag=' . rawurlencode(html_entity_decode(trim($tag), ENT_QUOTES, 'UTF-8')))
 					);
 				}
 			}


### PR DESCRIPTION
### Issue
Product tags with special characters (e.g., `&`, spaces) were not properly encoded, causing broken phrases

### Fix
Updated the product controller to use rawurlencode() and html_entity_decode() to handle special characters and HTML entities correctly.

### File Modified
- upload/catalog/controller/product/product.php

### Testing
- Tested with tags containing special characters (`&`, spaces, etc.) and verified correct URL encoding.
- Example: `Gas & Oil` now generates `tag=Gas%20%26%20Oil`.
https://www.carguygarage.com/index.php?route=product/search&tag=Gas%20%26%20Oil