### PR TITLE
Fix operation of docker-compose file/cli-install with recent class modifications.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 /upload/config.php
 /upload/admin/config.php
 
+# Install Files
+/upload/install.lock
+
 # Catalog JSON Files
 /upload/catalog/view/data/*
 !/upload/catalog/view/data/index.html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   opencart:
     build: tools

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
                apache2-foreground"
 
   mysql:
-    image: mysql:5.7
+    image: mariadb
     ports:
       - "3306:3306"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,8 @@ services:
     command: >
       bash -c "if [ ! -f /var/www/html/install.lock ]; then
                  wait-for-it mysql:3306 -t 60 &&
-                 cp config-dist.php config.php
-                 cp admin/config-dist.php admin/config.php
+                 cp config-dist.php config.php;
+                 cp admin/config-dist.php admin/config.php;
                  php /var/www/html/install/cli_install.php install --username admin --password admin --email email@example.com --http_server http://localhost/ --db_driver mysqli --db_hostname mysql --db_username root --db_password opencart --db_database opencart --db_port 3306 --db_prefix oc_;
                  touch /var/www/html/install.lock;
                fi &&

--- a/upload/install/cli_install.php
+++ b/upload/install/cli_install.php
@@ -291,8 +291,19 @@ class CliInstall extends \Opencart\System\Engine\Controller {
 
 		try {
 			// Database
-			$db = new \Opencart\System\Library\DB($db_driver, $db_hostname, $db_username, $db_password, $db_database, $db_port, $db_ssl_key, $db_ssl_cert, $db_ssl_ca);
+			$db = new \Opencart\System\Library\DB([
+				'engine' => $db_driver,
+				'hostname' => $db_hostname,
+				'username' => $db_username,
+				'password' => $db_password,
+				'database' => $db_database,
+				'port' => $db_port,
+				'ssl_key' => $db_ssl_key,
+				'ssl_cert' => $db_ssl_cert,
+				'ssl_ca' => $db_ssl_ca
+			]);
 		} catch (\Exception $e) {
+			echo $e->getMessage();
 			return 'Error: Could not make a database link using ' . $db_username . '@' . $db_hostname . '!' . "\n";
 		}
 

--- a/upload/system/library/db/mysqli.php
+++ b/upload/system/library/db/mysqli.php
@@ -78,7 +78,12 @@ class MySQLi {
 
 		$this->db = new \mysqli();
 
-		$this->db->report_mode = MYSQLI_REPORT_STRICT | MYSQLI_REPORT_ERROR;
+		// Check PHP version to use appropriate method
+		if (version_compare(PHP_VERSION, '8.1.0', '>=')) {
+			mysqli_report(MYSQLI_REPORT_STRICT | MYSQLI_REPORT_ERROR);
+		} else {
+			$this->db->report_mode = MYSQLI_REPORT_STRICT | MYSQLI_REPORT_ERROR;
+		}
 
 		if ($temp_ssl_key_file || $temp_ssl_cert_file || $temp_ssl_ca_file) {
 			$this->db->ssl_set($temp_ssl_key_file, $temp_ssl_cert_file, $temp_ssl_ca_file, null, null);


### PR DESCRIPTION
Changes:

1. Fixes basic operation of docker-compose by ensuring commands are closed properly.
2. Updates initialization to match new constructors
3. Removes 'version' option from `docker-compose.yaml`
4. Ignores `install.lock` file
5. Adds support for latest MySQLi engine version - as well as support for development on `arm64` boxes by using `mariadb` image

If any of these changes should be modified in any way, let me know - happy to adjust.