### PR TITLE
cache delete/unlink prevent error on file not found

### DIFF
--- a/upload/system/library/cache/file.php
+++ b/upload/system/library/cache/file.php
@@ -80,7 +80,7 @@ class File {
 					if (!@unlink($file)) {
 						clearstatcache(false, $file);
 					}
-				}catch(\Exception $e){}
+				}catch(\Throwable $e){}
 			}
 		}
 	}

--- a/upload/system/library/cache/file.php
+++ b/upload/system/library/cache/file.php
@@ -76,9 +76,11 @@ class File {
 
 		if ($files) {
 			foreach ($files as $file) {
-				if (!@unlink($file)) {
-					clearstatcache(false, $file);
-				}
+				try{//due to race conditions
+					if (!@unlink($file)) {
+						clearstatcache(false, $file);
+					}
+				}catch(\Exception $e){}
 			}
 		}
 	}


### PR DESCRIPTION
due to simultaneous running requests file found for deletion can be gone by time code gets to delete it, so wrapped in try, since @ suppression not coded for in error reporting.

https://github.com/opencart/opencart/pull/14096