### PR TITLE
fix(cli): ensure DB SSL constants are always defined

### DIFF
--- a/upload/install/cli_install.php
+++ b/upload/install/cli_install.php
@@ -435,16 +435,22 @@ class CliInstall extends \Opencart\System\Engine\Controller {
 		$output .= 'define(\'DB_PREFIX\', \'' . addslashes($option['db_prefix']) . '\');' . "\n";
 		$output .= 'define(\'DB_PORT\', \'' . addslashes($option['db_port']) . '\');' . "\n";
 
-		if ($option['db_ssl_key']) {
+		if (!empty($option['db_ssl_key'])) {
 			$output .= 'define(\'DB_SSL_KEY\', \'' . addslashes($option['db_ssl_key']) . '\');' . "\n";
+		} else {
+			$output .= 'define(\'DB_SSL_KEY\', \'\');' . "\n";
 		}
 
-		if ($option['db_ssl_cert']) {
+		if (!empty($option['db_ssl_cert'])) {
 			$output .= 'define(\'DB_SSL_CERT\', \'' . addslashes($option['db_ssl_cert']) . '\');' . "\n";
+		} else {
+			$output .= 'define(\'DB_SSL_CERT\', \'\');' . "\n";
 		}
 
-		if ($option['db_ssl_ca']) {
+		if (!empty($option['db_ssl_ca'])) {
 			$output .= 'define(\'DB_SSL_CA\', \'' . addslashes($option['db_ssl_ca']) . '\');' . "\n";
+		} else {
+			$output .= 'define(\'DB_SSL_CA\', \'\');' . "\n";
 		}
 
 		$file = fopen(DIR_OPENCART . 'config.php', 'w');
@@ -488,16 +494,22 @@ class CliInstall extends \Opencart\System\Engine\Controller {
 		$output .= 'define(\'DB_PREFIX\', \'' . addslashes($option['db_prefix']) . '\');' . "\n";
 		$output .= 'define(\'DB_PORT\', \'' . addslashes($option['db_port']) . '\');' . "\n\n";
 
-		if ($option['db_ssl_key']) {
+		if (!empty($option['db_ssl_key'])) {
 			$output .= 'define(\'DB_SSL_KEY\', \'' . addslashes($option['db_ssl_key']) . '\');' . "\n";
+		} else {
+			$output .= 'define(\'DB_SSL_KEY\', \'\');' . "\n";
 		}
 
-		if ($option['db_ssl_cert']) {
+		if (!empty($option['db_ssl_cert'])) {
 			$output .= 'define(\'DB_SSL_CERT\', \'' . addslashes($option['db_ssl_cert']) . '\');' . "\n";
+		} else {
+			$output .= 'define(\'DB_SSL_CERT\', \'\');' . "\n";
 		}
 
-		if ($option['db_ssl_ca']) {
+		if (!empty($option['db_ssl_ca'])) {
 			$output .= 'define(\'DB_SSL_CA\', \'' . addslashes($option['db_ssl_ca']) . '\');' . "\n";
+		} else {
+			$output .= 'define(\'DB_SSL_CA\', \'\');' . "\n";
 		}
 
 		$output .= '// OpenCart API' . "\n";


### PR DESCRIPTION
This PR fixes a fatal error that occurs after installing OpenCart using the command-line interface (`cli_install.php`).

### The Problem

When using the CLI installer without providing database SSL options, the constants DB_SSL_KEY, DB_SSL_CERT, and DB_SSL_CA are not defined in the generated config.php file.

This leads to a fatal error on the frontend and backend immediately after installation:

```
Fatal error: Uncaught Error: Undefined constant "DB_SSL_KEY" in /var/www/html/system/config/catalog.php on line 14
```

The web-based installer correctly handles this by defining these constants as empty strings if they are not provided, but the CLI installer was missing this logic.

### The Solution

This commit aligns the behavior of the CLI installer with the web installer. It adds the necessary `else` blocks to ensure that the database SSL constants are always defined, even if they are empty. This prevents the fatal error and allows for a successful installation via the command line.