### PR TITLE
Fix null product_id when joining tables without matches

### DIFF
--- a/upload/admin/model/catalog/product.php
+++ b/upload/admin/model/catalog/product.php
@@ -1021,7 +1021,7 @@ class Product extends \Opencart\System\Engine\Model {
 	 * $results = $this->model_catalog_product->getProducts($filter_data);
 	 */
 	public function getProducts(array $data = []): array {
-		$sql = "SELECT * FROM `" . DB_PREFIX . "product` `p` LEFT JOIN `" . DB_PREFIX . "product_description` `pd` ON (`p`.`product_id` = `pd`.`product_id`)";
+		$sql = "SELECT *, `p`.`product_id` AS `product_id` FROM `" . DB_PREFIX . "product` `p` LEFT JOIN `" . DB_PREFIX . "product_description` `pd` ON (`p`.`product_id` = `pd`.`product_id`)";
 
 		if (!empty($data['filter_model'])) {
 			$sql .= " LEFT JOIN `" . DB_PREFIX . "product_code` `pc` ON (`p`.`product_id` = `pc`.`product_id`)";


### PR DESCRIPTION
When calling `getProducts()` with parameters that cause a `LEFT JOIN`, and the joined table does not have a match for a give row, the `product_id` field from the joined table is null. And since that version of the `product_id` field comes later in the column order, it takes precedence over the earlier columns when `mysqli_result::fetch_assoc()` is called, and so the `product_id` fields ends up being `null` in the result in PHP, which can obviously cause a number of other issues.

Specifically calling out the `product_id` field from the base table, and making it last in the order of columns, causes it to take precedence.

In my particular case, I encountered the issue when loading the list of products on the admin side, and the page I was on did not have any discounts.