### PR TITLE
Enabled searching default store

### DIFF
--- a/upload/admin/model/design/seo_url.php
+++ b/upload/admin/model/design/seo_url.php
@@ -75,10 +75,10 @@ class SeoUrl extends \Opencart\System\Engine\Model {
 	/**
 	 * Delete Seo Urls by Key Value pair
 	 *
-	 * @param string $key
-	 * @param string $value
-	 * @param int    $store_id    primary key of the store record
-	 * @param int    $language_id primary key of the language record
+	 * @param string   $key
+	 * @param string   $value
+	 * @param int|null $store_id    primary key of the store record
+	 * @param int      $language_id primary key of the language record
 	 *
 	 * @return void
 	 *
@@ -88,10 +88,10 @@ class SeoUrl extends \Opencart\System\Engine\Model {
 	 *
 	 * $this->model_design_seo_url->deleteSeoUrlsByKeyValue($key, $value, $store_id, $language_id);
 	 */
-	public function deleteSeoUrlsByKeyValue(string $key, string $value, int $store_id = 0, int $language_id = 0): void {
+	public function deleteSeoUrlsByKeyValue(string $key, string $value, int|null $store_id = null, int $language_id = 0): void {
 		$sql = "DELETE FROM `" . DB_PREFIX . "seo_url` WHERE `key` = '" . $this->db->escape($key) . "' AND `value` LIKE '" . $this->db->escape($value) . "'";
 
-		if ($store_id) {
+		if ($store_id !== null) {
 			$sql .= " AND `store_id` = '" . (int)$store_id . "'";
 		}
 
@@ -158,10 +158,10 @@ class SeoUrl extends \Opencart\System\Engine\Model {
 	/**
 	 * Get Seo Url By Key Value
 	 *
-	 * @param string $key
-	 * @param string $value
-	 * @param int    $store_id    primary key of the store record
-	 * @param int    $language_id primary key of the language record
+	 * @param string   $key
+	 * @param string   $value
+	 * @param int|null $store_id    primary key of the store record
+	 * @param int      $language_id primary key of the language record
 	 *
 	 * @return array<string, mixed>
 	 *
@@ -171,10 +171,10 @@ class SeoUrl extends \Opencart\System\Engine\Model {
 	 *
 	 * $seo_url_info = $this->model_design_seo_url->getSeoUrlByKeyValue($key, $value, $store_id, $language_id);
 	 */
-	public function getSeoUrlByKeyValue(string $key, string $value, int $store_id = 0, int $language_id = 0): array {
+	public function getSeoUrlByKeyValue(string $key, string $value, int|null $store_id = null, int $language_id = 0): array {
 		$sql = "SELECT * FROM `" . DB_PREFIX . "seo_url` WHERE `key` = '" . $this->db->escape($key) . "' AND `value` LIKE '" . $this->db->escape($value) . "'";
 
-		if ($store_id) {
+		if ($store_id !== null) {
 			$sql .= " AND `store_id` = '" . (int)$store_id . "'";
 		}
 


### PR DESCRIPTION
The default store's ID is 0, which evaluates to `false` in a boolean check. Because of this, when calling the `SeoUrl::*SeoUrlsByKeyValue()` methods, and searching by the default store, the additional `WHERE` check doesn't get added. This causes the search to be applied to all stores instead of the intended target store.