### PR TITLE
Fix bug after exceeding login attempts.php

### DIFF
--- a/upload/catalog/controller/account/login.php
+++ b/upload/catalog/controller/account/login.php
@@ -136,7 +136,9 @@ class Login extends \Opencart\System\Engine\Controller {
 			if ($login_info && ($login_info['total'] >= $this->config->get('config_login_attempts')) && strtotime('-1 hour') < strtotime($login_info['date_modified'])) {
 				$json['error']['warning'] = $this->language->get('error_attempts');
 			}
+		}
 
+		if(!$json) {
 			// Check if customer has been approved.
 			$customer_info = $this->model_account_customer->getCustomerByEmail($this->request->post['email']);
 


### PR DESCRIPTION
After exceeding the login attempt limit, after refreshing the page you get an error: Undefined array key "customer_token".
This is because system doesn't allow you to log in but creates "customer_id".