### PR TITLE
feat(docker): add compose profiles for optional services and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,30 @@ services:
         - PHP_VERSION=8.2 # Change this value
 ```
 
+### Using Docker Compose Profiles for Optional Services
+
+By default, only the core services (`opencart`, `mysql`) are started.
+Optional services such as **Adminer**, **Redis**, **Memcached**, and **PostgreSQL** can be enabled using [Docker Compose profiles](https://docs.docker.com/compose/profiles/).
+
+To enable one or more optional services, use the `--profile` flag:
+
+- **Start with Adminer:**
+    ```bash
+    docker-compose --profile adminer up -d
+    ```
+- **Start with Redis and Memcached:**
+    ```bash
+    docker-compose --profile redis --profile memcached up -d
+    ```
+- **Start all optional services:**
+    ```bash
+    docker-compose --profile adminer --profile redis --profile memcached --profile postgres up -d
+    ```
+
+If you do not specify the `--profile` flag, only the core services will be started.
+
+> **Tip:** You can combine any profiles as needed for your development workflow.
+
 ## Versioning
 
 The version is broken down into 4 points e.g 1.2.3.4 We use MAJOR.MINOR.FEATURE.PATCH to describe the version numbers.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
 
   adminer:
     image: adminer:latest
+    profiles: [adminer]
     environment:
       ADMINER_DEFAULT_SERVER: mysql
     depends_on:
@@ -48,14 +49,17 @@ services:
 
   redis:
     image: redis:latest
+    profiles: [redis]
     volumes:
         - redis-data:/data
 
   memcached:
     image: memcached:latest
+    profiles: [memcached]
 
   postgres:
     image: postgres:latest
+    profiles: [postgres]
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-opencart}


### PR DESCRIPTION
### Summary

This PR introduces Docker Compose profiles for optional services, allowing developers to enable only the services they need for a lighter and faster development environment. The documentation has also been updated with clear instructions and usage examples.

### Key Changes

- Added Docker Compose profiles for `Adminer`, `Redis`, `Memcached`, and `PostgreSQL` in `docker-compose.yml`.
- Updated the documentation to explain how to enable optional services using the `--profile` flag.

### Notes for developers

Please note that this is part of an ongoing effort to improve the Docker configuration, which is **not yet considered production-ready**. Further work will continue.