### PR TITLE
Update error.php

### DIFF
--- a/upload/catalog/controller/startup/error.php
+++ b/upload/catalog/controller/startup/error.php
@@ -74,31 +74,50 @@ class Error extends \Opencart\System\Engine\Controller {
 	 * @return void
 	 */
 	public function exception(\Throwable $e): void {
-		$output  = 'Error: ' . $e->getMessage() . "\n";
-		$output .= 'File: ' . $e->getFile() . "\n";
-		$output .= 'Line: ' . $e->getLine() . "\n\n";
+    // Construct the initial error message with basic exception details
+    $output  = 'Error: ' . $e->getMessage() . "\n";
+    $output .= 'File: ' . $e->getFile() . "\n";
+    $output .= 'Line: ' . $e->getLine() . "\n\n";
 
-		foreach ($e->getTrace() as $key => $trace) {
-			$output .= 'Backtrace: ' . $key . "\n";
-			$output .= 'File: ' . $trace['file'] . "\n";
-			$output .= 'Line: ' . $trace['line'] . "\n";
+    // Iterate over the stack trace for detailed debugging info
+    foreach ($e->getTrace() as $key => $trace) {
+        $output .= 'Backtrace: ' . $key . "\n";
 
-			if (isset($trace['class'])) {
-				$output .= 'Class: ' . $trace['class'] . "\n";
-			}
+        // Safely add file info if available
+        if (isset($trace['file'])) {
+            $output .= 'File: ' . $trace['file'] . "\n";
+        }
 
-			$output .= 'Function: ' . $trace['function'] . "\n\n";
-		}
+        // Safely add line info if available
+        if (isset($trace['line'])) {
+            $output .= 'Line: ' . $trace['line'] . "\n";
+        }
 
-		if ($this->config->get('config_error_log')) {
-			$this->log->write(trim($output));
-		}
+        // Add class name if available (e.g., for object-oriented traces)
+        if (isset($trace['class'])) {
+            $output .= 'Class: ' . $trace['class'] . "\n";
+        }
 
-		if ($this->config->get('config_error_display')) {
-			echo $output;
-		} else {
-			header('Location: ' . $this->config->get('error_page'));
-			exit();
-		}
-	}
+        // Add the function name (almost always present, but still checked for safety)
+        if (isset($trace['function'])) {
+            $output .= 'Function: ' . $trace['function'] . "\n";
+        }
+
+        $output .= "\n"; // Add spacing between trace entries
+    }
+
+    // Log the error if logging is enabled in configuration
+    if ($this->config->get('config_error_log')) {
+        $this->log->write(trim($output));
+    }
+
+    // Display the error if error display is enabled; otherwise, redirect to the error page
+    if ($this->config->get('config_error_display')) {
+        echo $output;
+    } else {
+        header('Location: ' . $this->config->get('error_page'));
+        exit();
+    }
+}
+
 }


### PR DESCRIPTION
-Added checks for isset($trace['file']) before accessing the file
-Added checks for isset($trace['line']) before accessing the line
-Added checks for isset($trace['function']) before accessing the function
-Moved the newline character (\n\n) outside the conditional blocks to maintain consistent formatting

This makes the error handler more robust by handling cases where these trace elements might not be present in the backtrace, which can happen in certain PHP execution contexts or with certain types of errors.