### PR TITLE
Update to admin marketplace/installer.php

### DIFF
--- a/upload/admin/controller/marketplace/installer.php
+++ b/upload/admin/controller/marketplace/installer.php
@@ -109,6 +109,28 @@ class Installer extends \Opencart\System\Engine\Controller {
 			if (!$install_info) {
 				// Unzip the files
 				$zip = new \ZipArchive();
+				
+				// Zip error codes
+				$ZIP_ERROR = [
+					\ZipArchive::ER_EXISTS => 'File already exists.',
+					\ZipArchive::ER_INCONS => 'Zip archive inconsistent.',
+					\ZipArchive::ER_INVAL => 'Invalid argument.',
+					\ZipArchive::ER_MEMORY => 'Malloc failure.',
+					\ZipArchive::ER_NOENT => 'No such file.',
+					\ZipArchive::ER_NOZIP => 'Not a zip archive.',
+					\ZipArchive::ER_OPEN => "Can't open file.",
+					\ZipArchive::ER_READ => 'Read error.',
+					\ZipArchive::ER_SEEK => 'Seek error.',
+				];
+
+				// Check zip for errors
+				$result_code = $zip->open($file);
+				if ($result_code !== true) {
+					if (file_exists($file)) {
+						unlink($file);
+					}
+					continue;
+				}
 
 				if ($zip->open($file, \ZipArchive::RDONLY)) {
 					$install_info = json_decode($zip->getFromName('install.json'), true);

--- a/upload/admin/language/en-gb/marketplace/installer.php
+++ b/upload/admin/language/en-gb/marketplace/installer.php
@@ -44,3 +44,15 @@ $_['error_directory']        = 'Install directory %s could not be found!';
 $_['error_directory_exists'] = 'Path %s already exists!';
 $_['error_unzip']            = 'Zip file could not be opened!';
 $_['error_upload']           = 'File could not be uploaded!';
+$_['error_unknown']           = 'An unknown error occurred!';
+
+// Zip errors
+$_['zip_error_exists']       = 'File already exists!';
+$_['zip_error_incons']       = 'Zip archive inconsistent!';
+$_['zip_error_inval']        = 'Invalid argument!';
+$_['zip_error_memory']       = 'Memory allocation failure!';
+$_['zip_error_noent']        = 'No such file!';
+$_['zip_error_nozip']        = 'Not a zip archive!';
+$_['zip_error_open']         = 'Can not open file!';
+$_['zip_error_read']         = 'Read error!';
+$_['zip_error_seek']         = 'Seek error!';

--- a/upload/admin/language/fr-fr/marketplace/installer.php
+++ b/upload/admin/language/fr-fr/marketplace/installer.php
@@ -44,3 +44,15 @@ $_['error_directory']        = 'Le répertoire d\'installation %s est introuvabl
 $_['error_directory_exists'] = 'Le chemin %s existe déjà!';
 $_['error_unzip']            = 'Impossible d\'ouvrir le fichier .zip!';
 $_['error_upload']           = 'Le fichier n\'a pu être téléchargé!';
+$_['error_unknown']           = 'Une erreur inconnue s’est produite!';
+
+// Zip erreur
+$_['zip_error_exists']       = 'Le fichier existe déjà!';
+$_['zip_error_incons']       = 'Archive zip incohérente!';
+$_['zip_error_inval']        = 'Argument invalide!';
+$_['zip_error_memory']       = 'Échec de l’allocation de mémoire!';
+$_['zip_error_noent']        = 'Aucun fichier trouvé!';
+$_['zip_error_nozip']        = 'Ce n’est pas une archive zip!';
+$_['zip_error_open']         = 'Impossible d’ouvrir le fichier!';
+$_['zip_error_read']         = 'Erreur de lecture!';
+$_['zip_error_seek']         = 'Erreur de positionnement!';


### PR DESCRIPTION
I created an xml file and changed its extension to ocmod.zip and went to install. Thereafter, every time I attempted to load the extension installer page, I was greeted with a PHP unauthorised zip file error and the page just wouldn't load. This update checks for errors with the zip files, if there's an error it will delete the file and continue through the loop without crashing the page