### PR TITLE
fix(cli): sync installer requirements with web installer

### DIFF
--- a/upload/install/cli_install.php
+++ b/upload/install/cli_install.php
@@ -210,8 +210,14 @@ class CliInstall extends \Opencart\System\Engine\Controller {
 			$error .= 'ERROR: OpenCart will not work with session.auto_start enabled!' . "\n";
 		}
 
-		if (!extension_loaded('mysqli')) {
-			$error .= 'ERROR: MySQLi extension needs to be loaded for OpenCart to work!' . "\n";
+		$db = [
+			'mysqli',
+			'pdo',
+			'pgsql'
+		];
+
+		if (!array_filter($db, 'extension_loaded')) {
+			$error .= 'ERROR: A database extension needs to be loaded in the php.ini for OpenCart to work!' . "\n";
 		}
 
 		if (!extension_loaded('gd')) {
@@ -222,12 +228,12 @@ class CliInstall extends \Opencart\System\Engine\Controller {
 			$error .= 'ERROR: CURL extension needs to be loaded for OpenCart to work!' . "\n";
 		}
 
-		if (!function_exists('openssl_encrypt')) {
-			$error .= 'ERROR: OpenSSL extension needs to be loaded for OpenCart to work!' . "\n";
+		if (!function_exists('iconv') && !extension_loaded('mbstring')) {
+			$error .= 'ERROR: iconv OR mbstring extension needs to be loaded for OpenCart to work!' . "\n";
 		}
 
-		if (!extension_loaded('zlib')) {
-			$error .= 'ERROR: ZLIB extension needs to be loaded for OpenCart to work!' . "\n";
+		if (!function_exists('openssl_encrypt')) {
+			$error .= 'ERROR: OpenSSL extension needs to be loaded for OpenCart to work!' . "\n";
 		}
 
 		if (!is_file(DIR_OPENCART . 'config.php')) {


### PR DESCRIPTION
### Summary

This PR synchronizes the CLI installer requirements with the web installer to ensure consistency between installation methods.

### Key Changes

The CLI installer was missing some requirement checks that exist in the web installer, and had an outdated check that the web installer doesn't have. This update brings both installers into alignment:

- **Removed zlib extension check:** The web installer doesn't check for zlib, so this requirement has been removed from the CLI installer for consistency.
- **Added mbstring/iconv check:** The web installer requires either iconv or mbstring extension to be loaded. This check has been added to the CLI installer.
- **Updated database extension check:** The web installer supports multiple database drivers (mysqli, pdo, pgsql), while the CLI installer only checked for mysqli. Now both installers check for the same set of database extensions.