### PR TITLE
Fix schema errors in helper/db_schema.php to fix CLI installer errors

### DIFF
--- a/upload/system/helper/db_schema.php
+++ b/upload/system/helper/db_schema.php
@@ -7824,7 +7824,7 @@ function oc_db_schema() {
 			]
 		],
 		'primary' => [
-			'country_id',
+			'zone_id',
 			'language_id'
 		],
 		'foreign' => [

--- a/upload/system/helper/db_schema.php
+++ b/upload/system/helper/db_schema.php
@@ -1187,6 +1187,11 @@ function oc_db_schema() {
 				'default' => '0'
 			],
 			[
+				'name'    => 'column',
+				'type'    => 'int(11)',
+				'default' => '0'
+			],
+			[
 				'name'    => 'sort_order',
 				'type'    => 'int(3)',
 				'default' => '0'


### PR DESCRIPTION
CLI installer was failing with this 2 errors
1)
Fatal error: Uncaught Exception: Error: Key column 'country_id' doesn't exist in table<br/>Error No: 1072<br/>CREATE TABLE `oc_zone_description` (
  `zone_id` int(11),
  `language_id` int(11),
  `name` varchar(255),
  PRIMARY KEY (`country_id`,`language_id`),
  KEY `name` (`name`)
) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 in /var/www/html/system/library/db/mysqli.php:122
Stack trace:
#0 /var/www/html/system/library/db.php(54): Opencart\System\Library\DB\MySQLi->query('CREATE TABLE `o...')
#1 /var/www/html/install/cli_install.php(340): Opencart\System\Library\DB->query('CREATE TABLE `o...')
#2 /var/www/html/install/cli_install.php(118): Install\CliInstall->install(Array)
#3 /var/www/html/install/cli_install.php(550): Install\CliInstall->index()

2)
Fatal error: Uncaught Exception: Error: Unknown column 'column' in 'field list'<br/>Error No: 1054<br/>INSERT INTO `oc_category` (`category_id`, `image`, `parent_id`, `column`, `sort_order`, `status`, `date_added`, `date_modified`)VALUES (25, '', 0, ......); in /var/www/html/system/library/db/mysqli.php:122
Stack trace:
#0 /var/www/html/system/library/db.php(54): Opencart\System\Library\DB\MySQLi->query('INSERT INTO `oc...')
#1 /var/www/html/install/cli_install.php(363): Opencart\System\Library\DB->query('INSERT INTO `oc...')
#2 /var/www/html/install/cli_install.php(118): Install\CliInstall->install(Array)
#3 /var/www/html/install/cli_install.php(550): Install\CliInstall->index()
#4 {main}
  thrown in /var/www/html/system/library/db/mysqli.php on line 122