### PR TITLE
mysqli::$report_mode is deprecated

### DIFF
--- a/upload/catalog/controller/startup/language.php
+++ b/upload/catalog/controller/startup/language.php
@@ -25,21 +25,15 @@ class Language extends \Opencart\System\Engine\Controller {
 
 		$language_info = [];
 
-		if (isset(self::$languages[$this->config->get('config_language_catalog')])) {
-			$language_info = self::$languages[$this->config->get('config_language_catalog')];
-		}
-
 		// Set default language
-		if (!isset($this->request->get['language']) && !isset($this->request->get['language'])) {
+		if (isset(self::$languages[$this->config->get('config_language_catalog')])) {
 			$language_info = self::$languages[$this->config->get('config_language_catalog')];
 		}
 
 		// If GET has language var
 		if (isset($this->request->get['language']) && isset(self::$languages[$this->request->get['language']])) {
 			$language_info = self::$languages[$this->request->get['language']];
-		} else {
-			$this->request->get['route'] = 'error/not_found';
-		}
+		} 
 
 		if ($language_info) {
 			// If extension switch add language directory
@@ -52,6 +46,8 @@ class Language extends \Opencart\System\Engine\Controller {
 			$this->config->set('config_language', $language_info['code']);
 
 			$this->load->language('default');
+		} else {
+			$this->request->get['route'] = 'error/not_found';
 		}
 
 		return null;

--- a/upload/system/library/db/mysqli.php
+++ b/upload/system/library/db/mysqli.php
@@ -78,7 +78,7 @@ class MySQLi {
 
 		$this->db = new \mysqli();
 
-		$this->db->report_mode = MYSQLI_REPORT_STRICT | MYSQLI_REPORT_ERROR;
+		mysqli_report(flags: MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 
 		if ($temp_ssl_key_file || $temp_ssl_cert_file || $temp_ssl_ca_file) {
 			$this->db->ssl_set($temp_ssl_key_file, $temp_ssl_cert_file, $temp_ssl_ca_file, null, null);


### PR DESCRIPTION
1- Error: Creation of dynamic property mysqli::$report_mode is deprecated
Fixed by replacing it with the new function.

2- Fixed a bug where having no language param in address bar would redirect to error/not_found.

