### PR TITLE
Fix for the modification system

### DIFF
--- a/upload/system/engine/autoloader.php
+++ b/upload/system/engine/autoloader.php
@@ -76,7 +76,7 @@ class Autoloader {
 		}
 
 		if (isset($file) && is_file($file)) {
-			include_once($file);
+			include_once(modification($file));
 
 			return true;
 		} else {

--- a/upload/system/startup.php
+++ b/upload/system/startup.php
@@ -50,6 +50,18 @@ if (!empty($_SERVER['HTTP_CLIENT_IP'])) {
 	$_SERVER['REMOTE_ADDR'] = $_SERVER['HTTP_CLIENT_IP'];
 }
 
+// Modification Override
+function modification($filename): string
+{
+    $modification = DIR_EXTENSION . 'ocmod/' . substr($filename, strlen(DIR_OPENCART));
+
+    if (is_file($modification)) {
+        return $modification; // Modified file
+    }
+
+    return $filename; // Default file
+}
+
 // OpenCart Autoloader
 require_once(DIR_SYSTEM . 'engine/autoloader.php');
 

--- a/upload/system/startup.php
+++ b/upload/system/startup.php
@@ -63,10 +63,10 @@ function modification($filename): string
 }
 
 // OpenCart Autoloader
-require_once(DIR_SYSTEM . 'engine/autoloader.php');
+require_once(modification(DIR_SYSTEM . 'engine/autoloader.php'));
 
 // Need config to store application values
-require_once(DIR_SYSTEM . 'engine/config.php');
+require_once(modification(DIR_SYSTEM . 'engine/config.php'));
 
 // Helper
 require_once(DIR_SYSTEM . 'helper/general.php');


### PR DESCRIPTION
Hello,

I needed to make simple modifications to the admin/catalog files using OCMOD but was unsuccessful.

```xml
<file path="admin/controller/catalog/category.php">
  <operation>
    <search index="0">
      <![CDATA[public function form(): void {]]>
    </search>
    <add position="after">
      <![CDATA[exit(__FILE__ . ':' . __LINE__);]]>
    </add>
  </operation>
</file>
```

I noticed that the files are correctly created in `<root>/extension/ocmod/...`, but they are not being loaded.

After analyzing `<root>/system/engine/autoloader.php`, I confirmed that they are indeed not being loaded. I am not sure if this was a design decision or an actual issue. However, I found some open issues that are directly related to the problem I am experiencing:
- https://github.com/opencart/opencart/issues/14326
- https://github.com/opencart/opencart/issues/14480
- ... among many others

This is a very important feature, and considering this, I propose a solution.