### PR TITLE
Fix: Correct div ID from 'list' to 'extension' in installer.twig for proper JS/AJAX binding

### DIFF
--- a/upload/admin/view/template/marketplace/installer.twig
+++ b/upload/admin/view/template/marketplace/installer.twig
@@ -29,7 +29,7 @@
         </fieldset>
         <fieldset>
           <legend>{{ text_installed }}</legend>
-          <div id="list">{{ list }}</div>
+          <div id="extension">{{ list }}</div>
         </fieldset>
       </div>
     </div>


### PR DESCRIPTION
## Summary

PR fixes a mismatch in the `installer.twig` template where the `<div>` block was using `id="list"` but the associated JavaScript was targeting `#extension`. This mismatch caused AJAX operations (such as extension install/uninstall progress updates) to break, resulting in stuck progress indicators or raw JSON output in the browser.

## Details

- Updated `<div id="list">` to `<div id="extension">` in `upload/admin/view/template/marketplace/installer.twig`.
- Aligns the template markup with the JavaScript selectors used in `installer.twig`.
- Resolves backend extension installer UI breakage.

## Testing

- Applied and tested on a live OpenCart 4.1.0.3 deployment.
- Verified successful extension installation and uninstallation without UI dumping AJAX payload or seeing browser console errors.
- No apparent side effects on related templates or functions.

## Notes

Minor but important fix to help those experiencing the AJAX page breaks in the admin-side extension management feature.