### PR TITLE
Updated language installer + fix for issue 14765

### DIFF
--- a/upload/admin/controller/localisation/language.php
+++ b/upload/admin/controller/localisation/language.php
@@ -179,7 +179,7 @@ class Language extends \Opencart\System\Engine\Controller {
 
 		$data['text_form'] = !isset($this->request->get['language_id']) ? $this->language->get('text_add') : $this->language->get('text_edit');
 
-		$data['user_token'] = isset($this->request->get['user_token']) ? $this->request->get['user_token'] : '';
+		$data['user_token'] = $this->session->data['user_token'];
 
 		$url = '';
 

--- a/upload/admin/controller/localisation/language.php
+++ b/upload/admin/controller/localisation/language.php
@@ -107,7 +107,7 @@ class Language extends \Opencart\System\Engine\Controller {
 
 		$data['action'] = $this->url->link('localisation/language.list', 'user_token=' . $this->session->data['user_token'] . $url);
 
-		// Languages
+		// Language
 		$data['languages'] = [];
 
 		$filter_data = [
@@ -136,7 +136,6 @@ class Language extends \Opencart\System\Engine\Controller {
 			$url .= '&order=ASC';
 		}
 
-		// Sorts
 		$data['sort_name'] = $this->url->link('localisation/language.list', 'user_token=' . $this->session->data['user_token'] . '&sort=name' . $url);
 		$data['sort_code'] = $this->url->link('localisation/language.list', 'user_token=' . $this->session->data['user_token'] . '&sort=code' . $url);
 		$data['sort_sort_order'] = $this->url->link('localisation/language.list', 'user_token=' . $this->session->data['user_token'] . '&sort=sort_order' . $url);
@@ -151,10 +150,8 @@ class Language extends \Opencart\System\Engine\Controller {
 			$url .= '&order=' . $this->request->get['order'];
 		}
 
-		// Total Languages
 		$language_total = $this->model_localisation_language->getTotalLanguages();
 
-		// Pagination
 		$data['pagination'] = $this->load->controller('common/pagination', [
 			'total' => $language_total,
 			'page'  => $page,
@@ -181,6 +178,8 @@ class Language extends \Opencart\System\Engine\Controller {
 		$this->document->setTitle($this->language->get('heading_title'));
 
 		$data['text_form'] = !isset($this->request->get['language_id']) ? $this->language->get('text_add') : $this->language->get('text_edit');
+
+		$data['user_token'] = isset($this->request->get['user_token']) ? $this->request->get['user_token'] : '';
 
 		$url = '';
 
@@ -211,7 +210,6 @@ class Language extends \Opencart\System\Engine\Controller {
 		$data['save'] = $this->url->link('localisation/language.save', 'user_token=' . $this->session->data['user_token']);
 		$data['back'] = $this->url->link('localisation/language', 'user_token=' . $this->session->data['user_token'] . $url);
 
-		// Language
 		if (isset($this->request->get['language_id'])) {
 			$this->load->model('localisation/language');
 
@@ -305,7 +303,6 @@ class Language extends \Opencart\System\Engine\Controller {
 			$json['error']['locale'] = $this->language->get('error_locale');
 		}
 
-		// Language
 		$this->load->model('localisation/language');
 
 		$language_info = $this->model_localisation_language->getLanguageByCode($post_info['code']);
@@ -348,13 +345,10 @@ class Language extends \Opencart\System\Engine\Controller {
 			$json['error'] = $this->language->get('error_permission');
 		}
 
-		// Setting
+		// Store
 		$this->load->model('setting/store');
 
-		// Language
-		$this->load->model('localisation/language');
-
-		// Orders
+		// Order
 		$this->load->model('sale/order');
 
 		foreach ($selected as $language_id) {
@@ -376,7 +370,6 @@ class Language extends \Opencart\System\Engine\Controller {
 				}
 			}
 
-			// Total Orders
 			$order_total = $this->model_sale_order->getTotalOrdersByLanguageId($language_id);
 
 			if ($order_total) {
@@ -385,43 +378,13 @@ class Language extends \Opencart\System\Engine\Controller {
 		}
 
 		if (!$json) {
+			$this->load->model('localisation/language');
+
 			foreach ($selected as $language_id) {
 				$this->model_localisation_language->deleteLanguage($language_id);
 			}
 
 			$json['success'] = $this->language->get('text_success');
-		}
-
-		$this->response->addHeader('Content-Type: application/json');
-		$this->response->setOutput(json_encode($json));
-	}
-
-	/**
-	 * Generate
-	 *
-	 * @return void
-	 */
-	public function generate(): void {
-		$this->load->language('localisation/language');
-
-		$json = [];
-
-		if (!$this->user->hasPermission('modify', 'localisation/language')) {
-			$json['error'] = $this->language->get('error_permission');
-		}
-
-		if (!$json) {
-			$file = DIR_CATALOG . 'view/data/localisation/language.json';
-
-			$this->load->model('localisation/language');
-
-			$output = json_encode($this->model_localisation_language->getLanguages());
-
-			if (file_put_contents($file, $output)) {
-				$json['success'] = $this->language->get('text_success');
-			} else {
-				$json['error'] = $this->language->get('error_file');
-			}
 		}
 
 		$this->response->addHeader('Content-Type: application/json');

--- a/upload/admin/controller/localisation/language.php
+++ b/upload/admin/controller/localisation/language.php
@@ -390,4 +390,36 @@ class Language extends \Opencart\System\Engine\Controller {
 		$this->response->addHeader('Content-Type: application/json');
 		$this->response->setOutput(json_encode($json));
 	}
+
+	/**
+	 * Generate
+	 *
+	 * @return void
+	 */
+	public function generate(): void {
+		$this->load->language('localisation/language');
+
+		$json = [];
+
+		if (!$this->user->hasPermission('modify', 'localisation/language')) {
+			$json['error'] = $this->language->get('error_permission');
+		}
+
+		if (!$json) {
+			$file = DIR_CATALOG . 'view/data/localisation/language.json';
+
+			$this->load->model('localisation/language');
+
+			$output = json_encode($this->model_localisation_language->getLanguages());
+
+			if (file_put_contents($file, $output)) {
+				$json['success'] = $this->language->get('text_success');
+			} else {
+				$json['error'] = $this->language->get('error_file');
+			}
+		}
+
+		$this->response->addHeader('Content-Type: application/json');
+		$this->response->setOutput(json_encode($json));
+	}
 }

--- a/upload/admin/model/localisation/language.php
+++ b/upload/admin/model/localisation/language.php
@@ -39,223 +39,142 @@ class Language extends \Opencart\System\Engine\Model {
 
 		$language_id = $this->db->getLastId();
 
-		// Attribute
-		$this->load->model('catalog/attribute');
-
-		$results = $this->model_catalog_attribute->getDescriptionsByLanguageId($this->config->get('config_language_id'));
-
-		foreach ($results as $attribute) {
-			$this->model_catalog_attribute->addDescription($attribute['attribute_id'], $language_id, $attribute);
-		}
-
-		// Attribute Group
-		$this->load->model('catalog/attribute_group');
-
-		$results = $this->model_catalog_attribute_group->getDescriptionsByLanguageId($this->config->get('config_language_id'));
-
-		foreach ($results as $attribute_group) {
-			$this->model_catalog_attribute_group->addDescription($attribute_group['attribute_group_id'], $language_id, $attribute_group);
-		}
-
-		// Banner
-		$this->load->model('design/banner');
-
-		$results = $this->model_design_banner->getImagesByLanguageId($this->config->get('config_language_id'));
-
-		foreach ($results as $banner_image) {
-			$this->model_design_banner->addImage($banner_image['banner_id'], $language_id, $banner_image);
-		}
-
-		// Category
-		$this->load->model('catalog/category');
-
-		$results = $this->model_catalog_category->getDescriptionsByLanguageId($this->config->get('config_language_id'));
-
-		foreach ($results as $category) {
-			$this->model_catalog_category->addDescription($category['category_id'], $language_id, $category);
-		}
-
-		// Country
-		$this->load->model('localisation/country');
-
-		$results = $this->model_localisation_country->getDescriptionsByLanguageId($this->config->get('config_language_id'));
-
-		foreach ($results as $country) {
-			$this->model_localisation_country->addDescription($country['country_id'], $language_id, $country);
-		}
-
-		// Customer Group
-		$this->load->model('customer/customer_group');
-
-		$results = $this->model_customer_customer_group->getDescriptionsByLanguageId($this->config->get('config_language_id'));
-
-		foreach ($results as $customer_group) {
-			$this->model_customer_customer_group->addDescription($customer_group['customer_group_id'], $language_id, $customer_group);
-		}
-
-		// Custom Field
-		$this->load->model('customer/custom_field');
-
-		$results = $this->model_customer_custom_field->getDescriptionsByLanguageId($this->config->get('config_language_id'));
-
-		foreach ($results as $custom_field) {
-			$this->model_customer_custom_field->addDescription($custom_field['custom_field_id'], $language_id, $custom_field);
-		}
-
-		// Custom Field Value
-		$results = $this->model_customer_custom_field->getValueDescriptionsByLanguageId($this->config->get('config_language_id'));
-
-		foreach ($results as $custom_field_value) {
-			$this->model_customer_custom_field->addValueDescription($custom_field_value['custom_field_value_id'], $custom_field_value['custom_field_id'], $language_id, $custom_field_value);
-		}
-
-		// Download
-		$this->load->model('catalog/download');
-
-		$results = $this->model_catalog_download->getDescriptionsByLanguageId($this->config->get('config_language_id'));
-
-		foreach ($results as $download) {
-			$this->model_catalog_download->addDescription($download['download_id'], $language_id, $download);
-		}
-
-		// Filter
-		$this->load->model('catalog/filter');
-
-		$results = $this->model_catalog_filter->getDescriptionsByLanguageId($this->config->get('config_language_id'));
-
-		foreach ($results as $filter) {
-			$this->model_catalog_filter->addDescription($filter['filter_id'], $language_id, $filter);
-		}
-
-		// Filter Group
-		$this->load->model('catalog/filter_group');
-
-		$results = $this->model_catalog_filter_group->getDescriptionsByLanguageId($this->config->get('config_language_id'));
-
-		foreach ($results as $filter_group) {
-			$this->model_catalog_filter_group->addDescription($filter_group['filter_group_id'], $language_id, $filter_group);
-		}
-
-		// Information
-		$this->load->model('catalog/information');
-
-		$results = $this->model_catalog_information->getDescriptionsByLanguageId($this->config->get('config_language_id'));
-
-		foreach ($results as $information) {
-			$this->model_catalog_information->addDescription($information['information_id'], $language_id, $information);
-		}
-
-		// Length
-		$this->load->model('localisation/length_class');
-
-		$results = $this->model_localisation_length_class->getDescriptionsByLanguageId($this->config->get('config_language_id'));
-
-		foreach ($results as $length) {
-			$this->model_localisation_length_class->addDescription($length['length_class_id'], $language_id, $length);
-		}
-
-		// Option
-		$this->load->model('catalog/option');
-
-		$results = $this->model_catalog_option->getDescriptionsByLanguageId($this->config->get('config_language_id'));
-
-		foreach ($results as $option) {
-			$this->model_catalog_option->addDescription($option['option_id'], $language_id, $option);
-		}
-
-		// Option Value
-		$results = $this->model_catalog_option->getValueDescriptionsByLanguageId($this->config->get('config_language_id'));
-
-		foreach ($results as $option_value) {
-			$this->model_catalog_option->addValueDescription($option_value['option_value_id'], $option_value['option_id'], $language_id, $option_value);
-		}
-
-		// Order Status
-		$this->load->model('localisation/order_status');
-
-		$results = $this->model_localisation_order_status->getDescriptionsByLanguageId($this->config->get('config_language_id'));
-
-		foreach ($results as $order_status) {
-			$this->model_localisation_order_status->addDescription($order_status['order_status_id'], $language_id, $order_status);
-		}
-
-		// Product
-		$this->load->model('catalog/product');
-
-		$results = $this->model_catalog_product->getDescriptionsByLanguageId($this->config->get('config_language_id'));
-
-		foreach ($results as $product) {
-			$this->model_catalog_product->addDescription($product['product_id'], $language_id, $product);
-		}
-
-		// Product Attribute
-		$results = $this->model_catalog_product->getAttributesByLanguageId($this->config->get('config_language_id'));
-
-		foreach ($results as $product_attribute) {
-			$this->model_catalog_product->addAttribute($product_attribute['product_id'], $product_attribute['attribute_id'], $language_id, $product_attribute);
-		}
-
-		// Return Action
-		$this->load->model('localisation/return_action');
-
-		$results = $this->model_localisation_return_action->getDescriptionsByLanguageId($this->config->get('config_language_id'));
-
-		foreach ($results as $return_action) {
-			$this->model_localisation_return_action->addDescription($return_action['return_action_id'], $language_id, $return_action);
-		}
-
-		// Return Reason
-		$this->load->model('localisation/return_reason');
-
-		$results = $this->model_localisation_return_reason->getDescriptionsByLanguageId($this->config->get('config_language_id'));
-
-		foreach ($results as $return_reason) {
-			$this->model_localisation_return_reason->addDescription($return_reason['return_reason_id'], $language_id, $return_reason);
-		}
-
-		// Return Status
-		$this->load->model('localisation/return_status');
-
-		$results = $this->model_localisation_return_status->getDescriptionsByLanguageId($this->config->get('config_language_id'));
-
-		foreach ($results as $return_status) {
-			$this->model_localisation_return_status->addDescription($return_status['return_status_id'], $language_id, $return_status);
-		}
-
-		// Stock Status
-		$this->load->model('localisation/stock_status');
-
-		$results = $this->model_localisation_stock_status->getDescriptionsByLanguageId($this->config->get('config_language_id'));
-
-		foreach ($results as $stock_status) {
-			$this->model_localisation_stock_status->addDescription($stock_status['stock_status_id'], $language_id, $stock_status);
-		}
-
-		// Weight Class
-		$this->load->model('localisation/weight_class');
-
-		$results = $this->model_localisation_weight_class->getDescriptionsByLanguageId($this->config->get('config_language_id'));
-
-		foreach ($results as $weight_class) {
-			$this->model_localisation_weight_class->addDescription($weight_class['weight_class_id'], $language_id, $weight_class);
-		}
-
-		// Subscription Plan
-		$this->load->model('catalog/subscription_plan');
-
-		$results = $this->model_catalog_subscription_plan->getDescriptionsByLanguageId($this->config->get('config_language_id'));
-
-		foreach ($results as $subscription_plan) {
-			$this->model_catalog_subscription_plan->addDescription($subscription_plan['subscription_plan_id'], $language_id, $subscription_plan);
-		}
-
-		// Subscription Status
-		$this->load->model('localisation/subscription_status');
-
-		$results = $this->model_localisation_subscription_status->getDescriptionsByLanguageId($this->config->get('config_language_id'));
-
-		foreach ($results as $subscription) {
-			$this->model_localisation_subscription_status->addDescription($subscription['subscription_status_id'], $language_id, $subscription);
+		$models = [
+			'catalog/attribute' => [
+				'model' => 'model_catalog_attribute',
+				'methods' => ['getDescriptionsByLanguageId', 'addDescription']
+			],
+			'catalog/attribute_group' => [
+				'model' => 'model_catalog_attribute_group',
+				'methods' => ['getDescriptionsByLanguageId', 'addDescription']
+			],
+			'design/banner' => [
+				'model' => 'model_design_banner',
+				'methods' => ['getImagesByLanguageId', 'addImage']
+			],
+			'catalog/category' => [
+				'model' => 'model_catalog_category',
+				'methods' => ['getDescriptionsByLanguageId', 'addDescription']
+			],
+			'localisation/country' => [
+				'model' => 'model_localisation_country',
+				'methods' => ['getDescriptionsByLanguageId', 'addDescription']
+			],
+			'customer/customer_group' => [
+				'model' => 'model_customer_customer_group',
+				'methods' => ['getDescriptionsByLanguageId', 'addDescription']
+			],
+			'customer/custom_field' => [
+				'model' => 'model_customer_custom_field',
+				'methods' => ['getDescriptionsByLanguageId', 'addDescription', 'getValueDescriptionsByLanguageId', 'addValueDescription']
+			],
+			'catalog/download' => [
+				'model' => 'model_catalog_download',
+				'methods' => ['getDescriptionsByLanguageId', 'addDescription']
+			],
+			'catalog/filter' => [
+				'model' => 'model_catalog_filter',
+				'methods' => ['getDescriptionsByLanguageId', 'addDescription']
+			],
+			'catalog/filter_group' => [
+				'model' => 'model_catalog_filter_group',
+				'methods' => ['getDescriptionsByLanguageId', 'addDescription']
+			],
+			'catalog/information' => [
+				'model' => 'model_catalog_information',
+				'methods' => ['getDescriptionsByLanguageId', 'addDescription']
+			],
+			'localisation/length_class' => [
+				'model' => 'model_localisation_length_class',
+				'methods' => ['getDescriptionsByLanguageId', 'addDescription']
+			],
+			'catalog/option' => [
+				'model' => 'model_catalog_option',
+				'methods' => ['getDescriptionsByLanguageId', 'addDescription', 'getValueDescriptionsByLanguageId', 'addValueDescription']
+			],
+			'localisation/order_status' => [
+				'model' => 'model_localisation_order_status',
+				'methods' => ['getDescriptionsByLanguageId', 'addDescription']
+			],
+			'catalog/product' => [
+				'model' => 'model_catalog_product',
+				'methods' => ['getDescriptionsByLanguageId', 'addDescription', 'getAttributesByLanguageId', 'addAttribute']
+			],
+			'localisation/return_action' => [
+				'model' => 'model_localisation_return_action',
+				'methods' => ['getDescriptionsByLanguageId', 'addDescription']
+			],
+			'localisation/return_reason' => [
+				'model' => 'model_localisation_return_reason',
+				'methods' => ['getDescriptionsByLanguageId', 'addDescription']
+			],
+			'localisation/return_status' => [
+				'model' => 'model_localisation_return_status',
+				'methods' => ['getDescriptionsByLanguageId', 'addDescription']
+			],
+			'localisation/stock_status' => [
+				'model' => 'model_localisation_stock_status',
+				'methods' => ['getDescriptionsByLanguageId', 'addDescription']
+			],
+			'localisation/weight_class' => [
+				'model' => 'model_localisation_weight_class',
+				'methods' => ['getDescriptionsByLanguageId', 'addDescription']
+			],
+			'catalog/subscription_plan' => [
+				'model' => 'model_catalog_subscription_plan',
+				'methods' => ['getDescriptionsByLanguageId', 'addDescription']
+			],
+			'localisation/subscription_status' => [
+				'model' => 'model_localisation_subscription_status',
+				'methods' => ['getDescriptionsByLanguageId', 'addDescription']
+			],
+			'cms/topic' => [
+				'model' => 'model_cms_topic',
+				'methods' => ['getDescriptionsByLanguageId', 'addDescription']
+			],
+			'localisation/zone' => [
+				'model' => 'model_localisation_zone',
+				'methods' => ['getDescriptionsByLanguageId', 'addDescription']
+			]
+		];
+		
+		foreach ($models as $key => $methods) {
+			// Load the model dynamically
+			$this->load->model($key);
+
+			$keyParts = explode('/', $key);
+			$modelName = end($keyParts);
+
+			// Call the first method dynamically (e.g., getDescriptionsByLanguageId)
+			$results = $this->{$methods['model']}->{$methods['methods'][0]}($this->config->get('config_language_id'));
+
+			// Loop through the results and call the second method (e.g., addDescription)
+			foreach ($results as $result) {
+				$this->{$methods['model']}->{$methods['methods'][1]}($result[$modelName . '_id'], $language_id, $result);
+			}
+
+			// Special case for addValueDescription &  addAttribute
+			if (isset($methods['methods'][2]) && isset($methods['methods'][3])) {
+				$results = $this->{$methods['model']}->{$methods['methods'][2]}($this->config->get('config_language_id'));
+
+				foreach ($results as $result) {
+					if($methods['methods'][3] === 'addValueDescription') {
+						$this->{$methods['model']}->{$methods['methods'][3]}(
+							$result[$modelName . '_value_id'],
+							$result[$modelName . '_id'],
+							$language_id,
+							$result
+						);
+					} elseif($methods['methods'][3] === 'addAttribute') {
+						$this->{$methods['model']}->{$methods['methods'][3]}(
+							$result[$modelName . '_id'],
+							$result['attribute_id'],
+							$language_id,
+							$result
+						);
+					}
+				}
+			}
 		}
 
 		// SEO
@@ -275,33 +194,49 @@ class Language extends \Opencart\System\Engine\Model {
 			$this->model_design_seo_url->addSeoUrl('language', (string)$data['code'], (string)$data['code'], 0, $language['language_id'], -2);
 		}
 
-		// Set default store
+
 		$this->load->model('setting/store');
+		$this->load->model('setting/setting');
 
 		$stores = $this->model_setting_store->getStores();
+		$store_ids = [0]; 
 
 		foreach ($stores as $store) {
+			$store_ids[] = $store['store_id'];
+
 			foreach ($languages as $language) {
 				$this->model_design_seo_url->addSeoUrl('language', (string)$data['code'], (string)$data['code'], $store['store_id'], $language['language_id'], -2);
 			}
 		}
+		
+		foreach ($store_ids as $store_id) {
+			// Get all settings for this store
+			$settings = $this->model_setting_setting->getSetting('config', $store_id);
+	
+			// Ensure 'config_description' exists
+			if (isset($settings['config_description'])) {
+				$config_description = $settings['config_description'];
+			} else {
+				$config_description = [];
+			}
 
-		// Topic Status
-		$this->load->model('cms/topic');
+			// Get the first language's data
+			$firstLang = reset($config_description);
 
-		$results = $this->model_cms_topic->getDescriptionsByLanguageId($this->config->get('config_language_id'));
+			// Add new language entry if not already present
+			if (!isset($config_description[$language_id])) {
+				$config_description[$language_id] = [
+					'meta_title'       => $firstLang['meta_title'] ?? '',
+					'meta_description' => $firstLang['meta_description'] ?? '',
+					'meta_keyword'     => $firstLang['meta_keyword'] ?? ''
+				];
+			}
 
-		foreach ($results as $topic) {
-			$this->model_cms_topic->addDescription($topic['topic_id'], $language_id, $topic);
-		}
+			// Update the settings array
+			$settings['config_description'] = $config_description;
 
-		// Zone
-		$this->load->model('localisation/zone');
-
-		$results = $this->model_localisation_zone->getDescriptionsByLanguageId($this->config->get('config_language_id'));
-
-		foreach ($results as $zone) {
-			$this->model_localisation_zone->addDescription($zone['zone_id'], $language_id, $zone);
+			// Save back to the database
+			$this->model_setting_setting->editSetting('config', $settings, $store_id);
 		}
 
 		return $language_id;
@@ -338,21 +273,7 @@ class Language extends \Opencart\System\Engine\Model {
 		$this->cache->delete('language');
 	}
 
-	/**
-	 * Delete Language
-	 *
-	 * Delete language record in the database.
-	 *
-	 * @param int $language_id primary key of the language record
-	 *
-	 * @return void
-	 *
-	 * @example
-	 *
-	 * $this->load->model('localisation/language');
-	 *
-	 * $this->model_localisation_language->deleteLanguage($language_id);
-	 */
+
 	public function deleteLanguage(int $language_id): void {
 		$language_info = $this->getLanguage($language_id);
 

--- a/upload/admin/view/template/localisation/language.twig
+++ b/upload/admin/view/template/localisation/language.twig
@@ -1,61 +1,81 @@
 {{ header }}{{ column_left }}
 <div id="content">
-  <div class="page-header">
-    <div class="container-fluid">
-      <div class="float-end">
-        <button type="button" id="button-generate" data-bs-toggle="tooltip" title="{{ button_generate }}" class="btn btn-warning"><i class="fa-solid fa-rotate"></i></button>
-        <a href="{{ add }}" data-bs-toggle="tooltip" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" form="form-language" formaction="{{ delete }}" data-bs-toggle="tooltip" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
-      </div>
-      <h1>{{ heading_title }}</h1>
-      <ol class="breadcrumb">
-        {% for breadcrumb in breadcrumbs %}
-          <li class="breadcrumb-item"><a href="{{ breadcrumb.href }}">{{ breadcrumb.text }}</a></li>
-        {% endfor %}
-      </ol>
-    </div>
-  </div>
-  <div class="container-fluid">
-    <div class="card">
-      <div class="card-header"><i class="fa-solid fa-list"></i> {{ text_list }}</div>
-      <div id="language" class="card-body">{{ list }}</div>
-    </div>
-  </div>
+	<div class="page-header">
+		<div class="container-fluid">
+			<div class="float-end"><a href="{{ add }}" data-bs-toggle="tooltip" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
+				<button type="submit" form="form-language" formaction="{{ delete }}" data-bs-toggle="tooltip" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+			</div>
+			<h1>{{ heading_title }}</h1>
+			<ol class="breadcrumb">
+				{% for breadcrumb in breadcrumbs %}
+					<li class="breadcrumb-item">
+						<a href="{{ breadcrumb.href }}">{{ breadcrumb.text }}</a>
+					</li>
+				{% endfor %}
+			</ol>
+		</div>
+	</div>
+	<div class="container-fluid">
+		<!-- Progress Bar -->
+		<div class="row mb-3">
+			<div class="col-sm-10 offset-sm-1">
+				<div id="progress-bar-container" class="progress" style="display: none;">
+					<div id="progress-bar" class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 0%"></div>
+				</div>
+			</div>
+		</div>
+
+		<!-- Main Form -->
+		<div class="card">
+			<div class="card-header"><i class="fa-solid fa-list"></i> {{ text_list }}</div>
+			<div id="language" class="card-body">{{ list }}</div>
+		</div>
+	</div>
 </div>
 <script type="text/javascript"><!--
-$('#language').on('click', 'thead a, .pagination a', function(e) {
-    e.preventDefault();
+	let isUpdating = false;
 
-    $('#language').load(this.href);
-});
+	window.addEventListener('beforeunload', function (e) {
+		if (isUpdating) {
+			e.preventDefault();
+		}
+	});
 
-$('#button-generate').on('click', function() {
-    var element = this;
+	$('#language').on('click', 'thead a, .pagination a', function(e) {
+		e.preventDefault();
 
-    $.ajax({
-        url: 'index.php?route=localisation/language.generate&user_token={{ user_token }}',
-        dataType: 'json',
-        beforeSend: function() {
-            $(element).button('loading');
-        },
-        complete: function() {
-            $(element).button('reset');
-        },
-        success: function(json) {
-            $('.alert-dismissible').remove();
+		$('#language').load(this.href);
+	});
 
-            if (json['error']) {
-                $('#alert').prepend('<x-alert-danger class="alert-dismissible">' + json['error'] + '</x-alert-danger>');
-            }
+	$('#form-language').on('submit', function(e) {
+		e.preventDefault();
 
-            if (json['success']) {
-                $('#alert').prepend('<x-alert-success class="alert-dismissible">' + json['success'] + '</x-alert-success>');
-            }
-        },
-        error: function(xhr, ajaxOptions, thrownError) {
-            console.log(thrownError + "\r\n" + xhr.statusText + "\r\n" + xhr.responseText);
-        }
-    });
-});
+		$(document).on('ajaxStart', function() {
+			isUpdating = true;
+			$('#progress-bar-container').show();
+			$('#progress-bar').css('width', '0%').attr('aria-valuenow', 0);
+		});
+
+		let interval = '';
+
+		$(document).on('ajaxSend', function() {
+			let progress = 0;
+			interval = setInterval(function() {
+				if (progress < 100) {
+					progress += 20;
+					$('#progress-bar').css('width', progress + '%').attr('aria-valuenow', progress);
+				}
+			}, 10);
+		});
+
+		$(document).on('ajaxStop', function() {
+			isUpdating = false;
+			clearInterval(interval);
+			$('#progress-bar-container').hide();
+			$('#progress-bar').css('width', '0%').attr('aria-valuenow', 0);
+		});
+
+		$(this).trigger('submit');
+	});
 //--></script>
 {{ footer }}

--- a/upload/admin/view/template/localisation/language_form.twig
+++ b/upload/admin/view/template/localisation/language_form.twig
@@ -1,71 +1,127 @@
 {{ header }}{{ column_left }}
 <div id="content">
-  <div class="page-header">
-    <div class="container-fluid">
-      <div class="float-end">
-        <button type="submit" form="form-language" formaction="{{ save }}" data-bs-toggle="tooltip" title="{{ button_save }}" class="btn btn-primary"><i class="fa-solid fa-floppy-disk"></i></button>
-        <a href="{{ back }}" data-bs-toggle="tooltip" title="{{ button_back }}" class="btn btn-light"><i class="fa-solid fa-reply"></i></a></div>
-      <h1>{{ heading_title }}</h1>
-      <ol class="breadcrumb">
-        {% for breadcrumb in breadcrumbs %}
-          <li class="breadcrumb-item"><a href="{{ breadcrumb.href }}">{{ breadcrumb.text }}</a></li>
-        {% endfor %}
-      </ol>
-    </div>
-  </div>
-  <div class="container-fluid">
-    <div class="card">
-      <div class="card-header"><i class="fa-solid fa-pencil"></i> {{ text_form }}</div>
-      <div class="card-body">
-        <form id="form-language" action="{{ save }}" method="post" data-oc-toggle="ajax">
-          <div class="row mb-3 required">
-            <label for="input-name" class="col-sm-2 col-form-label">{{ entry_name }}</label>
-            <div class="col-sm-10">
-              <input type="text" name="name" value="{{ name }}" placeholder="{{ entry_name }}" id="input-name" class="form-control"/>
-              <div id="error-name" class="invalid-feedback"></div>
-            </div>
-          </div>
-          <div class="row mb-3 required">
-            <label for="input-code" class="col-sm-2 col-form-label">{{ entry_code }}</label>
-            <div class="col-sm-10">
-              <input type="text" name="code" value="{{ code }}" placeholder="{{ entry_code }}" id="input-code" class="form-control"/>
-              <div id="error-code" class="invalid-feedback"></div>
-            </div>
-          </div>
-          <div class="row mb-3">
-            <label for="input-extension" class="col-sm-2 col-form-label">{{ entry_extension }}</label>
-            <div class="col-sm-10">
-              <input type="text" name="extension" value="{{ extension }}" id="input-extension" class="form-control" readonly/>
-            </div>
-          </div>
-          <div class="row mb-3 required">
-            <label for="input-locale" class="col-sm-2 col-form-label">{{ entry_locale }}</label>
-            <div class="col-sm-10">
-              <input type="text" name="locale" value="{{ locale }}" placeholder="{{ entry_locale }}" id="input-locale" class="form-control"/>
-              <div class="form-text">{{ help_locale }}</div>
-              <div id="error-locale" class="invalid-feedback"></div>
-            </div>
-          </div>
-          <div class="row mb-3">
-            <label class="col-sm-2 col-form-label">{{ entry_status }}</label>
-            <div class="col-sm-10">
-              <div class="form-switch form-switch-lg">
-                <input type="hidden" name="status" value="0"/>
-                <input type="checkbox" name="status" value="1" id="input-status" class="form-check-input"{% if status %} checked{% endif %}/>
-              </div>
-              <div class="form-text">{{ help_status }}</div>
-            </div>
-          </div>
-          <div class="row mb-3">
-            <label for="input-sort-order" class="col-sm-2 col-form-label">{{ entry_sort_order }}</label>
-            <div class="col-sm-10">
-              <input type="number" name="sort_order" value="{{ sort_order }}" placeholder="{{ entry_sort_order }}" id="input-sort-order" class="form-control"/>
-            </div>
-          </div>
-          <input type="hidden" name="language_id" value="{{ language_id }}" id="input-language-id"/>
-        </form>
-      </div>
-    </div>
-  </div>
+	<div class="page-header">
+		<div class="container-fluid">
+			<div class="float-end">
+				<button type="submit" form="form-language" formaction="{{ save }}" data-bs-toggle="tooltip" title="{{ button_save }}" class="btn btn-primary"><i class="fa-solid fa-floppy-disk"></i></button>
+				<a href="{{ back }}" data-bs-toggle="tooltip" title="{{ button_back }}" class="btn btn-light"><i class="fa-solid fa-reply"></i></a></div>
+				<h1>{{ heading_title }}</h1>
+				<ol class="breadcrumb">
+					{% for breadcrumb in breadcrumbs %}
+						<li class="breadcrumb-item"><a href="{{ breadcrumb.href }}">{{ breadcrumb.text }}</a></li>
+					{% endfor %}
+				</ol>
+			</div>
+		</div>
+		<div class="container-fluid">
+			<!-- Progress Bar -->
+			<div class="row mb-3">
+				<div class="col-sm-10 offset-sm-1">
+					<div id="progress-bar-container" class="progress" style="display: none;">
+						<div id="progress-bar" class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 0%"></div>
+					</div>
+				</div>
+			</div>
+
+			<!-- Main Form -->
+			<div class="card">
+				<div class="card-header">
+					<i class="fa-solid fa-pencil"></i> {{ text_form }}
+				</div>
+				<div class="card-body">
+					<form id="form-language" action="{{ save }}" method="post" data-oc-toggle="ajax">
+						<div class="row mb-3 required">
+							<label for="input-name" class="col-sm-2 col-form-label">{{ entry_name }}</label>
+							<div class="col-sm-10">
+								<input type="text" name="name" value="{{ name }}" placeholder="{{ entry_name }}" id="input-name" class="form-control"/>
+								<div id="error-name" class="invalid-feedback"></div>
+							</div>
+						</div>
+						<div class="row mb-3 required">
+							<label for="input-code" class="col-sm-2 col-form-label">{{ entry_code }}</label>
+							<div class="col-sm-10">
+								<input type="text" name="code" value="{{ code }}" placeholder="{{ entry_code }}" id="input-code" class="form-control"/>
+								<div id="error-code" class="invalid-feedback"></div>
+							</div>
+						</div>
+						<div class="row mb-3">
+							<label for="input-extension" class="col-sm-2 col-form-label">{{ entry_extension }}</label>
+						<div class="col-sm-10">
+							<input type="text" name="extension" value="{{ extension }}" id="input-extension" class="form-control" readonly/>
+						</div>
+					</div>
+					<div class="row mb-3 required">
+						<label for="input-locale" class="col-sm-2 col-form-label">{{ entry_locale }}</label>
+						<div class="col-sm-10">
+							<input type="text" name="locale" value="{{ locale }}" placeholder="{{ entry_locale }}" id="input-locale" class="form-control"/>
+							<div class="form-text">{{ help_locale }}</div>
+							<div id="error-locale" class="invalid-feedback"></div>
+						</div>
+					</div>
+					<div class="row mb-3">
+						<label class="col-sm-2 col-form-label">{{ entry_status }}</label>
+						<div class="col-sm-10">
+							<div class="form-check form-switch form-switch-lg">
+								<input type="hidden" name="status" value="0"/>
+								<input type="checkbox" name="status" value="1" id="input-status" class="form-check-input"{% if status %} checked{% endif %}/>
+							</div>
+							<div class="form-text">{{ help_status }}</div>
+						</div>
+					</div>
+					<div class="row mb-3">
+						<label for="input-sort-order" class="col-sm-2 col-form-label">{{ entry_sort_order }}</label>
+						<div class="col-sm-10">
+							<input type="number" name="sort_order" value="{{ sort_order }}" placeholder="{{ entry_sort_order }}" id="input-sort-order" class="form-control"/>
+						</div>
+					</div>
+					<input type="hidden" name="language_id" value="{{ language_id }}" id="input-language-id"/>
+				</form>
+			</div>
+		</div>
+	</div>
 </div>
+
+<script type="text/javascript"><!--
+	let isUpdating = false;
+
+	window.addEventListener('beforeunload', function (e) {
+		if (isUpdating) {
+			e.preventDefault();
+		}
+	});
+
+	$('#form-language').on('submit', function(e) {
+		e.preventDefault();
+
+		$(document).on('ajaxStart', function() {
+			isUpdating = true;
+			$('#progress-bar-container').show();
+			$('#progress-bar').css('width', '0%').attr('aria-valuenow', 0);
+		});
+
+		let interval = '';
+
+		$(document).on('ajaxSend', function() {
+			let progress = 0;
+			interval = setInterval(function() {
+				if (progress < 99) {
+					progress += 1;
+					$('#progress-bar').css('width', progress + '%').attr('aria-valuenow', progress);
+				}
+			}, 750);
+		});
+
+		$(document).on('ajaxStop', function() {
+			isUpdating = false;
+			clearInterval(interval);
+
+			$('#progress-bar').css('width', '100%').attr('aria-valuenow', 100);
+			setTimeout(function() {
+				window.location.href = 'index.php?route=localisation/language&user_token={{ user_token }}';
+			}, 500);
+		});
+
+		$(this).trigger('submit');
+	});
+//--></script>
 {{ footer }}


### PR DESCRIPTION
## Fix: Language Installer Progress & Store Meta Data Update

### Summary
This pull request enhances the language installation process by introducing a progress bar, preventing accidental navigation during installation, and ensuring that store metadata is updated with the first language's data.

### Changes Implemented
- **Added a progress bar** to the language installer UI to provide visual feedback while the installation is running.
- **Prevented accidental navigation** during the installation process to avoid interruptions.
- **Refreshed the page upon successful installation** to return to the language list.
- **Refactored `addLanguage` function** in the model for improved efficiency.
- **Updated store metadata** for all stores, applying the first language's metadata to newly added languages (fix for issue #14765).

### Issue Fixed
- Fixes #14765: Ensures that store metadata updates correctly when a new language is installed.

### Testing
- Tested with multiple languages to verify that metadata updates correctly.
- Confirmed that the progress bar displays properly and reflects ongoing installation.
- Ensured that navigation prevention works as expected.
- Verified that the page refreshes upon completion.

### Additional Notes
- The delete function is going to need some work, it doesn't currently delete all instances of a language.
- If any edge cases arise, feel free to report them, and I'll address them accordingly.

---

Let me know if any further refinements are needed!