### PR TITLE
Revert "cache delete/unlink prevent error on file not found"

### DIFF
--- a/upload/system/library/cache/file.php
+++ b/upload/system/library/cache/file.php
@@ -76,11 +76,9 @@ class File {
 
 		if ($files) {
 			foreach ($files as $file) {
-				try{//due to race conditions
-					if (!@unlink($file)) {
-						clearstatcache(false, $file);
-					}
-				}catch(\Throwable $e){}
+				if (!@unlink($file)) {
+					clearstatcache(false, $file);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Reverts #14778 

sorry daniel bet it seems warning cant be caught,