### PR TITLE
[fix] Cookie SameSite

### DIFF
--- a/upload/admin/controller/common/language.php
+++ b/upload/admin/controller/common/language.php
@@ -92,6 +92,7 @@ class Language extends \Opencart\System\Engine\Controller {
 			$option = [
 				'expires'  => time() + 60 * 60 * 24 * 365 * 10,
 				'path'     => $this->config->get('session_path'),
+                'secure'   => $this->request->server['HTTPS'],
 				'SameSite' => $this->config->get('config_session_samesite')
 			];
 

--- a/upload/catalog/controller/common/cookie.php
+++ b/upload/catalog/controller/common/cookie.php
@@ -54,6 +54,7 @@ class Cookie extends \Opencart\System\Engine\Controller {
 			$option = [
 				'expires'  => time() + 60 * 60 * 24 * 365,
 				'path'     => $this->config->get('session_path'),
+                'secure'   => $this->request->server['HTTPS'],
 				'SameSite' => $this->config->get('config_session_samesite')
 			];
 

--- a/upload/catalog/controller/startup/marketing.php
+++ b/upload/catalog/controller/startup/marketing.php
@@ -48,6 +48,7 @@ class Marketing extends \Opencart\System\Engine\Controller {
 						$option = [
 							'expires'  => $this->config->get('config_affiliate_expire') ? time() + (int)$this->config->get('config_affiliate_expire') : 0,
 							'path'     => $this->config->get('session_path'),
+                            'secure'   => $this->request->server['HTTPS'],
 							'SameSite' => $this->config->get('config_session_samesite')
 						];
 


### PR DESCRIPTION
DESCRIPTION: If you set Cookie SameSite=None in the system settings, then the Admin Panel languages ​​will not switch.

REASON: for Cookie SameSite=None the "secure" parameter is mandatory. Without it the cookie will not be set at all.