### PR TITLE
Fix for repairCategories

### DIFF
--- a/upload/admin/model/catalog/category.php
+++ b/upload/admin/model/catalog/category.php
@@ -359,10 +359,10 @@ class Category extends \Opencart\System\Engine\Model {
 	 * $this->model_catalog_category->repairCategories();
 	 */
 	public function repairCategories(int $parent_id = 0): void {
-		$categories = $this->model_catalog_category->getCategories(['filter_parent_id' => $parent_id]);
-
+		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "category` WHERE `parent_id` = '" . (int)$parent_id . "'");
+		
 		// Delete the path below the current one
-		foreach ($categories as $category) {
+		foreach ($query->rows as $category) {
 			// Delete the path below the current one
 			$this->model_catalog_category->deletePaths($category['category_id']);
 


### PR DESCRIPTION
If table 'oc_category_path' is empty or corrupted, then the repairCategories function won't repopulate it correctly. This fix addresses the scenario where the table was empty.