### PR TITLE
Add barcode search functionality to product list

### DIFF
--- a/upload/admin/controller/catalog/product.php
+++ b/upload/admin/controller/catalog/product.php
@@ -21,6 +21,12 @@ class Product extends \Opencart\System\Engine\Controller {
 		} else {
 			$filter_name = '';
 		}
+		
+		if (isset($this->request->get['filter_barcode'])) {
+			$filter_barcode = $this->request->get['filter_barcode'];
+		} else {
+			$filter_barcode = '';
+		}
 
 		if (isset($this->request->get['filter_model'])) {
 			$filter_model = $this->request->get['filter_model'];
@@ -90,6 +96,10 @@ class Product extends \Opencart\System\Engine\Controller {
 			$url .= '&filter_name=' . urlencode(html_entity_decode($this->request->get['filter_name'], ENT_QUOTES, 'UTF-8'));
 		}
 
+		if (isset($this->request->get['filter_barcode'])) {
+			$url .= '&filter_barcode=' . urlencode(html_entity_decode($this->request->get['filter_barcode'], ENT_QUOTES, 'UTF-8'));
+		}
+
 		if (isset($this->request->get['filter_model'])) {
 			$url .= '&filter_model=' . urlencode(html_entity_decode($this->request->get['filter_model'], ENT_QUOTES, 'UTF-8'));
 		}
@@ -153,6 +163,7 @@ class Product extends \Opencart\System\Engine\Controller {
 		$data['list'] = $this->load->controller('catalog/product.getList');
 
 		$data['filter_name'] = $filter_name;
+		$data['filter_barcode'] = $filter_barcode;
 		$data['filter_model'] = $filter_model;
 		$data['filter_category_id'] = $filter_category_id;
 		$data['filter_manufacturer_id'] = $filter_manufacturer_id;
@@ -208,6 +219,12 @@ class Product extends \Opencart\System\Engine\Controller {
 			$filter_name = $this->request->get['filter_name'];
 		} else {
 			$filter_name = '';
+		}
+
+		if (isset($this->request->get['filter_barcode'])) {
+			$filter_barcode = $this->request->get['filter_barcode'];
+		} else {
+			$filter_barcode = '';
 		}
 
 		if (isset($this->request->get['filter_model'])) {
@@ -282,6 +299,10 @@ class Product extends \Opencart\System\Engine\Controller {
 			$url .= '&filter_name=' . urlencode(html_entity_decode($this->request->get['filter_name'], ENT_QUOTES, 'UTF-8'));
 		}
 
+		if (isset($this->request->get['filter_barcode'])) {
+			$url .= '&filter_barcode=' . urlencode(html_entity_decode($this->request->get['filter_barcode'], ENT_QUOTES, 'UTF-8'));
+		}
+
 		if (isset($this->request->get['filter_model'])) {
 			$url .= '&filter_model=' . urlencode(html_entity_decode($this->request->get['filter_model'], ENT_QUOTES, 'UTF-8'));
 		}
@@ -325,6 +346,7 @@ class Product extends \Opencart\System\Engine\Controller {
 
 		$filter_data = [
 			'filter_name'            => $filter_name,
+			'filter_barcode'         => $filter_barcode,
 			'filter_model'           => $filter_model,
 			'filter_category_id'     => $filter_category_id,
 			'filter_manufacturer_id' => $filter_manufacturer_id,
@@ -379,6 +401,10 @@ class Product extends \Opencart\System\Engine\Controller {
 		if (isset($this->request->get['filter_name'])) {
 			$url .= '&filter_name=' . urlencode(html_entity_decode($this->request->get['filter_name'], ENT_QUOTES, 'UTF-8'));
 		}
+		
+		if (isset($this->request->get['filter_barcode'])) {
+			$url .= '&filter_barcode=' . $this->request->get['filter_barcode'];
+		}
 
 		if (isset($this->request->get['filter_model'])) {
 			$url .= '&filter_model=' . urlencode(html_entity_decode($this->request->get['filter_model'], ENT_QUOTES, 'UTF-8'));
@@ -428,6 +454,10 @@ class Product extends \Opencart\System\Engine\Controller {
 
 		if (isset($this->request->get['filter_name'])) {
 			$url .= '&filter_name=' . urlencode(html_entity_decode($this->request->get['filter_name'], ENT_QUOTES, 'UTF-8'));
+		}
+
+		if (isset($this->request->get['filter_barcode'])) {
+			$url .= '&filter_barcode=' . $this->request->get['filter_barcode'];
 		}
 
 		if (isset($this->request->get['filter_model'])) {
@@ -525,6 +555,10 @@ class Product extends \Opencart\System\Engine\Controller {
 		if (isset($this->request->get['filter_name'])) {
 			$url .= '&filter_name=' . urlencode(html_entity_decode($this->request->get['filter_name'], ENT_QUOTES, 'UTF-8'));
 		}
+		
+		if (isset($this->request->get['filter_barcode'])) {
+			$url .= '&filter_barcode=' . urlencode(html_entity_decode($this->request->get['filter_barcode'], ENT_QUOTES, 'UTF-8'));
+		}
 
 		if (isset($this->request->get['filter_model'])) {
 			$url .= '&filter_model=' . urlencode(html_entity_decode($this->request->get['filter_model'], ENT_QUOTES, 'UTF-8'));
@@ -586,6 +620,10 @@ class Product extends \Opencart\System\Engine\Controller {
 
 		if (isset($this->request->get['filter_name'])) {
 			$url .= '&filter_name=' . urlencode(html_entity_decode($this->request->get['filter_name'], ENT_QUOTES, 'UTF-8'));
+		}
+		
+		if (isset($this->request->get['filter_barcode'])) {
+			$url .= '&filter_barcode=' . urlencode(html_entity_decode($this->request->get['filter_barcode'], ENT_QUOTES, 'UTF-8'));
 		}
 
 		if (isset($this->request->get['filter_model'])) {

--- a/upload/admin/language/en-gb/catalog/product.php
+++ b/upload/admin/language/en-gb/catalog/product.php
@@ -117,6 +117,7 @@ $_['entry_tag']                  = 'Product Tags';
 $_['entry_reward']               = 'Reward Points';
 $_['entry_layout']               = 'Layout Override';
 $_['entry_subscription']         = 'Subscription Plan';
+$_['entry_barcode']              = 'Barcode';
 
 // Help
 $_['help_tag']                   = 'Comma separated';

--- a/upload/admin/language/fr-fr/catalog/product.php
+++ b/upload/admin/language/fr-fr/catalog/product.php
@@ -117,6 +117,7 @@ $_['entry_tag']                  = 'Tags du Produit';
 $_['entry_reward']               = 'Points de Récompenses';
 $_['entry_layout']               = 'Remplacement de la Disposition';
 $_['entry_subscription']         = 'Plan d\'Abonnement';
+$_['entry_barcode']              = 'Code-barres';
 
 // Aide
 $_['help_tag']                   = 'Séparés par des virgules';

--- a/upload/admin/model/catalog/product.php
+++ b/upload/admin/model/catalog/product.php
@@ -977,6 +977,7 @@ class Product extends \Opencart\System\Engine\Model {
 	 *     'filter_quantity_from'   => 1,
 	 *     'filter_quantity_to'     => 100,
 	 *     'filter_status'          => 1,
+	 *     'filter_barcode'         => 'xyz123',
 	 *     'start'                  => 0,
 	 *     'limit'                  => 10
 	 * ];
@@ -1026,6 +1027,15 @@ class Product extends \Opencart\System\Engine\Model {
 
 		if (isset($data['filter_status']) && $data['filter_status'] !== '') {
 			$sql .= " AND `p`.`status` = '" . (int)$data['filter_status'] . "'";
+		}
+
+		if (isset($data['filter_barcode']) && $data['filter_barcode'] !== '') {
+			$sql .= " AND (LOWER(`p`.`sku`) LIKE '" . $this->db->escape("%" . oc_strtolower($data['filter_barcode']) . "%") . "'";
+			$sql .= " OR LOWER(`p`.`upc`) LIKE '" . $this->db->escape("%" . oc_strtolower($data['filter_barcode']) . "%") . "'";
+			$sql .= " OR LOWER(`p`.`ean`) LIKE '" . $this->db->escape("%" . oc_strtolower($data['filter_barcode']) . "%") . "'";
+			$sql .= " OR LOWER(`p`.`jan`) LIKE '" . $this->db->escape("%" . oc_strtolower($data['filter_barcode']) . "%") . "'";
+			$sql .= " OR LOWER(`p`.`isbn`) LIKE '" . $this->db->escape("%" . oc_strtolower($data['filter_barcode']) . "%") . "'";
+			$sql .= " OR LOWER(`p`.`mpn`) LIKE '" . $this->db->escape("%" . oc_strtolower($data['filter_barcode']) . "%") . "')";
 		}
 
 		$sql .= " GROUP BY `p`.`product_id`";
@@ -1096,6 +1106,7 @@ class Product extends \Opencart\System\Engine\Model {
 	 *     'filter_quantity_from'   => 1,
 	 *     'filter_quantity_to'     => 100,
 	 *     'filter_status'          => 1,
+	 * 	   'filter_barcode'         => 'xyz123',
 	 *     'start'                  => 0,
 	 *     'limit'                  => 10
 	 * ];
@@ -1145,6 +1156,15 @@ class Product extends \Opencart\System\Engine\Model {
 
 		if (isset($data['filter_status']) && $data['filter_status'] !== '') {
 			$sql .= " AND `p`.`status` = '" . (int)$data['filter_status'] . "'";
+		}
+		
+		if (isset($data['filter_barcode']) && $data['filter_barcode'] !== '') {
+			$sql .= " AND (LOWER(`p`.`sku`) LIKE '" . $this->db->escape("%" . oc_strtolower($data['filter_barcode']) . "%") . "'";
+			$sql .= " OR LOWER(`p`.`upc`) LIKE '" . $this->db->escape("%" . oc_strtolower($data['filter_barcode']) . "%") . "'";
+			$sql .= " OR LOWER(`p`.`ean`) LIKE '" . $this->db->escape("%" . oc_strtolower($data['filter_barcode']) . "%") . "'";
+			$sql .= " OR LOWER(`p`.`jan`) LIKE '" . $this->db->escape("%" . oc_strtolower($data['filter_barcode']) . "%") . "'";
+			$sql .= " OR LOWER(`p`.`isbn`) LIKE '" . $this->db->escape("%" . oc_strtolower($data['filter_barcode']) . "%") . "'";
+			$sql .= " OR LOWER(`p`.`mpn`) LIKE '" . $this->db->escape("%" . oc_strtolower($data['filter_barcode']) . "%") . "')";
 		}
 
 		$query = $this->db->query($sql);

--- a/upload/admin/view/template/catalog/product.twig
+++ b/upload/admin/view/template/catalog/product.twig
@@ -28,6 +28,14 @@
                 <ul id="autocomplete-name" class="dropdown-menu"></ul>
               </div>
               <div class="mb-3">
+                <label for="input-barcode" class="form-label">{{ entry_barcode }}</label>
+                <div class="row">
+                  <div class="col">
+                    <input type="text" name="filter_barcode" value="{{ filter_barcode }}" placeholder="{{ entry_barcode }}" id="input-barcode" class="form-control" autocomplete="off"/>
+                  </div>
+                </div>
+              </div>
+              <div class="mb-3">
                 <label for="input-model" class="form-label">{{ entry_model }}</label> <input type="text" name="filter_model" value="{{ filter_model }}" placeholder="{{ entry_model }}" id="input-model" data-oc-target="autocomplete-model" class="form-control" autocomplete="off"/>
                 <ul id="autocomplete-model" class="dropdown-menu"></ul>
               </div>
@@ -103,6 +111,12 @@ $('#button-filter').on('click', function() {
 
     if (filter_name) {
         url += '&filter_name=' + encodeURIComponent(filter_name);
+    }
+
+    var filter_barcode = $('#input-barcode').val();
+
+    if (filter_barcode) {
+        url += '&filter_barcode=' + encodeURIComponent(filter_barcode);
     }
 
     var filter_model = $('#input-model').val();


### PR DESCRIPTION
### Add Barcode Search Functionality to Product List

#### Description
This PR introduces a new feature that allows users to search for products using barcode numbers in the product list. The search functionality is case-insensitive and performs a "contains" search on the entered barcode number. The search checks the following fields:
- SKU
- UPC
- EAN
- JAN
- ISBN
- MPN

If the entered barcode number matches any of these fields, the corresponding product will be found.

#### Benefits
This feature is particularly useful for sellers who use a barcode system, making it easier and more practical to find products.

#### Testing
Tested with MariaDB version 11.5.2.

![image](https://github.com/user-attachments/assets/d4b989a1-32c7-4bdf-999f-40076752d49a)
