### PR TITLE
Fix autoloader in storeInstance to ensure proper class loading

### DIFF
--- a/upload/catalog/controller/cron/subscription.php
+++ b/upload/catalog/controller/cron/subscription.php
@@ -143,6 +143,8 @@ class Subscription extends \Opencart\System\Engine\Controller {
 					if (!isset($error['shipping_method'])) {
 						$store->session->data['shipping_method'] = $result['shipping_method'];
 					}
+				} else {
+					$shipping_address_info = [];
 				}
 
 				// Validate payment method

--- a/upload/catalog/model/setting/store.php
+++ b/upload/catalog/model/setting/store.php
@@ -92,7 +92,12 @@ class Store extends \Opencart\System\Engine\Model {
 	 */
 	public function createStoreInstance(int $store_id = 0, string $language = '', string $session_id = ''): \Opencart\System\Engine\Registry {
 		// Autoloader
-		$this->autoloader->register('Opencart\Catalog', DIR_APPLICATION);
+
+		$autoloader = new \Opencart\System\Engine\Autoloader();
+		$autoloader->register('Opencart\Catalog', DIR_APPLICATION);
+		// Registry
+		$registry = new \Opencart\System\Engine\Registry();
+		$registry->set('autoloader', $autoloader);
 
 		// Registry
 		$registry = new \Opencart\System\Engine\Registry();


### PR DESCRIPTION
As explained in issue #14823, the use of $this->autoloader fails to load certain classes—likely because they were already loaded earlier in the execution flow. To resolve this, a new $autoloader instance is created to ensure proper and consistent class loading within storeInstance.