### PR TITLE
feat(dev): add YAML formatting rules to EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,7 @@ indent_size = 4
 [*.twig]
 indent_style = space
 indent_size = 2
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
### Summary

Adds YAML formatting rules to EditorConfig for consistent indentation in Docker Compose and other YAML files.

### Changes
- Add 2-space indentation rule for `.yml` and `.yaml` files