### PR TITLE
Active, inactive and uninstalled CSS template tweaks for #14821

### DIFF
--- a/upload/admin/controller/extension/shipping.php
+++ b/upload/admin/controller/extension/shipping.php
@@ -60,6 +60,7 @@ class Shipping extends \Opencart\System\Engine\Controller {
 
 				$data['extensions'][] = [
 					'name'       => $this->language->get($code . '_heading_title'),
+					'code'       => $code,
 					'status'     => $this->config->get('shipping_' . $code . '_status'),
 					'sort_order' => $this->config->get('shipping_' . $code . '_sort_order'),
 					'install'    => $this->url->link('extension/shipping.install', 'user_token=' . $this->session->data['user_token'] . '&extension=' . $extension . '&code=' . $code),

--- a/upload/admin/language/en-gb/extension/shipping.php
+++ b/upload/admin/language/en-gb/extension/shipping.php
@@ -10,6 +10,7 @@ $_['text_list']         = 'Shipping List';
 $_['column_name']       = 'Shipping Method';
 $_['column_status']     = 'Status';
 $_['column_sort_order'] = 'Sort Order';
+$_['column_code']       = 'Code';
 $_['column_action']     = 'Action';
 
 // Error

--- a/upload/admin/language/en-gb/marketplace/cron.php
+++ b/upload/admin/language/en-gb/marketplace/cron.php
@@ -16,6 +16,7 @@ $_['text_month']           = 'Month';
 // Column
 $_['column_code']          = 'CRON Code';
 $_['column_cycle']         = 'Cycle';
+$_['column_cron_action']   = 'CRON Action';
 $_['column_date_added']    = 'Date Added';
 $_['column_date_modified'] = 'Date Modified';
 $_['column_action']        = 'Action';

--- a/upload/admin/language/en-gb/marketplace/ssr.php
+++ b/upload/admin/language/en-gb/marketplace/ssr.php
@@ -14,6 +14,7 @@ $_['entry_progress']       = 'Progress';
 
 // Column
 $_['column_code']          = 'SSR Code';
+$_['column_ssr_action']    = 'SSR Action';
 $_['column_progress']      = 'Progress';
 $_['column_sort_order']    = 'Sort Order';
 $_['column_date_modified'] = 'Date Modified';

--- a/upload/admin/view/stylesheet/stylesheet.css
+++ b/upload/admin/view/stylesheet/stylesheet.css
@@ -496,7 +496,13 @@ a {
 }
 
 /* required */
-label.required:before, label:has(+ * *[required]):before, label:has(+ *[required]):before {
+label:has(+ div *[required]):before {
+    content: '* ';
+    color: red;
+    font-weight: bold;
+}
+
+label.required:before, label:has(+ input:required):before, label:has(+ select:required):before, label:has(+ textarea:required):before {
     content: '* ';
     color: red;
     font-weight: bold;
@@ -886,4 +892,31 @@ label.required:before, label:has(+ * *[required]):before, label:has(+ *[required
 td {
     position: relative;
 	vertical-align: middle;
+}
+
+.text-decoration-disabled td {
+  text-decoration: none !important;
+  color: rgba(0, 0, 0, 0.5) !important;
+}
+
+.text-decoration-enabled td {
+  text-decoration: none !important;
+  color: rgba(0, 0, 0, 1.0) !important;
+}
+
+.text-decoration-uninstalled td {
+  text-decoration: line-through !important;
+  color: rgba(0, 0, 0, 0.5) !important;
+}
+
+.text-decoration-none td {
+  text-decoration: none !important;
+  color: rgba(255, 0, 0, 1.0) !important;
+}
+
+.text-decoration-uninstalled .text-decoration-none,
+.text-decoration-disabled .text-decoration-none,
+.text-decoration-enabled .text-decoration-none {
+  text-decoration: none !important;
+  color: rgba(0, 0, 0, 1.0) !important;
 }

--- a/upload/admin/view/template/catalog/category_list.twig
+++ b/upload/admin/view/template/catalog/category_list.twig
@@ -14,7 +14,7 @@
       <tbody>
         {% if categories %}
           {% for category in categories %}
-            <tr{% if not category.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not category.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td class="text-center"><input type="checkbox" name="selected[]" value="{{ category.category_id }}" class="form-check-input"/></td>
               <td class="text-center"><img src="{{ category.image }}" alt="{{ category.name }}" class="img-thumbnail"/></td>
               <td>{{ category.name }}</td>
@@ -25,7 +25,7 @@
                 </div>
               </td>
               <td class="text-end">{{ category.sort_order }}</td>
-              <td class="text-end"><a href="{{ category.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a></td>
+              <td class="text-end text-nowrap text-decoration-none"><a href="{{ category.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not category.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a></td>
             </tr>
           {% endfor %}
         {% else %}

--- a/upload/admin/view/template/catalog/information_list.twig
+++ b/upload/admin/view/template/catalog/information_list.twig
@@ -12,11 +12,11 @@
       <tbody>
         {% if informations %}
           {% for information in informations %}
-            <tr{% if not information.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not information.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td class="text-center"><input type="checkbox" name="selected[]" value="{{ information.information_id }}" class="form-check-input"/></td>
               <td>{{ information.title }}</td>
               <td class="text-end">{{ information.sort_order }}</td>
-              <td class="text-end"><a href="{{ information.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a></td>
+              <td class="text-end text-nowrap text-decoration-none"><a href="{{ information.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not information.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a></td>
             </tr>
           {% endfor %}
         {% else %}

--- a/upload/admin/view/template/catalog/product_list.twig
+++ b/upload/admin/view/template/catalog/product_list.twig
@@ -15,7 +15,7 @@
       <tbody>
         {% if products %}
           {% for product in products %}
-            <tr class="{% if not product.variant %}table-warning{% endif %} {% if not product.status %}table-active opacity-50{% endif %}">
+            <tr class="{% if not product.variant %}table-warning{% endif %}{% if not product.status %} text-decoration-disabled{% else %} text-decoration-enabled{% endif %}">
               <td class="text-center"><input type="checkbox" name="selected[]" value="{{ product.product_id }}" class="form-check-input"/></td>
               <td class="text-center"><img src="{{ product.image }}" alt="{{ product.name }}" class="img-thumbnail"/></td>
               <td>{{ product.name }}</td>
@@ -29,17 +29,17 @@
                 {% endif %}</td>
               <td class="text-end">
                 {% if product.quantity <= 0 %}
-                  <span class="badge bg-warning">{{ product.quantity }}</span>
+                  <span class="badge bg-warning{% if not product.status %} bg-opacity-50{% endif %}">{{ product.quantity }}</span>
                 {% elseif product.quantity <= 5 %}
-                  <span class="badge bg-danger">{{ product.quantity }}</span>
+                  <span class="badge bg-danger{% if not product.status %} bg-opacity-50{% endif %}">{{ product.quantity }}</span>
                 {% else %}
-                  <span class="badge bg-success">{{ product.quantity }}</span>
+                  <span class="badge bg-success{% if not product.status %} bg-opacity-50{% endif %}">{{ product.quantity }}</span>
                 {% endif %}</td>
-              <td class="text-end">
+              <td class="text-end text-nowrap text-decoration-none">
                 {% if product.variant %}
                   <div class="btn-group">
-                    <a href="{{ product.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a>
-                    <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown"><i class="fa-solid fa-caret-down"></i></button>
+                    <a href="{{ product.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not product.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a>
+                    <button type="button" class="{% if not product.status %}btn btn-secondary{% else %}btn btn-primary{% endif %} dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown"><i class="fa-solid fa-caret-down"></i></button>
                     <div class="dropdown-menu dropdown-menu-end"><a href="{{ product.variant }}" class="dropdown-item"><i class="fa-solid fa-plus"></i> {{ text_variant_add }}</a></div>
                   </div>
                 {% else %}

--- a/upload/admin/view/template/catalog/review_list.twig
+++ b/upload/admin/view/template/catalog/review_list.twig
@@ -14,18 +14,18 @@
       <tbody>
         {% if reviews %}
           {% for review in reviews %}
-            <tr{% if not review.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not review.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td class="text-center"><input type="checkbox" name="selected[]" value="{{ review.review_id }}" class="form-check-input"/></td>
               <td>{{ review.name }}</td>
               <td>{{ review.author }}</td>
               <td class="text-end d-none d-lg-table-cell">{{ review.rating }}</td>
               <td>{{ review.date_added }}</td>
-              <td class="text-end"><a href="{{ review.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a></td>
+              <td class="text-end text-nowrap text-decoration-none"><a href="{{ review.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not review.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a></td>
             </tr>
           {% endfor %}
         {% else %}
           <tr>
-            <td class="text-center" colspan="7">{{ text_no_results }}</td>
+            <td class="text-center" colspan="6">{{ text_no_results }}</td>
           </tr>
         {% endif %}
       </tbody>

--- a/upload/admin/view/template/catalog/subscription_plan_list.twig
+++ b/upload/admin/view/template/catalog/subscription_plan_list.twig
@@ -12,11 +12,11 @@
       <tbody>
         {% if subscription_plans %}
           {% for subscription_plan in subscription_plans %}
-            <tr{% if not subscription_plan.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not subscription_plan.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td class="text-center"><input type="checkbox" name="selected[]" value="{{ subscription_plan.subscription_plan_id }}" class="form-check-input"/></td>
               <td>{{ subscription_plan.name }}</td>
               <td class="text-end">{{ subscription_plan.sort_order }}</td>
-              <td class="text-end"><a href="{{ subscription_plan.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a></td>
+              <td class="text-end text-nowrap text-decoration-none"><a href="{{ subscription_plan.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not subscription_plan.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a></td>
             </tr>
           {% endfor %}
         {% else %}

--- a/upload/admin/view/template/cms/article_list.twig
+++ b/upload/admin/view/template/cms/article_list.twig
@@ -14,18 +14,18 @@
       <tbody>
         {% if articles %}
           {% for article in articles %}
-            <tr{% if not article.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not article.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td class="text-center"><input type="checkbox" name="selected[]" value="{{ article.article_id }}" class="form-check-input"/></td>
               <td>{{ article.name }}</td>
               <td>{{ article.author }}</td>
               <td class="text-end">{{ article.rating }}</td>
               <td class="text-end">{{ article.date_added }}</td>
-              <td class="text-end"><a href="{{ article.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a></td>
+              <td class="text-end text-nowrap text-decoration-none"><a href="{{ article.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not article.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a></td>
             </tr>
           {% endfor %}
         {% else %}
           <tr>
-            <td class="text-center" colspan="5">{{ text_no_results }}</td>
+            <td class="text-center" colspan="6">{{ text_no_results }}</td>
           </tr>
         {% endif %}
       </tbody>

--- a/upload/admin/view/template/cms/comment_list.twig
+++ b/upload/admin/view/template/cms/comment_list.twig
@@ -9,7 +9,7 @@
     <tbody>
       {% if comments %}
         {% for comment in comments %}
-          <tr{% if not comment.status %} class="table-active opacity-50"{% endif %}>
+          <tr>
             <td class="text-center" rowspan="2"><input type="checkbox" name="selected[]" value="{{ comment.article_comment_id }}" class="form-check-input"/></td>
             <td><a href="{{ comment.article_edit }}" target="_blank">{{ comment.article }}</a>
               <p>
@@ -26,7 +26,7 @@
             </td>
           </tr>
           <tr>
-            <td class="text-end">
+            <td class="text-end text-nowrap text-decoration-none">
               {% if comment.approve %}
                 <button type="button" value="{{ comment.approve }}" data-bs-toggle="tooltip" title="{{ button_approve }}" class="btn btn-success"><i class="fa-solid fa-check"></i></button>
               {% else %}

--- a/upload/admin/view/template/cms/topic_list.twig
+++ b/upload/admin/view/template/cms/topic_list.twig
@@ -12,11 +12,11 @@
       <tbody>
         {% if topics %}
           {% for topic in topics %}
-            <tr{% if not topic.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not topic.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td class="text-center"><input type="checkbox" name="selected[]" value="{{ topic.topic_id }}" class="form-check-input"/></td>
               <td>{{ topic.name }}</td>
               <td class="text-end">{{ topic.sort_order }}</td>
-              <td class="text-end"><a href="{{ topic.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a></td>
+              <td class="text-end text-nowrap text-decoration-none"><a href="{{ topic.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not topic.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a></td>
             </tr>
           {% endfor %}
         {% else %}

--- a/upload/admin/view/template/customer/custom_field_list.twig
+++ b/upload/admin/view/template/customer/custom_field_list.twig
@@ -14,13 +14,13 @@
       <tbody>
         {% if custom_fields %}
           {% for custom_field in custom_fields %}
-            <tr{% if not custom_field.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not custom_field.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td class="text-center"><input type="checkbox" name="selected[]" value="{{ custom_field.custom_field_id }}" class="form-check-input"/></td>
               <td>{{ custom_field.name }}</td>
               <td>{{ custom_field.location }}</td>
               <td>{{ custom_field.type }}</td>
               <td class="text-end d-none d-lg-table-cell">{{ custom_field.sort_order }}</td>
-              <td class="text-end"><a href="{{ custom_field.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a></td>
+              <td class="text-end text-nowrap text-decoration-none"><a href="{{ custom_field.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not custom_field.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a></td>
             </tr>
           {% endfor %}
         {% else %}

--- a/upload/admin/view/template/customer/customer_approval.twig
+++ b/upload/admin/view/template/customer/customer_approval.twig
@@ -4,8 +4,8 @@
     <div class="container-fluid">
       <div class="float-end">
         <button type="button" data-bs-toggle="tooltip" title="{{ button_filter }}" onclick="$('#filter-customer').toggleClass('d-none');" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
-        <button type="submit" form="form-customer-approval" formaction="{{ approve }}" data-bs-toggle="tooltip" title="{{ text_approve }}" class="btn btn-success"><i class="fa-solid fa-check"></i></button>
-        <button type="submit" form="form-customer-approval" formaction="{{ deny }}" data-bs-toggle="tooltip" title="{{ text_deny }}" class="btn btn-warning"><i class="fa-solid fa-circle-xmark"></i></button>
+        <button type="submit" form="form-customer-approval" formaction="{{ approve }}" data-bs-toggle="tooltip" title="{{ text_approve }}" class="btn btn-success"><i class="fa-solid fa-thumbs-up"></i></button>
+        <button type="submit" form="form-customer-approval" formaction="{{ deny }}" data-bs-toggle="tooltip" title="{{ text_deny }}" class="btn btn-danger"><i class="fa-solid fa-thumbs-down"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/customer/customer_authorize.twig
+++ b/upload/admin/view/template/customer/customer_authorize.twig
@@ -12,12 +12,12 @@
     <tbody>
       {% if authorizes %}
         {% for authorize in authorizes %}
-          <tr{% if not authorize.status %} class="table-active opacity-50"{% endif %}>
+          <tr{% if not authorize.status %}  class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
             <td><a href="https://whatismyipaddress.com/ip/{{ user_login.ip }}" target="_blank">{{ authorize.ip }}</a></td>
             <td>{{ authorize.user_agent }}</td>
             <td>{{ authorize.date_added }}</td>
             <td>{{ authorize.date_expire }}</td>
-            <td class="text-end"><a href="{{ authorize.delete }}" data-bs-toggle="tooltip" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></a></td>
+            <td class="text-end text-nowrap text-decoration-none"><a href="{{ authorize.delete }}" data-bs-toggle="tooltip" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></a></td>
           </tr>
         {% endfor %}
       {% else %}

--- a/upload/admin/view/template/customer/customer_list.twig
+++ b/upload/admin/view/template/customer/customer_list.twig
@@ -14,16 +14,16 @@
       <tbody>
         {% if customers %}
           {% for customer in customers %}
-            <tr{% if not customer.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not customer.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td class="text-center"><input type="checkbox" name="selected[]" value="{{ customer.customer_id }}" class="form-check-input"/></td>
               <td>{{ customer.name }}</td>
               <td>{{ customer.email }}</td>
               <td>{{ customer.customer_group }}</td>
               <td class="d-none d-lg-table-cell">{{ customer.date_added }}</td>
-              <td class="text-end">
+              <td class="text-end text-nowrap text-decoration-none">
                 <div class="btn-group dropdown">
-                  <a href="{{ customer.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a>
-                  <button type="button" data-bs-toggle="dropdown" class="btn btn-primary dropdown-toggle dropdown-toggle-split"><span class="fa-solid fa-caret-down"></span></button>
+                  <a href="{{ customer.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not customer.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a>
+                  <button type="button" data-bs-toggle="dropdown" class="{% if not customer.status %}btn btn-secondary{% else %}btn btn-primary{% endif %} dropdown-toggle dropdown-toggle-split"><span class="fa-solid fa-caret-down"></span></button>
                   <ul class="dropdown-menu dropdown-menu-end">
                     <li><h6 class="dropdown-header">{{ text_option }}</h6></li>
                     {% if customer.unlock %}
@@ -37,12 +37,13 @@
                       <li><a href="{{ store.href }}" target="_blank" class="dropdown-item"><i class="fa-solid fa-lock"></i> {{ store.name }}</a></li>
                     {% endfor %}
                   </ul>
-                </div></td>
+                </div>
+              </td>
             </tr>
           {% endfor %}
         {% else %}
           <tr>
-            <td class="text-center" colspan="7">{{ text_no_results }}</td>
+            <td class="text-center" colspan="6">{{ text_no_results }}</td>
           </tr>
         {% endif %}
       </tbody>

--- a/upload/admin/view/template/design/banner_list.twig
+++ b/upload/admin/view/template/design/banner_list.twig
@@ -11,10 +11,10 @@
       <tbody>
         {% if banners %}
           {% for banner in banners %}
-            <tr{% if not banner.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not banner.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td class="text-center"><input type="checkbox" name="selected[]" value="{{ banner.banner_id }}" class="form-check-input"/></td>
               <td>{{ banner.name }}</td>
-              <td class="text-end"><a href="{{ banner.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a></td>
+              <td class="text-end text-nowrap text-decoration-none"><a href="{{ banner.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not banner.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a></td>
             </tr>
           {% endfor %}
         {% else %}

--- a/upload/admin/view/template/design/theme_list.twig
+++ b/upload/admin/view/template/design/theme_list.twig
@@ -13,17 +13,17 @@
       <tbody>
         {% if themes %}
           {% for theme in themes %}
-            <tr{% if not theme.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not theme.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td class="text-center"><input type="checkbox" name="selected[]" value="{{ theme.theme_id }}" class="form-check-input"/></td>
               <td>{{ theme.route }}</td>
               <td>{{ theme.store }}</td>
               <td>{{ theme.date_added }}</td>
-              <td class="text-end text-nowrap"><a href="{{ theme.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a> <button type="button" value="{{ theme.delete }}" data-bs-toggle="tooltip" title="{{ button_delete }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button></td>
+              <td class="text-end text-nowrap text-decoration-none"><a href="{{ theme.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not theme.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a> <button type="button" value="{{ theme.delete }}" data-bs-toggle="tooltip" title="{{ button_delete }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button></td>
             </tr>
           {% endfor %}
         {% else %}
           <tr>
-            <td class="text-center" colspan="6">{{ text_no_results }}</td>
+            <td class="text-center" colspan="5">{{ text_no_results }}</td>
           </tr>
         {% endif %}
       </tbody>

--- a/upload/admin/view/template/extension/analytics.twig
+++ b/upload/admin/view/template/extension/analytics.twig
@@ -12,19 +12,23 @@
       <tbody>
         {% if extensions %}
           {% for extension in extensions %}
-            <tr>
+            <tr{% if not extension.installed %} class="text-decoration-uninstalled"{% elseif not extension.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td><b>{{ extension.name }}</b></td>
-              <td class="text-end">{% if not extension.installed %}
-                <a href="{{ extension.install }}" data-bs-toggle="tooltip" title="{{ button_install }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></a>
-              {% else %}
+              <td class="text-end text-nowrap text-decoration-none">
+              {% if extension.installed %}
                 <a href="{{ extension.uninstall }}" data-bs-toggle="tooltip" title="{{ button_uninstall }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></a>
-              {% endif %}</td>
+              {% else %}
+                <a href="{{ extension.install }}" data-bs-toggle="tooltip" title="{{ button_install }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></a>
+              {% endif %}
+              </td>
             </tr>
             {% if extension.installed %}
               {% for store in extension.store %}
-                <tr{% if not store.status %} class="table-active opacity-50"{% endif %}>
+                <tr{% if not store.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
                   <td>&nbsp;&nbsp;&nbsp;-&nbsp;&nbsp;&nbsp;{{ store.name }}</td>
-                  <td class="text-end text-nowrap"><a href="{{ store.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a></td>
+                  <td class="text-end text-nowrap text-decoration-none">
+                    <a href="{{ store.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not store.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a>
+                  </td>
                 </tr>
               {% endfor %}
             {% endif %}

--- a/upload/admin/view/template/extension/captcha.twig
+++ b/upload/admin/view/template/extension/captcha.twig
@@ -12,15 +12,22 @@
       <tbody>
         {% if extensions %}
           {% for extension in extensions %}
-            <tr{% if not extension.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not extension.installed %} class="text-decoration-uninstalled"{% elseif not extension.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td>{{ extension.name }}{% if extension.code == code %} <strong>({{ text_default }})</strong>{% endif %}</td>
-              <td class="text-end text-nowrap">{% if extension.installed %}<a href="{{ extension.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a>{% else %}<button type="button" class="btn btn-primary" disabled="disabled"><i class="fa-solid fa-pencil"></i></button>{% endif %}
-                {% if not extension.installed %} <a href="{{ extension.install }}" data-bs-toggle="tooltip" title="{{ button_install }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></a> {% else %} <a href="{{ extension.uninstall }}" data-bs-toggle="tooltip" title="{{ button_uninstall }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></a>{% endif %}</td>
+              <td class="text-end text-nowrap text-decoration-none">
+              {% if extension.installed %}
+                <a href="{{ extension.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not extension.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a>
+                <a href="{{ extension.uninstall }}" data-bs-toggle="tooltip" title="{{ button_uninstall }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></a>
+              {% else %}
+                <button type="button" class="btn btn-secondary" disabled="disabled"><i class="fa-solid fa-pencil"></i></button>
+                <a href="{{ extension.install }}" data-bs-toggle="tooltip" title="{{ button_install }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></a>
+              {% endif %}
+              </td>
             </tr>
           {% endfor %}
         {% else %}
           <tr>
-            <td class="text-center" colspan="3">{{ text_no_results }}</td>
+            <td class="text-center" colspan="2">{{ text_no_results }}</td>
           </tr>
         {% endif %}
       </tbody>

--- a/upload/admin/view/template/extension/currency.twig
+++ b/upload/admin/view/template/extension/currency.twig
@@ -12,15 +12,22 @@
       <tbody>
         {% if extensions %}
           {% for extension in extensions %}
-            <tr{% if not extension.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not extension.installed %} class="text-decoration-uninstalled"{% elseif not extension.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td>{{ extension.name }}{% if extension.code == code %} <strong>({{ text_default }})</strong>{% endif %}</td>
-              <td class="text-end text-nowrap">{% if extension.installed %}<a href="{{ extension.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a>{% else %}<button type="button" class="btn btn-primary" disabled="disabled"><i class="fa-solid fa-pencil"></i></button>{% endif %}
-                {% if not extension.installed %}<a href="{{ extension.install }}" data-bs-toggle="tooltip" title="{{ button_install }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></a>{% else %}<a href="{{ extension.uninstall }}" data-bs-toggle="tooltip" title="{{ button_uninstall }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></a>{% endif %}</td>
+              <td class="text-end text-nowrap text-decoration-none">
+              {% if extension.installed %}
+                <a href="{{ extension.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not extension.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a>
+                <a href="{{ extension.uninstall }}" data-bs-toggle="tooltip" title="{{ button_uninstall }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></a>
+              {% else %}
+                <button type="button" class="btn btn-secondary" disabled="disabled"><i class="fa-solid fa-pencil"></i></button>
+                <a href="{{ extension.install }}" data-bs-toggle="tooltip" title="{{ button_install }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></a>
+              {% endif %}
+              </td>
             </tr>
           {% endfor %}
         {% else %}
           <tr>
-            <td class="text-center" colspan="3">{{ text_no_results }}</td>
+            <td class="text-center" colspan="2">{{ text_no_results }}</td>
           </tr>
         {% endif %}
       </tbody>

--- a/upload/admin/view/template/extension/dashboard.twig
+++ b/upload/admin/view/template/extension/dashboard.twig
@@ -14,25 +14,24 @@
       <tbody>
         {% if extensions %}
           {% for extension in extensions %}
-            <tr{% if not extension.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not extension.installed %} class="text-decoration-uninstalled"{% elseif not extension.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td>{{ extension.name }}</td>
               <td class="text-end">{{ extension.width }}</td>
               <td class="text-end">{{ extension.sort_order }}</td>
-              <td class="text-end text-nowrap">{% if extension.installed %}
-                <a href="{{ extension.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a>
-              {% else %}
-                <button type="button" class="btn btn-primary" disabled="disabled"><i class="fa-solid fa-pencil"></i></button>
-              {% endif %}
-              {% if not extension.installed %}
-                <a href="{{ extension.install }}" data-bs-toggle="tooltip" title="{{ button_install }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></a>
-              {% else %}
+              <td class="text-end text-nowrap text-decoration-none">
+              {% if extension.installed %}
+                <a href="{{ extension.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not extension.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a>
                 <a href="{{ extension.uninstall }}" data-bs-toggle="tooltip" title="{{ button_uninstall }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></a>
-              {% endif %}</td>
+              {% else %}
+                <button type="button" class="btn btn-secondary" disabled="disabled"><i class="fa-solid fa-pencil"></i></button>
+                <a href="{{ extension.install }}" data-bs-toggle="tooltip" title="{{ button_install }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></a>
+              {% endif %}
+              </td>
             </tr>
           {% endfor %}
         {% else %}
           <tr>
-            <td class="text-center" colspan="3">{{ text_no_results }}</td>
+            <td class="text-center" colspan="4">{{ text_no_results }}</td>
           </tr>
         {% endif %}
       </tbody>

--- a/upload/admin/view/template/extension/feed.twig
+++ b/upload/admin/view/template/extension/feed.twig
@@ -12,18 +12,17 @@
       <tbody>
         {% if extensions %}
           {% for extension in extensions %}
-            <tr{% if not extension.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not extension.installed %} class="text-decoration-uninstalled"{% elseif not extension.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td>{{ extension.name }}</td>
-              <td class="text-end text-nowrap">{% if extension.installed %}
-                <a href="{{ extension.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a>
-              {% else %}
-                <button type="button" class="btn btn-primary" disabled="disabled"><i class="fa-solid fa-pencil"></i></button>
-              {% endif %}
-              {% if not extension.installed %}
-                <a href="{{ extension.install }}" data-bs-toggle="tooltip" title="{{ button_install }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></a>
-              {% else %}
+              <td class="text-end text-nowrap text-decoration-none">
+              {% if extension.installed %}
+                <a href="{{ extension.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not extension.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a>
                 <a href="{{ extension.uninstall }}" data-bs-toggle="tooltip" title="{{ button_uninstall }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></a>
-              {% endif %}</td>
+              {% else %}
+                <button type="button" class="btn btn-secondary" disabled="disabled"><i class="fa-solid fa-pencil"></i></button>
+                <a href="{{ extension.install }}" data-bs-toggle="tooltip" title="{{ button_install }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></a>
+              {% endif %}
+              </td>
             </tr>
           {% endfor %}
         {% else %}

--- a/upload/admin/view/template/extension/fraud.twig
+++ b/upload/admin/view/template/extension/fraud.twig
@@ -12,23 +12,22 @@
       <tbody>
         {% if extensions %}
           {% for extension in extensions %}
-            <tr{% if not extension.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not extension.installed %} class="text-decoration-uninstalled"{% elseif not extension.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td>{{ extension.name }}</td>
-              <td class="text-end text-nowrap">{% if extension.installed %}
-                <a href="{{ extension.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a>
-              {% else %}
-                <button type="button" class="btn btn-primary" disabled="disabled"><i class="fa-solid fa-pencil"></i></button>
-              {% endif %}
-              {% if not extension.installed %}
-                <a href="{{ extension.install }}" data-bs-toggle="tooltip" title="{{ button_install }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></a>
-              {% else %}
+              <td class="text-end text-nowrap text-decoration-none">
+              {% if extension.installed %}
+                <a href="{{ extension.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not extension.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a>
                 <a href="{{ extension.uninstall }}" data-bs-toggle="tooltip" title="{{ button_uninstall }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></a>
-              {% endif %}</td>
+              {% else %}
+                <button type="button" class="btn btn-secondary" disabled="disabled"><i class="fa-solid fa-pencil"></i></button>
+                <a href="{{ extension.install }}" data-bs-toggle="tooltip" title="{{ button_install }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></a>
+              {% endif %}
+              </td>
             </tr>
           {% endfor %}
         {% else %}
           <tr>
-            <td class="text-center" colspan="3">{{ text_no_results }}</td>
+            <td class="text-center" colspan="2">{{ text_no_results }}</td>
           </tr>
         {% endif %}
       </tbody>

--- a/upload/admin/view/template/extension/language.twig
+++ b/upload/admin/view/template/extension/language.twig
@@ -12,18 +12,17 @@
       <tbody>
         {% if extensions %}
           {% for extension in extensions %}
-            <tr{% if not extension.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not extension.installed %} class="text-decoration-uninstalled"{% elseif not extension.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td>{{ extension.name }}</td>
-              <td class="text-end text-nowrap">{% if extension.installed %}
-                <a href="{{ extension.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a>
-              {% else %}
-                <button type="button" class="btn btn-primary" disabled="disabled"><i class="fa-solid fa-pencil"></i></button>
-              {% endif %}
-              {% if not extension.installed %}
-                <a href="{{ extension.install }}" data-bs-toggle="tooltip" title="{{ button_install }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></a>
-              {% else %}
+              <td class="text-end text-nowrap text-decoration-none">
+              {% if extension.installed %}
+                <a href="{{ extension.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not extension.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a>
                 <a href="{{ extension.uninstall }}" data-bs-toggle="tooltip" title="{{ button_uninstall }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></a>
-              {% endif %}</td>
+              {% else %}
+                <button type="button" class="btn btn-secondary" disabled="disabled"><i class="fa-solid fa-pencil"></i></button>
+                <a href="{{ extension.install }}" data-bs-toggle="tooltip" title="{{ button_install }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></a>
+              {% endif %}
+              </td>
             </tr>
           {% endfor %}
         {% else %}

--- a/upload/admin/view/template/extension/marketplace.twig
+++ b/upload/admin/view/template/extension/marketplace.twig
@@ -11,32 +11,27 @@
         </tr>
       </thead>
       <tbody>
-        {% if extensions %}
-          {% for extension in extensions %}
-            <tr>
-              <td>{{ extension.name }}</td>
-              <td>{{ extension.status }}</td>
-              <td class="text-end text-nowrap">
-
-                {% if extension.installed %}
-                  <a href="{{ extension.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a>
-                {% else %}
-                  <button type="button" class="btn btn-primary" disabled="disabled"><i class="fa-solid fa-pencil"></i></button>
-                {% endif %}
-
-                {% if not extension.installed %}
-                  <a href="{{ extension.install }}" data-bs-toggle="tooltip" title="{{ button_install }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></a>
-                {% else %}
-                  <a href="{{ extension.uninstall }}" data-bs-toggle="tooltip" title="{{ button_uninstall }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></a>
-                {% endif %}</td>
-
-            </tr>
-          {% endfor %}
-        {% else %}
-          <tr>
-            <td class="text-center" colspan="3">{{ text_no_results }}</td>
-          </tr>
-        {% endif %}
+      {% if extensions %}
+        {% for extension in extensions %}
+        <tr{% if not extension.installed %} class="text-decoration-uninstalled"{% elseif not extension.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
+		  <td>{{ extension.name }}</td>
+		  <td>{{ extension.status }}</td>
+		  <td class="text-end text-nowrap text-decoration-none">
+          {% if extension.installed %}
+            <a href="{{ extension.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not extension.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a>
+            <a href="{{ extension.uninstall }}" data-bs-toggle="tooltip" title="{{ button_uninstall }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></a>
+          {% else %}
+            <button type="button" class="btn btn-secondary" disabled="disabled"><i class="fa-solid fa-pencil"></i></button>
+            <a href="{{ extension.install }}" data-bs-toggle="tooltip" title="{{ button_install }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></a>
+          {% endif %}
+          </td>
+        </tr>
+        {% endfor %}
+      {% else %}
+        <tr>
+          <td class="text-center" colspan="3">{{ text_no_results }}</td>
+        </tr>
+      {% endif %}
       </tbody>
     </table>
   </div>

--- a/upload/admin/view/template/extension/module.twig
+++ b/upload/admin/view/template/extension/module.twig
@@ -13,17 +13,17 @@
       <tbody>
         {% if extensions %}
           {% for extension in extensions %}
-            <tr{% if not extension.module and not extension.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not extension.installed %} class="text-decoration-uninstalled"{% elseif not extension.module and not extension.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td><b>{{ extension.name }}</b></td>
-              <td class="text-end text-nowrap">
+              <td class="text-end text-nowrap text-decoration-none">
                 {% if extension.installed %}
                   {% if extension.module %}
                     <a href="{{ extension.edit }}" data-bs-toggle="tooltip" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus-circle"></i></a>
                   {% else %}
-                    <a href="{{ extension.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a>
+                    <a href="{{ extension.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not extension.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a>
                   {% endif %}
                 {% else %}
-                  <button type="button" class="btn btn-primary" disabled="disabled"><i class="fa-solid fa-pencil"></i></button>
+                  <button type="button" class="btn btn-secondary" disabled="disabled"><i class="fa-solid fa-pencil"></i></button>
                 {% endif %}
                 {% if not extension.installed %}
                   <a href="{{ extension.install }}" data-bs-toggle="tooltip" title="{{ button_install }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></a>
@@ -33,9 +33,9 @@
               </td>
             </tr>
             {% for module in extension.module %}
-              <tr{% if not module.status %} class="table-active opacity-50"{% endif %}>
+              <tr{% if not module.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled""{% endif %}>
                 <td>&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-folder-open"></i>&nbsp;&nbsp;&nbsp;{{ module.name }}</td>
-                <td class="text-end text-nowrap"><a href="{{ module.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-outline-primary"><i class="fa-solid fa-pencil"></i></a> <a href="{{ module.delete }}" data-bs-toggle="tooltip" title="{{ button_delete }}" class="btn btn-outline-danger"><i class="fa-regular fa-trash-can"></i></a></td>
+                <td class="text-end text-nowrap"><a href="{{ module.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not module.status %}btn btn-outline-secondary{% else %}btn btn-outline-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a> <a href="{{ module.delete }}" data-bs-toggle="tooltip" title="{{ button_delete }}" class="btn btn-outline-danger"><i class="fa-regular fa-trash-can"></i></a></td>
               </tr>
             {% endfor %}
           {% endfor %}

--- a/upload/admin/view/template/extension/other.twig
+++ b/upload/admin/view/template/extension/other.twig
@@ -12,18 +12,17 @@
       <tbody>
         {% if extensions %}
           {% for extension in extensions %}
-            <tr{% if not extension.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not extension.installed %} class="text-decoration-uninstalled"{% elseif not extension.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td>{{ extension.name }}</td>
-              <td class="text-end text-nowrap">{% if extension.installed %}
-                <a href="{{ extension.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a>
-              {% else %}
-                <button type="button" class="btn btn-primary" disabled="disabled"><i class="fa-solid fa-pencil"></i></button>
-              {% endif %}
-              {% if not extension.installed %}
-                <a href="{{ extension.install }}" data-bs-toggle="tooltip" title="{{ button_install }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></a>
-              {% else %}
+              <td class="text-end text-nowrap text-decoration-none">
+              {% if extension.installed %}
+                <a href="{{ extension.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not extension.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a>
                 <a href="{{ extension.uninstall }}" data-bs-toggle="tooltip" title="{{ button_uninstall }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></a>
-              {% endif %}</td>
+              {% else %}
+                <button type="button" class="btn btn-secondary" disabled="disabled"><i class="fa-solid fa-pencil"></i></button>
+                <a href="{{ extension.install }}" data-bs-toggle="tooltip" title="{{ button_install }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></a>
+              {% endif %}
+              </td>
             </tr>
           {% endfor %}
         {% else %}

--- a/upload/admin/view/template/extension/payment.twig
+++ b/upload/admin/view/template/extension/payment.twig
@@ -14,20 +14,19 @@
       <tbody>
         {% if extensions %}
           {% for extension in extensions %}
-            <tr{% if not extension.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not extension.installed %} class="text-decoration-uninstalled"{% elseif not extension.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td>{{ extension.name }}</td>
               <td class="text-center">{{ extension.link }}</td>
               <td class="text-end">{{ extension.sort_order }}</td>
-              <td class="text-end text-nowrap">{% if extension.installed %}
-                <a href="{{ extension.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a>
-              {% else %}
-                <button type="button" class="btn btn-primary" disabled="disabled"><i class="fa-solid fa-pencil"></i></button>
-              {% endif %}
-              {% if not extension.installed %}
-                <a href="{{ extension.install }}" data-bs-toggle="tooltip" title="{{ button_install }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></a>
-              {% else %}
+              <td class="text-end text-nowrap text-decoration-none">
+              {% if extension.installed %}
+                <a href="{{ extension.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not extension.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a>
                 <a href="{{ extension.uninstall }}" data-bs-toggle="tooltip" title="{{ button_uninstall }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></a>
-              {% endif %}</td>
+              {% else %}
+                <button type="button" class="btn btn-secondary" disabled="disabled"><i class="fa-solid fa-pencil"></i></button>
+                <a href="{{ extension.install }}" data-bs-toggle="tooltip" title="{{ button_install }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></a>
+              {% endif %}
+              </td>
             </tr>
           {% endfor %}
         {% else %}

--- a/upload/admin/view/template/extension/report.twig
+++ b/upload/admin/view/template/extension/report.twig
@@ -13,19 +13,18 @@
       <tbody>
         {% if extensions %}
           {% for extension in extensions %}
-            <tr{% if not extension.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not extension.installed %} class="text-decoration-uninstalled"{% elseif not extension.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td>{{ extension.name }}</td>
               <td class="text-end">{{ extension.sort_order }}</td>
-              <td class="text-end text-nowrap">{% if extension.installed %}
-                <a href="{{ extension.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a>
-              {% else %}
-                <button type="button" class="btn btn-primary" disabled="disabled"><i class="fa-solid fa-pencil"></i></button>
-              {% endif %}
-              {% if not extension.installed %}
-                <a href="{{ extension.install }}" data-bs-toggle="tooltip" title="{{ button_install }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></a>
-              {% else %}
+              <td class="text-end text-nowrap text-decoration-none">
+              {% if extension.installed %}
+                <a href="{{ extension.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not extension.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a>
                 <a href="{{ extension.uninstall }}" data-bs-toggle="tooltip" title="{{ button_uninstall }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></a>
-              {% endif %}</td>
+              {% else %}
+                <button type="button" class="btn btn-secondary" disabled="disabled"><i class="fa-solid fa-pencil"></i></button>
+                <a href="{{ extension.install }}" data-bs-toggle="tooltip" title="{{ button_install }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></a>
+              {% endif %}
+              </td>
             </tr>
           {% endfor %}
         {% else %}

--- a/upload/admin/view/template/extension/shipping.twig
+++ b/upload/admin/view/template/extension/shipping.twig
@@ -7,30 +7,31 @@
         <tr>
           <th>{{ column_name }}</th>
           <th class="text-end">{{ column_sort_order }}</th>
+          <th class="text-start">{{ column_code }}</th>
           <th class="text-end">{{ column_action }}</th>
         </tr>
       </thead>
       <tbody>
         {% if extensions %}
           {% for extension in extensions %}
-            <tr{% if not extension.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not extension.installed %} class="text-decoration-uninstalled"{% elseif not extension.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td>{{ extension.name }}</td>
               <td class="text-end">{{ extension.sort_order }}</td>
-              <td class="text-end text-nowrap">{% if extension.installed %}
-                <a href="{{ extension.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a>
-              {% else %}
-                <button type="button" class="btn btn-primary" disabled="disabled"><i class="fa-solid fa-pencil"></i></button>
-              {% endif %}
-              {% if not extension.installed %}
-                <a href="{{ extension.install }}" data-bs-toggle="tooltip" title="{{ button_install }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></a>
-              {% else %}
+              <td>{{ extension.code }}{% if extension.code == code %} <strong>({{ text_default }})</strong>{% endif %}</td>
+              <td class="text-end text-nowrap text-decoration-none">
+              {% if extension.installed %}
+                <a href="{{ extension.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not extension.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a>
                 <a href="{{ extension.uninstall }}" data-bs-toggle="tooltip" title="{{ button_uninstall }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></a>
-              {% endif %}</td>
+              {% else %}
+                <button type="button" class="btn btn-secondary" disabled="disabled"><i class="fa-solid fa-pencil"></i></button>
+                <a href="{{ extension.install }}" data-bs-toggle="tooltip" title="{{ button_install }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></a>
+              {% endif %}
+              </td>
             </tr>
           {% endfor %}
         {% else %}
           <tr>
-            <td class="text-center" colspan="3">{{ text_no_results }}</td>
+            <td class="text-center" colspan="4">{{ text_no_results }}</td>
           </tr>
         {% endif %}
       </tbody>

--- a/upload/admin/view/template/extension/theme.twig
+++ b/upload/admin/view/template/extension/theme.twig
@@ -14,17 +14,19 @@
           {% for extension in extensions %}
             <tr>
               <td><b>{{ extension.name }}</b></td>
-              <td class="text-end">{% if not extension.installed %}
+              <td class="text-end text-decoration-none">
+              {% if not extension.installed %}
                 <a href="{{ extension.install }}" data-bs-toggle="tooltip" title="{{ button_install }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></a>
               {% else %}
                 <a href="{{ extension.uninstall }}" data-bs-toggle="tooltip" title="{{ button_uninstall }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></a>
-              {% endif %}</td>
+              {% endif %}
+              </td>
             </tr>
             {% if extension.installed %}
               {% for store in extension.store %}
-                <tr{% if not store.status %} class="table-active opacity-50"{% endif %}>
+                <tr{% if not store.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
                   <td>&nbsp;&nbsp;&nbsp;-&nbsp;&nbsp;&nbsp;{{ store.name }}</td>
-                  <td class="text-end text-nowrap"><a href="{{ store.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a></td>
+                  <td class="text-end text-nowrap text-decoration-none"><a href="{{ store.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not store.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a></td>
                 </tr>
               {% endfor %}
             {% endif %}

--- a/upload/admin/view/template/extension/total.twig
+++ b/upload/admin/view/template/extension/total.twig
@@ -13,19 +13,18 @@
       <tbody>
         {% if extensions %}
           {% for extension in extensions %}
-            <tr{% if not extension.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not extension.installed %} class="text-decoration-uninstalled"{% elseif not extension.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td>{{ extension.name }}</td>
               <td class="text-end">{{ extension.sort_order }}</td>
-              <td class="text-end text-nowrap">{% if extension.installed %}
-                  <a href="{{ extension.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a>
-                {% else %}
-                  <button type="button" class="btn btn-primary" disabled="disabled"><i class="fa-solid fa-pencil"></i></button>
-                {% endif %}
-                {% if not extension.installed %}
-                  <a href="{{ extension.install }}" data-bs-toggle="tooltip" title="{{ button_install }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></a>
-                {% else %}
-                  <a href="{{ extension.uninstall }}" data-bs-toggle="tooltip" title="{{ button_uninstall }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></a>
-                {% endif %}</td>
+              <td class="text-end text-nowrap text-decoration-none">
+              {% if extension.installed %}
+                <a href="{{ extension.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not extension.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a>
+                <a href="{{ extension.uninstall }}" data-bs-toggle="tooltip" title="{{ button_uninstall }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></a>
+              {% else %}
+                <button type="button" class="btn btn-secondary" disabled="disabled"><i class="fa-solid fa-pencil"></i></button>
+                <a href="{{ extension.install }}" data-bs-toggle="tooltip" title="{{ button_install }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></a>
+              {% endif %}
+              </td>
             </tr>
           {% endfor %}
         {% else %}

--- a/upload/admin/view/template/localisation/country_list.twig
+++ b/upload/admin/view/template/localisation/country_list.twig
@@ -13,12 +13,12 @@
       <tbody>
         {% if countries %}
           {% for country in countries %}
-            <tr{% if not country.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not country.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td class="text-center"><input type="checkbox" name="selected[]" value="{{ country.country_id }}" class="form-check-input"/></td>
               <td>{{ country.name }}{% if country.country_id == country_id %} <strong>({{ text_default }})</strong>{% endif %}</td>
               <td>{{ country.iso_code_2 }}</td>
               <td>{{ country.iso_code_3 }}</td>
-              <td class="text-end"><a href="{{ country.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a></td>
+              <td class="text-end text-nowrap text-decoration-none"><a href="{{ country.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not country.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a></td>
             </tr>
           {% endfor %}
         {% else %}

--- a/upload/admin/view/template/localisation/currency_list.twig
+++ b/upload/admin/view/template/localisation/currency_list.twig
@@ -14,18 +14,18 @@
       <tbody>
         {% if currencies %}
           {% for currency in currencies %}
-            <tr{% if not currency.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not currency.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td class="text-center"><input type="checkbox" name="selected[]" value="{{ currency.currency_id }}" class="form-check-input"/></td>
               <td>{{ currency.title }}{% if currency.code == code %} <strong>({{ text_default }})</strong>{% endif %}</td>
               <td>{{ currency.code }}</td>
               <td class="text-end">{{ currency.value }}</td>
               <td class="d-none d-lg-table-cell">{{ currency.date_modified }}</td>
-              <td class="text-end"><a href="{{ currency.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a></td>
+              <td class="text-end text-nowrap text-decoration-none"><a href="{{ currency.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not currency.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a></td>
             </tr>
           {% endfor %}
         {% else %}
           <tr>
-            <td class="text-center" colspan="7">{{ text_no_results }}</td>
+            <td class="text-center" colspan="6">{{ text_no_results }}</td>
           </tr>
         {% endif %}
       </tbody>

--- a/upload/admin/view/template/localisation/language_list.twig
+++ b/upload/admin/view/template/localisation/language_list.twig
@@ -13,12 +13,12 @@
       <tbody>
         {% if languages %}
           {% for language in languages %}
-            <tr{% if not language.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not language.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td class="text-center"><input type="checkbox" name="selected[]" value="{{ language.language_id }}" class="form-check-input"/></td>
               <td>{{ language.name }}{% if language.code == code %} <strong>({{ text_default }})</strong>{% endif %}</td>
               <td>{{ language.code }}</td>
               <td class="text-end">{{ language.sort_order }}</td>
-              <td class="text-end"><a href="{{ language.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a></td>
+              <td class="text-end text-nowrap text-decoration-none"><a href="{{ language.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not language.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a></td>
             </tr>
           {% endfor %}
         {% else %}

--- a/upload/admin/view/template/localisation/zone_list.twig
+++ b/upload/admin/view/template/localisation/zone_list.twig
@@ -13,12 +13,12 @@
       <tbody>
         {% if zones %}
           {% for zone in zones %}
-            <tr{% if not zone.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not zone.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td class="text-center"><input type="checkbox" name="selected[]" value="{{ zone.zone_id }}" class="form-check-input"/></td>
               <td>{{ zone.country }}</td>
               <td>{{ zone.name }}{% if zone.zone_id == zone_id %} <strong>({{ text_default }})</strong>{% endif %}</td>
               <td>{{ zone.code }}</td>
-              <td class="text-end"><a href="{{ zone.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a></td>
+              <td class="text-end text-nowrap text-decoration-none"><a href="{{ zone.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not zone.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a></td>
             </tr>
           {% endfor %}
         {% else %}

--- a/upload/admin/view/template/marketing/affiliate_list.twig
+++ b/upload/admin/view/template/marketing/affiliate_list.twig
@@ -15,19 +15,19 @@
       <tbody>
         {% if affiliates %}
           {% for affiliate in affiliates %}
-            <tr{% if not affiliate.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not affiliate.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td class="text-center"><input type="checkbox" name="selected[]" value="{{ affiliate.customer_id }}" class="form-check-input"/></td>
               <td><a href="{{ affiliate.customer }}">{{ affiliate.name }}</a></td>
               <td class="d-none d-lg-table-cell">{{ affiliate.tracking }}</td>
               <td class="text-end">{{ affiliate.commission }}</td>
               <td class="text-end d-none d-lg-table-cell">{{ affiliate.balance }}</td>
               <td class="d-none d-lg-table-cell">{{ affiliate.date_added }}</td>
-              <td class="text-end"><a href="{{ affiliate.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a></td>
+              <td class="text-end text-nowrap text-decoration-none"><a href="{{ affiliate.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not affiliate.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a></td>
             </tr>
           {% endfor %}
         {% else %}
           <tr>
-            <td class="text-center" colspan="8">{{ text_no_results }}</td>
+            <td class="text-center" colspan="7">{{ text_no_results }}</td>
           </tr>
         {% endif %}
       </tbody>

--- a/upload/admin/view/template/marketing/coupon_list.twig
+++ b/upload/admin/view/template/marketing/coupon_list.twig
@@ -15,19 +15,19 @@
       <tbody>
         {% if coupons %}
           {% for coupon in coupons %}
-            <tr{% if not coupon.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not coupon.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td class="text-center"><input type="checkbox" name="selected[]" value="{{ coupon.coupon_id }}" class="form-check-input"/></td>
               <td>{{ coupon.name }}</td>
               <td>{{ coupon.code }}</td>
               <td class="text-end">{{ coupon.discount }}</td>
               <td class="d-none d-lg-table-cell">{{ coupon.date_start }}</td>
               <td class="d-none d-lg-table-cell">{{ coupon.date_end }}</td>
-              <td class="text-end"><a href="{{ coupon.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a></td>
+              <td class="text-end text-nowrap text-decoration-none"><a href="{{ coupon.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not coupon.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a></td>
             </tr>
           {% endfor %}
         {% else %}
           <tr>
-            <td class="text-center" colspan="8">{{ text_no_results }}</td>
+            <td class="text-center" colspan="7">{{ text_no_results }}</td>
           </tr>
         {% endif %}
       </tbody>

--- a/upload/admin/view/template/marketplace/cron_list.twig
+++ b/upload/admin/view/template/marketplace/cron_list.twig
@@ -6,7 +6,7 @@
           <th class="text-center" style="width: 1px;"><input type="checkbox" onclick="$('input[name*=\'selected\']').prop('checked', $(this).prop('checked'));" class="form-check-input"/></th>
           <th>{{ column_code }}</th>
           <th>{{ column_cycle }}</th>
-          <th>{{ column_action }}</th>
+          <th>{{ column_cron_action }}</th>
           <th class="d-none d-lg-table-cell">{{ column_date_added }}</th>
           <th class="d-none d-lg-table-cell">{{ column_date_modified }}</th>
           <th class="text-end">{{ column_action }}</th>
@@ -15,14 +15,14 @@
       <tbody>
         {% if crons %}
           {% for cron in crons %}
-            <tr{% if not cron.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not cron.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td class="text-center"><input type="checkbox" name="selected[]" value="{{ cron.cron_id }}" class="form-check-input"/></td>
               <td>{{ cron.code }}</td>
               <td>{{ cron.cycle }}</td>
               <td>{{ cron.action }}</td>
               <td class="d-none d-lg-table-cell">{{ cron.date_added }}</td>
               <td class="d-none d-lg-table-cell">{{ cron.date_modified }}</td>
-              <td class="text-end text-nowrap">
+              <td class="text-end text-nowrap text-decoration-none">
                 {% if cron.description %}
                   <button type="button" data-bs-toggle="modal" data-bs-target="#modal-cron-{{ cron.cron_id }}" class="btn btn-info"><i class="fa-solid fa-info-circle"></i></button>
                 {% else %}

--- a/upload/admin/view/template/marketplace/event_list.twig
+++ b/upload/admin/view/template/marketplace/event_list.twig
@@ -12,11 +12,11 @@
       <tbody>
         {% if events %}
           {% for event in events %}
-            <tr{% if not event.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not event.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td class="text-center"><input type="checkbox" name="selected[]" value="{{ event.event_id }}" class="form-check-input"/></td>
               <td>{{ event.code }}</td>
               <td class="text-end d-none d-lg-table-cell">{{ event.sort_order }}</td>
-              <td class="text-end text-nowrap">
+              <td class="text-end text-nowrap text-decoration-none">
                 <button type="button" data-bs-toggle="modal" data-bs-target="#modal-event-{{ event.event_id }}" class="btn btn-info"><i class="fa-solid fa-info-circle"></i></button>
               {% if not event.status %}
                 <button type="button" value="{{ event.enable }}" data-bs-toggle="tooltip" title="{{ button_enable }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></button>

--- a/upload/admin/view/template/marketplace/installer_extension.twig
+++ b/upload/admin/view/template/marketplace/installer_extension.twig
@@ -11,7 +11,7 @@
     <tbody>
       {% if extensions %}
         {% for extension in extensions %}
-          <tr{% if not extension.status %} class="table-active opacity-50"{% endif %}>
+          <tr{% if not extension.status %} class="text-decoration-uninstalled"{% else %} class="text-decoration-enabled"{% endif %}>
             <td>
               {% if extension.link %}
                 <a href="{{ extension.link }}" target="_blank">{{ extension.name }}</a>
@@ -20,7 +20,7 @@
               {% endif %}</td>
             <td class="align-text-top">{{ extension.version }}</td>
             <td class="align-text-top">{{ extension.date_added }}</td>
-            <td class="text-end align-text-top text-nowrap">
+            <td class="text-end align-text-top text-nowrap text-decoration-none">
               <button type="button" data-bs-toggle="modal" data-bs-target="#extension-install-{{ extension.extension_install_id }}" class="btn btn-info"><i class="fa-solid fa-info-circle"></i></button>
               {% if not extension.status %}
                 <a href="{{ extension.install }}" data-bs-toggle="tooltip" title="{{ button_install }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></a>

--- a/upload/admin/view/template/marketplace/modification_list.twig
+++ b/upload/admin/view/template/marketplace/modification_list.twig
@@ -14,13 +14,13 @@
       <tbody>
         {% if modifications %}
           {% for modification in modifications %}
-            <tr{% if not modification.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not modification.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td class="text-center"><input type="checkbox" name="selected[]" value="{{ modification.modification_id }}" class="form-check-input"/></td>
               <td>{{ modification.name }}</td>
               <td>{{ modification.author }}</td>
               <td>{{ modification.version }}</td>
               <td>{{ modification.date_added }}</td>
-              <td class="text-end text-nowrap">
+              <td class="text-end text-nowrap text-decoration-none">
                 <button type="button" data-bs-toggle="modal" data-bs-target="#modal-modification-{{ modification.modification_id }}" class="btn btn-info"><i class="fa-solid fa-info-circle"></i></button>
                 {% if not modification.status %}
                   <button type="button" value="{{ modification.enable }}" data-bs-toggle="tooltip" title="{{ button_enable }}" class="btn btn-success"><i class="fa-solid fa-plus-circle"></i></button>

--- a/upload/admin/view/template/marketplace/ssr_list.twig
+++ b/upload/admin/view/template/marketplace/ssr_list.twig
@@ -5,7 +5,7 @@
         <tr>
           <th class="text-center" style="width: 1px;"><input type="checkbox" onclick="$('input[name*=\'selected\']').prop('checked', $(this).prop('checked'));" class="form-check-input"/></th>
           <th>{{ column_code }}</th>
-          <th>{{ column_action }}</th>
+          <th>{{ column_ssr_action }}</th>
           <th class="text-end d-none d-lg-table-cell">{{ column_sort_order }}</th>
           <th class="d-none d-lg-table-cell">{{ column_date_modified }}</th>
           <th class="text-end" style="width: 1px;">{{ column_action }}</th>
@@ -14,13 +14,13 @@
       <tbody>
         {% if ssrs %}
           {% for ssr in ssrs %}
-            <tr{% if not ssr.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not ssr.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td class="text-center"><input type="checkbox" name="selected[]" value="{{ ssr.ssr_id }}" class="form-check-input"/></td>
               <td>{{ ssr.code }}</td>
               <td>{{ ssr.action }}</td>
               <td class="text-end d-none d-lg-table-cell">{{ ssr.sort_order }}</td>
               <td class="d-none d-lg-table-cell">{{ ssr.date_modified }}</td>
-              <td class="text-end text-nowrap">{% if ssr.description %}
+              <td class="text-end text-nowrap text-decoration-none">{% if ssr.description %}
                   <button type="button" data-bs-toggle="modal" data-bs-target="#modal-ssr-{{ ssr.ssr_id }}" class="btn btn-info"><i class="fa-solid fa-info-circle"></i></button>
                 {% else %}
                   <button type="button" class="btn btn-info" disabled><i class="fa-solid fa-info-circle"></i></button>
@@ -37,7 +37,7 @@
           {% endfor %}
         {% else %}
           <tr>
-            <td class="text-center" colspan="7">{{ text_no_results }}</td>
+            <td class="text-center" colspan="6">{{ text_no_results }}</td>
           </tr>
         {% endif %}
       </tbody>

--- a/upload/admin/view/template/marketplace/startup_list.twig
+++ b/upload/admin/view/template/marketplace/startup_list.twig
@@ -13,12 +13,12 @@
       <tbody>
         {% if startups %}
           {% for startup in startups %}
-            <tr{% if not startup.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not startup.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td class="text-center"><input type="checkbox" name="selected[]" value="{{ startup.startup_id }}" class="form-check-input"/></td>
               <td>{{ startup.code }}</td>
               <td>{{ startup.action }}</td>
               <td class="text-end">{{ startup.sort_order }}</td>
-              <td class="text-end text-nowrap">{% if startup.description %}
+              <td class="text-end text-nowrap text-decoration-none">{% if startup.description %}
                 <button type="button" data-bs-toggle="modal" data-bs-target="#modal-startup-{{ startup.startup_id }}" class="btn btn-info"><i class="fa-solid fa-info-circle"></i></button>
               {% else %}
                 <button type="button" class="btn btn-info" disabled><i class="fa-solid fa-info-circle"></i></button>

--- a/upload/admin/view/template/tool/notification_list.twig
+++ b/upload/admin/view/template/tool/notification_list.twig
@@ -13,7 +13,7 @@
         {% if notifications %}
           {% set notification_row = 0 %}
           {% for notification in notifications %}
-            <tr id="notification-row-{{ notification_row }}"{% if not notification.status %} class="table-active opacity-50"{% endif %}>
+            <tr id="notification-row-{{ notification_row }}"{% if not notification.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td class="text-center"><input type="checkbox" name="selected[]" value="{{ notification.notification_id }}" class="form-check-input"/></td>
               <td class="text-primary" style="width: 1px;"><i class="fa-regular fa-bell fa-3x"></i></td>
               <td><a href="{{ notification.view }}" class="text-primary{% if not notification.status %} font-weight-bold{% endif %}">{{ notification.title }}</a>
@@ -25,7 +25,7 @@
           {% endfor %}
         {% else %}
           <tr>
-            <td class="text-center" colspan="3">{{ text_no_results }}</td>
+            <td class="text-center" colspan="4">{{ text_no_results }}</td>
           </tr>
         {% endif %}
       </tbody>

--- a/upload/admin/view/template/user/api_list.twig
+++ b/upload/admin/view/template/user/api_list.twig
@@ -13,12 +13,12 @@
       <tbody>
         {% if apis %}
           {% for api in apis %}
-            <tr{% if not api.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not api.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td class="text-center"><input type="checkbox" name="selected[]" value="{{ api.api_id }}" class="form-check-input"/></td>
               <td>{{ api.username }}</td>
               <td>{{ api.date_added }}</td>
               <td>{{ api.date_modified }}</td>
-              <td class="text-end"><a href="{{ api.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a></td>
+              <td class="text-end text-nowrap text-decoration-none"><a href="{{ api.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not api.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a></td>
             </tr>
           {% endfor %}
         {% else %}

--- a/upload/admin/view/template/user/user_list.twig
+++ b/upload/admin/view/template/user/user_list.twig
@@ -15,19 +15,19 @@
       <tbody>
         {% if users %}
           {% for user in users %}
-            <tr{% if not user.status %} class="table-active opacity-50"{% endif %}>
+            <tr{% if not user.status %} class="text-decoration-disabled"{% else %} class="text-decoration-enabled"{% endif %}>
               <td class="text-center"><input type="checkbox" name="selected[]" value="{{ user.user_id }}" class="form-check-input"/></td>
               <td>{{ user.username }}</td>
               <td>{{ user.name }}</td>
               <td>{{ user.email }}</td>
               <td>{{ user.user_group }}</td>
               <td class="d-none d-lg-table-cell">{{ user.date_added }}</td>
-              <td class="text-end"><a href="{{ user.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></a></td>
+              <td class="text-end text-nowrap text-decoration-none"><a href="{{ user.edit }}" data-bs-toggle="tooltip" title="{{ button_edit }}" class="{% if not user.status %}btn btn-secondary{% else %}btn btn-primary{% endif %}"><i class="fa-solid fa-pencil"></i></a></td>
             </tr>
           {% endfor %}
         {% else %}
           <tr>
-            <td class="text-center" colspan="5">{{ text_no_results }}</td>
+            <td class="text-center" colspan="7">{{ text_no_results }}</td>
           </tr>
         {% endif %}
       </tbody>


### PR DESCRIPTION
- Added: CSS styles to indicate: 'enabled', 'disabled' and 'uninstalled' item statuses.
- Changed: Update .twig files throughout Admin Dashboard to use the new CSS styles.
- Replaced all occurances of class="table-active opacity-50" with new CSS styles.
- Only templates which list items that can be installed/uninstalled or enabled/disabled have been modified.

- Fixed: Ambigous use of 'column_action' in: cron_list.twig and ssr_list.twig. Added 'column_ssr_action' and 'column_cron_action' to appropriate language files.
- Fixed: Missing 'column_code' in 'shipping' extension. Language and controller.
- Fixed: Column 'span' count in several templates when there are no items to display.
- Fixed: 'customer_approval.twig' - Top button icons mismatched with list button icons.

<img width="1402" alt="Screenshot 2025-05-15 at 3 52 38 AM" src="https://github.com/user-attachments/assets/8add0d50-fb21-45a4-a148-4e14575a609d" />
