### PR TITLE
Fix save product master with variants

### DIFF
--- a/upload/admin/model/catalog/product.php
+++ b/upload/admin/model/catalog/product.php
@@ -767,10 +767,6 @@ class Product extends \Opencart\System\Engine\Model {
 		foreach ($products as $product) {
 			$product_data = [];
 
-			// We need to convert JSON strings back into an array so they can be re-encoded to a string to go back into the database.
-			$product['override'] = (array)json_decode($product['override'], true);
-			$product['variant'] = (array)json_decode($product['variant'], true);
-
 			// We use the override to override the master product values
 			if ($product['override']) {
 				$override = $product['override'];


### PR DESCRIPTION
Trying to use `json_decode`on the indexes 'override' and 'variant', but in `function getProducts`, the json-string is already decoded into an array.

Triggering the errors:
```
Error: json_decode(): Argument #1 ($json) must be of type string, array given
File: .\admin\model\catalog\product.php
Line: 771

Backtrace: 0
File: .\admin\model\catalog\product.php
Line: 771
Function: json_decode

Backtrace: 1
File: .\system\engine\loader.php
Line: 343
Class: Opencart\Admin\Model\Catalog\Product
Function: editVariants

Backtrace: 2
File: .\system\engine\proxy.php
Line: 87
Class: Opencart\System\Engine\Loader
Function: Opencart\System\Engine\{closure}

Backtrace: 3
File: .\admin\controller\catalog\product.php
Line: 1261
Class: Opencart\System\Engine\Proxy
Function: __call

Backtrace: 4
File: .\system\engine\action.php
Line: 96
Class: Opencart\Admin\Controller\Catalog\Product
Function: save

Backtrace: 5
File: .\system\framework.php
Line: 259
Class: Opencart\System\Engine\Action
Function: execute

Backtrace: 6
File: .\admin\index.php
Line: 20
Function: require_once
```