### PR TITLE
Add OPTIMIZE TABLE to db.php

### DIFF
--- a/upload/system/library/session/db.php
+++ b/upload/system/library/session/db.php
@@ -87,6 +87,7 @@ class DB {
 	public function gc(): bool {
 		if (round(mt_rand(1, $this->config->get('session_divisor') / $this->config->get('session_probability'))) == 1) {
 			$this->db->query("DELETE FROM `" . DB_PREFIX . "session` WHERE `expire` < '" . $this->db->escape(gmdate('Y-m-d H:i:s', time())) . "'");
+			$this->db->query("OPTIMIZE TABLE `" . DB_PREFIX . "session`");
 		}
 
 		return true;


### PR DESCRIPTION
With standard MySQL operation, InnoDB does not free up disk space when deleting records. In fact, it is marked "Deleted", but there is no actual deletion. To free up space, you need to perform:
OPTIMIZE TABLE foo;

This will recreate the table and free up space.

https://dev.mysql.com/doc/refman/8.4/en/optimize-table.html#optimize-table-innodb-details

Adding optimization will help save space on the server over a long period of time and speed up work so that the table does not grow infinitely in size.