### PR TITLE
Update order.php

### DIFF
--- a/upload/admin/controller/sale/order.php
+++ b/upload/admin/controller/sale/order.php
@@ -794,7 +794,7 @@ class Order extends \Opencart\System\Engine\Controller {
 
 					if ($upload_info) {
 						$option_data[] = [
-							'filename' => $upload_info['mask'],
+							'filename' => $upload_info['name'],
 							'href'     => $this->url->link('tool/upload.download', 'user_token=' . $this->session->data['user_token'] . '&code=' . $upload_info['code'])
 						] + $option;
 					}


### PR DESCRIPTION
Order files are not displaying in the admin order details page. Instead, I'm seeing this error:
"Warning: Undefined array key "mask" in E:\xampp\htdocs\oc\4103\1\admin\controller\sale\order.php on line 796".