### PR TITLE
Display current language in the language switcher

### DIFF
--- a/upload/catalog/controller/common/language.php
+++ b/upload/catalog/controller/common/language.php
@@ -51,9 +51,10 @@ class Language extends \Opencart\System\Engine\Controller {
 
 		$this->config->set('config_language_id', $language_id);
 
-		$data['name'] = $data['languages'][$result['code']]['name'];
-		$data['code'] = $this->config->get('config_language');
-		$data['image'] = $data['languages'][$result['code']]['image'];
+		$code = $this->config->get('config_language');
+		$data['code'] = $code;
+		$data['name'] = $data['languages'][$code]['name'];
+		$data['image'] = $data['languages'][$code]['image'];
 
 		return $this->load->view('common/language', $data);
 	}


### PR DESCRIPTION
In the header always shows the last language of the list as current, which is incorrect. It should show real current language.