### PR TITLE
refactor(docker): move opencart init logic to entrypoint script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,14 +12,6 @@ services:
     depends_on:
       mysql:
         condition: service_healthy
-    command: >
-      bash -c "if [ ! -f /var/www/html/install.lock ]; then
-                 cp config-dist.php config.php;
-                 cp admin/config-dist.php admin/config.php;
-                 php /var/www/html/install/cli_install.php install --username admin --password admin --email email@example.com --http_server http://localhost/ --db_driver mysqli --db_hostname mysql --db_username root --db_password opencart --db_database opencart --db_port 3306 --db_prefix oc_;
-                 touch /var/www/html/install.lock;
-               fi &&
-               apache2-foreground"
 
   mysql:
     image: mariadb

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -4,7 +4,7 @@ ARG PHP_VERSION=8.4
 
 FROM php:${PHP_VERSION}-apache
 
-# Copy the advanced PHP extension installer
+# Copy the advanced PHP extension installer.
 RUN apt-get update && apt-get install -y --no-install-recommends unzip
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
@@ -17,6 +17,10 @@ RUN install-php-extensions \
     mysqli \
     zip \
     opcache
+
+# Set entrypoint script for container startup.
+COPY --chown=www-data:www-data entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 
 # Enable mod_rewrite for SEO-friendly URLs, as it's not enabled by default.
 RUN a2enmod rewrite

--- a/docker/php/entrypoint.sh
+++ b/docker/php/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+if [ ! -f /var/www/html/install.lock ]; then
+  cp config-dist.php config.php
+  cp admin/config-dist.php admin/config.php
+  php /var/www/html/install/cli_install.php install \
+    --username admin \
+    --password admin \
+    --email email@example.com \
+    --http_server http://localhost/ \
+    --db_driver mysqli \
+    --db_hostname mysql \
+    --db_username root \
+    --db_password opencart \
+    --db_database opencart \
+    --db_port 3306 \
+    --db_prefix oc_
+  touch /var/www/html/install.lock
+fi
+
+exec apache2-foreground


### PR DESCRIPTION
### Summary

This PR refactors the Docker configuration by moving the OpenCart initialization logic from the Docker Compose `command` section into a dedicated `entrypoint.sh` script.

### Key Changes

This change is a straightforward refactoring that centralizes the container's startup process. By moving the existing OpenCart setup commands (including copying config files, running the CLI installer, and launching Apache via `exec` with the `install.lock` check) to `entrypoint.sh`, the configuration becomes:

- **Cleaner and More Readable:** The `docker-compose.yml` is simplified, with all container startup logic encapsulated in a single, dedicated script.
- **Easier to Maintain:** Future adjustments or extensions to the initialization process can be made in one place, streamlining development.
- **More Robust:** Confirms the standard Docker pattern for managing the main application process within the container.

### Notes for developers

This PR focuses on improving the internal structure of the Docker setup. The **Docker configuration is still not considered production-ready** and further work will continue on enhancing its robustness and features.