### PR TITLE
Fix autocomplete in Safari

### DIFF
--- a/upload/admin/view/javascript/common.js
+++ b/upload/admin/view/javascript/common.js
@@ -425,7 +425,7 @@ $(document).on('click', '[data-oc-toggle=\'image\']', function(e) {
             });
 
             // Click
-            $dropdown.on('click', 'a', function(e) {
+            $dropdown.on('mousedown', 'a', function(e) {
                 e.preventDefault();
 
                 var value = $(this).attr('href');

--- a/upload/catalog/view/javascript/common.js
+++ b/upload/catalog/view/javascript/common.js
@@ -334,7 +334,7 @@ var chain = new Chain();
             });
 
             // Click
-            $dropdown.on('click', 'a', function(e) {
+            $dropdown.on('mousedown', 'a', function(e) {
                 e.preventDefault();
 
                 var value = $(this).attr('href');


### PR DESCRIPTION
Safary often does not assign `click` event on dynamic, bubble or hidden elements