### PR TITLE
[fix] The update procedure does not work

### DIFF
--- a/upload/install/controller/upgrade/upgrade_10.php
+++ b/upload/install/controller/upgrade/upgrade_10.php
@@ -17,7 +17,7 @@ class Upgrade10 extends \Opencart\System\Engine\Controller {
 		$json = [];
 
 		try {
-			$query = $this->db->query("SELECT * FROM '" . DB_PREFIX . "identifier'");
+			$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "identifier`");
 
 			if (!$query->num_rows) {
 				$identifiers = [];

--- a/upload/install/model/upgrade/upgrade.php
+++ b/upload/install/model/upgrade/upgrade.php
@@ -66,7 +66,7 @@ class Upgrade extends \Opencart\System\Engine\Model {
 	}
 
 	public function dropField($table, $field): void {
-		if ($this->hasTable($table, $field)) {
+		if ($this->hasField($table, $field)) {
 			$this->db->query("ALTER TABLE `" . DB_PREFIX . $table . "` DROP `" . $field . "`");
 		}
 	}


### PR DESCRIPTION
There are critical error in the installer that make it impossible to update.
Steps 7, 8, 9 are not executed due to an error in the model.
Step 10 has an SQL error

@danielkerr possible errors `$json['error']` are not displayed in any way. This is very inconvenient and makes it very difficult to find and fix errors.

