### PR TITLE
[offer] Style of disabled list items

### DIFF
--- a/upload/admin/view/stylesheet/bootstrap.css
+++ b/upload/admin/view/stylesheet/bootstrap.css
@@ -1613,7 +1613,7 @@ progress {
   --bs-table-active-color: var(--bs-emphasis-color);
   --bs-table-active-bg: rgba(var(--bs-emphasis-color-rgb), 0.1);
   --bs-table-hover-color: var(--bs-emphasis-color);
-  --bs-table-hover-bg: rgba(var(--bs-emphasis-color-rgb), 0.075);
+  --bs-table-hover-bg: rgba(var(--bs-emphasis-color-rgb), 0.03);
   width: 100%;
   margin-bottom: 1rem;
   vertical-align: top;
@@ -1677,7 +1677,7 @@ progress {
   --bs-table-striped-color: #000;
   --bs-table-active-bg: #bdd2dd;
   --bs-table-active-color: #000;
-  --bs-table-hover-bg: #c2d8e3;
+  --bs-table-hover-bg: #cce2ee;
   --bs-table-hover-color: #000;
   color: var(--bs-table-color);
   border-color: var(--bs-table-border-color);
@@ -1690,7 +1690,7 @@ progress {
   --bs-table-striped-color: #000;
   --bs-table-active-bg: #cbccce;
   --bs-table-active-color: #000;
-  --bs-table-hover-bg: #d1d2d4;
+  --bs-table-hover-bg: #dbdcde;
   --bs-table-hover-color: #000;
   color: var(--bs-table-color);
   border-color: var(--bs-table-border-color);
@@ -1703,7 +1703,7 @@ progress {
   --bs-table-striped-color: #000;
   --bs-table-active-bg: #c5d8c5;
   --bs-table-active-color: #000;
-  --bs-table-hover-bg: #cbdecb;
+  --bs-table-hover-bg: #d4e9d4;
   --bs-table-hover-color: #000;
   color: var(--bs-table-color);
   border-color: var(--bs-table-border-color);
@@ -1716,7 +1716,7 @@ progress {
   --bs-table-striped-color: #000;
   --bs-table-active-bg: #c7d9dd;
   --bs-table-active-color: #000;
-  --bs-table-hover-bg: #ccdfe4;
+  --bs-table-hover-bg: #d6eaef;
   --bs-table-hover-color: #000;
   color: var(--bs-table-color);
   border-color: var(--bs-table-border-color);
@@ -1729,7 +1729,7 @@ progress {
   --bs-table-striped-color: #000;
   --bs-table-active-bg: #e4d5c2;
   --bs-table-active-color: #000;
-  --bs-table-hover-bg: #eadbc7;
+  --bs-table-hover-bg: #f5e6d1;
   --bs-table-hover-color: #000;
   color: var(--bs-table-color);
   border-color: var(--bs-table-border-color);
@@ -1742,7 +1742,7 @@ progress {
   --bs-table-striped-color: #000;
   --bs-table-active-bg: #e0c6c2;
   --bs-table-active-color: #000;
-  --bs-table-hover-bg: #e6ccc8;
+  --bs-table-hover-bg: #f2d5d2;
   --bs-table-hover-color: #000;
   color: var(--bs-table-color);
   border-color: var(--bs-table-border-color);
@@ -1755,7 +1755,7 @@ progress {
   --bs-table-striped-color: #000;
   --bs-table-active-bg: #e6e6e6;
   --bs-table-active-color: #000;
-  --bs-table-hover-bg: #ececec;
+  --bs-table-hover-bg: #f7f7f7;
   --bs-table-hover-color: #000;
   color: var(--bs-table-color);
   border-color: var(--bs-table-border-color);
@@ -1768,7 +1768,7 @@ progress {
   --bs-table-striped-color: #fff;
   --bs-table-active-bg: #373b3e;
   --bs-table-active-color: #fff;
-  --bs-table-hover-bg: #323539;
+  --bs-table-hover-bg: #282c2f;
   --bs-table-hover-color: #fff;
   color: var(--bs-table-color);
   border-color: var(--bs-table-border-color);

--- a/upload/admin/view/stylesheet/scss/_variables.scss
+++ b/upload/admin/view/stylesheet/scss/_variables.scss
@@ -750,7 +750,7 @@ $table-active-bg-factor:      .1 !default;
 $table-active-bg:             rgba(var(--#{$prefix}emphasis-color-rgb), $table-active-bg-factor) !default;
 
 $table-hover-color:           $table-color !default;
-$table-hover-bg-factor:       .075 !default;
+$table-hover-bg-factor:       .03 !default;
 $table-hover-bg:              rgba(var(--#{$prefix}emphasis-color-rgb), $table-hover-bg-factor) !default;
 
 $table-border-factor:         .2 !default;

--- a/upload/admin/view/stylesheet/stylesheet.css
+++ b/upload/admin/view/stylesheet/stylesheet.css
@@ -886,3 +886,11 @@ td {
     position: relative;
 	vertical-align: middle;
 }
+ .list-disabled, .list-disabled td {
+     color: #888;
+     background-color: #EBEBEB;
+     border: #CCC 1px solid;
+ }
+ .list-disabled :hover {
+     color: #000;
+ }

--- a/upload/admin/view/template/catalog/product_list.twig
+++ b/upload/admin/view/template/catalog/product_list.twig
@@ -15,15 +15,10 @@
       <tbody>
         {% if products %}
           {% for product in products %}
-            <tr{% if not product.variant %} class="table-warning"{% endif %}>
+            <tr{% if not product.status %} class="list-disabled"{% endif %}>
               <td class="text-center"><input type="checkbox" name="selected[]" value="{{ product.product_id }}" class="form-check-input"/></td>
               <td class="text-center"><img src="{{ product.image }}" alt="{{ product.name }}" class="img-thumbnail"/></td>
-              <td>{{ product.name }}
-                {% if product.status %}
-                  <span class="badge text-bg-success">{{ text_enabled }}</span>
-                {% else %}
-                  <span class="badge text-bg-danger">{{ text_disabled }}</span>
-                {% endif %}</td>
+              <td>{{ product.name }}</td>
               <td class="d-none d-lg-table-cell">{{ product.model }}</td>
               <td class="text-end">
                 {% if product.special %}<span style="text-decoration: line-through;">{{ product.price }}</span>
@@ -40,7 +35,7 @@
                 {% else %}
                   <span class="badge bg-success">{{ product.quantity }}</span>
                 {% endif %}</td>
-              <td class="text-end">
+              <td class="text-end col-1">
                 {% if product.variant %}
                   <div class="btn-group">
                     <a href="{{ product.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a>


### PR DESCRIPTION
In this PR, I propose to change the style of highlighting the disabled table list items.
If the PR is accepted, I will prepare a continuation and finalize the rest of the admin panel's tabular lists.
If you don't like it, then just close this PR.

Description of the offer
- To highlight the disabled table rows, the CSS class `.list-disabled` was added
- The code is slightly simplified: it is enough (by the condition) to add a CSS class to the `<TR>` tag
- Lists look more strict and clean
- If desired, the style of all disabled elements can be changed by simply editing the CSS style
- Previously, the line with the product variant was highlighted with a yellow background, but the variant is already highlighted with a yellow button, which is clearly visible.

![r1_c1](https://github.com/user-attachments/assets/d9985b01-1761-41a9-bd13-fb01405a8a51)