### PR TITLE
Retrieve more in depth files from extension directory for permission

### DIFF
--- a/upload/admin/controller/user/user_permission.php
+++ b/upload/admin/controller/user/user_permission.php
@@ -296,7 +296,7 @@ class UserPermission extends \Opencart\System\Engine\Controller {
 		$data['extensions'] = [];
 
 		// Extension permissions
-		$results = glob(DIR_EXTENSION . '*/admin/controller/*/*.php');
+		$results = glob(DIR_EXTENSION . '*/admin/controller/{,*/,*/*/,*/*/*/}*.php', GLOB_BRACE);
 
 		foreach ($results as $result) {
 			$path = substr($result, strlen(DIR_EXTENSION));


### PR DESCRIPTION
this is revised PR of previous https://github.com/opencart/opencart/pull/14751

Currently if controllers file is inside nested folder at more than 2 level then it is impossible to access it because of permission.

This PR will fix this issue