### PR TITLE
Admin Zone Filter Fixes & Improvements

### DIFF
--- a/upload/admin/model/localisation/zone.php
+++ b/upload/admin/model/localisation/zone.php
@@ -149,7 +149,7 @@ class Zone extends \Opencart\System\Engine\Model {
 	 * $results = $this->model_localisation_zone->getZones($filter_data);
 	 */
 	public function getZones(array $data = []): array {
-		$sql = "SELECT *, `cd`.`name` AS `country` FROM `" . DB_PREFIX . "zone` `z` LEFT JOIN `" . DB_PREFIX . "zone_description` `zd` ON (`z`.`zone_id` = `zd`.`zone_id` AND `zd`.`language_id` = '" . (int)$this->config->get('config_language_id') . "') LEFT JOIN `" . DB_PREFIX . "country_description` `cd` ON (`z`.`country_id` = `cd`.`country_id` AND `cd`.`language_id` = '" . (int)$this->config->get('config_language_id') . "')";
+		$sql = "SELECT *, `zd`.`name` AS `zone_name`, `cd`.`name` AS `country` FROM `" . DB_PREFIX . "zone` `z` LEFT JOIN `" . DB_PREFIX . "zone_description` `zd` ON (`z`.`zone_id` = `zd`.`zone_id` AND `zd`.`language_id` = '" . (int)$this->config->get('config_language_id') . "') LEFT JOIN `" . DB_PREFIX . "country_description` `cd` ON (`z`.`country_id` = `cd`.`country_id` AND `cd`.`language_id` = '" . (int)$this->config->get('config_language_id') . "')";
 
 		$implode = [];
 

--- a/upload/admin/view/template/localisation/zone.twig
+++ b/upload/admin/view/template/localisation/zone.twig
@@ -1,87 +1,103 @@
 {{ header }}{{ column_left }}
 <div id="content">
-  <div class="page-header">
-    <div class="container-fluid">
-      <div class="float-end">
-        <button type="button" data-bs-toggle="tooltip" title="{{ button_filter }}" onclick="$('#filter-zone').toggleClass('d-none');" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
-        <a href="{{ add }}" data-bs-toggle="tooltip" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" form="form-zone" formaction="{{ delete }}" data-bs-toggle="tooltip" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
-      </div>
-      <h1>{{ heading_title }}</h1>
-      <ol class="breadcrumb">
-        {% for breadcrumb in breadcrumbs %}
-          <li class="breadcrumb-item"><a href="{{ breadcrumb.href }}">{{ breadcrumb.text }}</a></li>
-        {% endfor %}
-      </ol>
-    </div>
-  </div>
-  <div class="container-fluid">
-    <div class="row">
-      <div id="filter-zone" class="col-lg-3 col-md-12 order-lg-last d-none d-lg-block mb-3">
-        <div class="card">
-          <div class="card-header"><i class="fa-solid fa-filter"></i> {{ text_filter }}</div>
-          <div class="card-body">
-            <form id="form-filter">
-              <div class="mb-3">
-                <label class="form-label">{{ entry_name }}</label>
-                <input type="text" name="filter_name" value="{{ filter_name }}" placeholder="{{ entry_name }}" id="input-name" class="form-control"/>
-              </div>
-              <div class="mb-3">
-                <label class="form-label">{{ entry_country }}</label>
-                <input type="text" name="filter_country" value="{{ filter_country }}" placeholder="{{ entry_country }}" id="input-country" class="form-control"/>
-              </div>
-              <div class="mb-3">
-                <label class="form-label">{{ entry_code }}</label>
-                <input type="text" name="filter_code" value="{{ filter_code }}" placeholder="{{ entry_code }}" id="input-code" class="form-control"/>
-              </div>
-              <div class="text-end">
-                <button type="button" id="button-filter" class="btn btn-light"><i class="fa-solid fa-filter"></i> {{ button_filter }}</button>
-                <button type="reset" data-bs-toggle="tooltip" title="{{ button_reset }}" class="btn btn-outline-secondary"><i class="fa-solid fa-filter-circle-xmark"></i></button>
-              </div>
-            </form>
-          </div>
-        </div>
-      </div>
-      <div class="col-lg-9 col-md-122">
-        <div class="card">
-          <div class="card-header"><i class="fa-solid fa-list"></i> {{ text_list }}</div>
-          <div id="zone" class="card-body">{{ list }}</div>
-        </div>
-      </div>
-    </div>
-  </div>
+	<div class="page-header">
+		<div class="container-fluid">
+			<div class="float-end">
+				<button type="button" data-bs-toggle="tooltip" title="{{ button_filter }}" onclick="$('#filter-zone').toggleClass('d-none');" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
+				<a href="{{ add }}" data-bs-toggle="tooltip" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
+				<button type="submit" form="form-zone" formaction="{{ delete }}" data-bs-toggle="tooltip" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+			</div>
+			<h1>{{ heading_title }}</h1>
+			<ol class="breadcrumb">
+				{% for breadcrumb in breadcrumbs %}
+					<li class="breadcrumb-item"><a href="{{ breadcrumb.href }}">{{ breadcrumb.text }}</a></li>
+				{% endfor %}
+			</ol>
+		</div>
+	</div>
+	<div class="container-fluid">
+		<div class="row">
+			<div id="filter-zone" class="col-lg-3 col-md-12 order-lg-last d-none d-lg-block mb-3">
+				<div class="card">
+					<div class="card-header d-flex justify-content-between align-items-center py-1">
+						<span>
+							<i class="fa-solid fa-filter"></i> {{ text_filter }}
+						</span>
+
+						<button type="reset" data-bs-toggle="tooltip" title="{{ button_reset }}" class="btn btn-outline-secondary border-0" id="button-reset">
+							<i class="fa-solid fa-filter-circle-xmark"></i>
+						</button>
+					</div>
+					<div class="card-body">
+						<form id="form-filter">
+							<div class="mb-3">
+								<label class="form-label">{{ entry_name }}</label>
+								<input type="text" name="filter_name" value="{{ filter_name }}" placeholder="{{ entry_name }}" id="input-name" class="form-control"/>
+							</div>
+							<div class="mb-3">
+								<label class="form-label">{{ entry_country }}</label>
+								<input type="text" name="filter_country" value="{{ filter_country }}" placeholder="{{ entry_country }}" id="input-country" class="form-control"/>
+							</div>
+							<div class="mb-3">
+								<label class="form-label">{{ entry_code }}</label>
+								<input type="text" name="filter_code" value="{{ filter_code }}" placeholder="{{ entry_code }}" id="input-code" class="form-control"/>
+							</div>
+						</form>
+					</div>
+				</div>
+			</div>
+			<div class="col-lg-9 col-md-122">
+				<div class="card">
+					<div class="card-header"><i class="fa-solid fa-list"></i> {{ text_list }}</div>
+					<div id="zone" class="card-body">{{ list }}</div>
+				</div>
+			</div>
+		</div>
+	</div>
 </div>
 <script type="text/javascript"><!--
 $('#zone').on('click', 'thead a, .pagination a', function(e) {
-    e.preventDefault();
+		e.preventDefault();
 
-    $('#zone').load(this.href);
+		$('#zone').load(this.href);
 });
 
-$('#button-filter').on('click', function() {
-    var url = '';
+const textInputs = {
+	'#input-name': 'filter_name',
+	'#input-country': 'filter_country',
+	'#input-code': 'filter_code'
+};
 
-    var filter_name = $('#input-name').val();
-
-    if (filter_name) {
-        url += '&filter_name=' + encodeURIComponent(filter_name);
-    }
-
-    var filter_country = $('#input-country').val();
-
-    if (filter_country) {
-        url += '&filter_country=' + encodeURIComponent(filter_country);
-    }
-
-    var filter_code = $('#input-code').val();
-
-    if (filter_code) {
-        url += '&filter_code=' + encodeURIComponent(filter_code);
-    }
-
-    window.history.pushState({}, null, 'index.php?route=localisation/zone&user_token={{ user_token }}' + url);
-
-    $('#zone').load('index.php?route=localisation/zone.list&user_token={{ user_token }}' + url);
+Object.keys(textInputs).forEach(selector => {
+	$(selector).on('keyup', submitForm);
+	$(selector).on('cut paste', () => setTimeout(submitForm, 0));
 });
+
+$('#button-reset').on('click', function() {
+	if (
+		$('#input-name').val() != '' ||
+		$('#input-country').val() != '' ||
+		$('#input-code').val() != ''
+	) {
+		Object.keys(textInputs).forEach(selector => {
+			$(selector).val('');
+		});
+
+		submitForm();
+	}
+});
+
+function submitForm() {
+	let url = '';
+
+	Object.keys(textInputs).forEach(selector => {
+		const inputValue = $(selector).val();
+		if (inputValue) {
+			url += '&' + textInputs[selector] + '=' + encodeURIComponent(inputValue);
+		}
+	});
+
+	$('#zone').load('index.php?route=localisation/zone.list&user_token={{ user_token }}' + url);
+}
 //--></script>
 {{ footer }}

--- a/upload/admin/view/template/localisation/zone_list.twig
+++ b/upload/admin/view/template/localisation/zone_list.twig
@@ -16,7 +16,7 @@
             <tr{% if not zone.status %} class="table-active opacity-50"{% endif %}>
               <td class="text-center"><input type="checkbox" name="selected[]" value="{{ zone.zone_id }}" class="form-check-input"/></td>
               <td>{{ zone.country }}</td>
-              <td>{{ zone.name }}</td>
+              <td>{{ zone.zone_name }}</td>
               <td>{{ zone.code }}</td>
               <td class="text-end"><a href="{{ zone.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a></td>
             </tr>


### PR DESCRIPTION
## 🛠️ Admin Zone Filter Fixes & Improvements 
I initially started this work intending to update the zone filter to match the changes I had made fixing the category filter. However, while doing so, I discovered existing issues that needed to be addressed: 

- Filtering by zone name appeared to give erroneous results 

- The form only submitted when clicking the filter button, which felt outdated compared to the improvements made elsewhere.

## ✅ Summary of Changes:
- Fixed the zone name error 

- Updated the form to auto-submit on input (keyup, cut, paste) events. 

- Removed the now-redundant submit button.

- Moved the reset/clear filter button to the top-right of the filter box for a cleaner and more accessible layout.

- Clear Filter button now clears all filter inputs and automatically submits the form for a clean reset.

- Removed history push state to improve workflow

**BEFORE**
![before](https://github.com/user-attachments/assets/30a3b19e-ecb8-4348-9ad9-8b7cf8b954fc)

**AFTER**
![after](https://github.com/user-attachments/assets/b72207bf-7baf-4e57-89d5-3c58c1893d9b)
