### PR TITLE
fix cookie_lifetime

### DIFF
--- a/upload/catalog/controller/startup/session.php
+++ b/upload/catalog/controller/startup/session.php
@@ -22,7 +22,7 @@ class ControllerStartupSession extends Controller {
 			
 			$this->session->start($session_id);
 			
-			setcookie($this->config->get('session_name'), $this->session->getId(), ini_get('session.cookie_lifetime'), ini_get('session.cookie_path'), ini_get('session.cookie_domain'));	
+			setcookie($this->config->get('session_name'), $this->session->getId(), (ini_get('session.cookie_lifetime') ? time() + ini_get('session.cookie_lifetime') : 0), ini_get('session.cookie_path'), ini_get('session.cookie_domain'));	
 		}
 	}
 }


### PR DESCRIPTION
Did anyone ever check cookies with lifetime set in php.ini?

```
; Lifetime in seconds of cookie or, if 0, until browser is restarted.
; http://php.net/session.cookie-lifetime
session.cookie_lifetime = 7776000
```