### PR TITLE
Update product_list.twig

### DIFF
--- a/upload/admin/view/template/catalog/product_list.twig
+++ b/upload/admin/view/template/catalog/product_list.twig
@@ -15,7 +15,7 @@
       <tbody>
         {% if products %}
           {% for product in products %}
-            <tr class="{% if not product.variant %}table-warning{% endif %} {% if not product.status %}opacity-50{% endif %}">
+            <tr class="{% if not product.variant %}table-warning{% endif %} {% if not product.status %}table-active opacity-50{% endif %}">
               <td class="text-center"><input type="checkbox" name="selected[]" value="{{ product.product_id }}" class="form-check-input"/></td>
               <td class="text-center"><img src="{{ product.image }}" alt="{{ product.name }}" class="img-thumbnail"/></td>
               <td>{{ product.name }}</td>


### PR DESCRIPTION
Fix disabled products design same as other table lists.

PS Actually the old design with green/red labels was much better and informative. Only labels should have `<br>` before them.