### PR TITLE
Fix `Could not call registry key model_design_seo_url` exception

### DIFF
--- a/upload/admin/model/catalog/product.php
+++ b/upload/admin/model/catalog/product.php
@@ -367,6 +367,7 @@ class Product extends \Opencart\System\Engine\Model {
 		}
 
 		// SEO
+		$this->load->model('design/seo_url');
 		$this->model_design_seo_url->deleteSeoUrlsByKeyValue('product_id', $product_id);
 
 		if (isset($data['product_seo_url'])) {


### PR DESCRIPTION
When editing an existing product, calling `Opencart\Admin\Model\Catalog\Product@editProduct()` would result in an exception with the message "Error: Could not call registry key model_design_seo_url!". This would happen only when `editProduct()` was the first method call after instantiation of `Opencart\Admin\Model\Catalog\Product` (via `$this->load->model('catalog/product')`). If the first method called after instantiation was one that included a call to `$this->load->model('design/seo_url')` such as `Product@deleteProduct()` or `Product@addProduct()`, the exception would not be thrown because the `design/seo_url` model was already loaded by one of the previous method calls.