### PR TITLE
fix(models): correct method names for bulk delete operations

### DIFF
--- a/upload/catalog/controller/account/address.php
+++ b/upload/catalog/controller/account/address.php
@@ -483,7 +483,7 @@ class Address extends \Opencart\System\Engine\Controller {
 
 		if (!$json) {
 			// Delete address from database.
-			$this->model_account_address->deleteAddress($this->customer->getId(), $address_id);
+			$this->model_account_address->deleteAddresses($this->customer->getId(), $address_id);
 
 			// Delete address from session.
 			if (isset($this->session->data['shipping_address']['address_id']) && ($this->session->data['shipping_address']['address_id'] == $address_id)) {

--- a/upload/catalog/controller/account/wishlist.php
+++ b/upload/catalog/controller/account/wishlist.php
@@ -151,7 +151,7 @@ class WishList extends \Opencart\System\Engine\Controller {
 					'remove'  => $this->url->link('account/wishlist.remove', 'language=' . $this->config->get('config_language') . '&product_id=' . $product_info['product_id'] . (isset($this->session->data['customer_token']) ? '&customer_token=' . $this->session->data['customer_token'] : ''))
 				] + $product_info;
 			} else {
-				$this->model_account_wishlist->deleteWishlist($this->customer->getId(), $result['product_id']);
+				$this->model_account_wishlist->deleteWishlists($this->customer->getId(), $result['product_id']);
 			}
 		}
 
@@ -239,7 +239,7 @@ class WishList extends \Opencart\System\Engine\Controller {
 			// Wishlist
 			$this->load->model('account/wishlist');
 
-			$this->model_account_wishlist->deleteWishlist($this->customer->getId(), $product_id);
+			$this->model_account_wishlist->deleteWishlists($this->customer->getId(), $product_id);
 
 			$json['success'] = $this->language->get('text_remove');
 		}

--- a/upload/catalog/model/account/address.php
+++ b/upload/catalog/model/account/address.php
@@ -90,9 +90,9 @@ class Address extends \Opencart\System\Engine\Model {
 	}
 
 	/**
-	 * Delete Address
+	 * Delete Addresses
 	 *
-	 * Delete address record in the database.
+	 * Delete address records in the database.
 	 *
 	 * @param int $customer_id primary key of the customer record
 	 * @param int $address_id  primary key of the address record
@@ -103,9 +103,9 @@ class Address extends \Opencart\System\Engine\Model {
 	 *
 	 * $this->load->model('account/address');
 	 *
-	 * $this->model_account_address->deleteAddress($customer_id, $address_id);
+	 * $this->model_account_address->deleteAddresses($customer_id, $address_id);
 	 */
-	public function deleteAddress(int $customer_id, int $address_id = 0): void {
+	public function deleteAddresses(int $customer_id, int $address_id = 0): void {
 		$sql = "DELETE FROM `" . DB_PREFIX . "address` WHERE `customer_id` = '" . (int)$customer_id . "'";
 
 		if ($address_id) {

--- a/upload/catalog/model/account/affiliate.php
+++ b/upload/catalog/model/account/affiliate.php
@@ -98,7 +98,7 @@ class Affiliate extends \Opencart\System\Engine\Model {
 	 *
 	 * $this->load->model('account/affiliate');
 	 *
-	 * $this->model_account_affiliate->editAffiliate($customer_id);
+	 * $this->model_account_affiliate->deleteAffiliate($customer_id);
 	 */
 	public function deleteAffiliate(int $customer_id): void {
 		$this->db->query("DELETE FROM `" . DB_PREFIX . "customer_affiliate` WHERE `customer_id` = '" . (int)$customer_id . "'");

--- a/upload/catalog/model/account/customer.php
+++ b/upload/catalog/model/account/customer.php
@@ -267,16 +267,16 @@ class Customer extends \Opencart\System\Engine\Model {
 	 *
 	 * $this->load->model('account/customer');
 	 *
-	 * $this->model_account_customer->deleteHistory($customer_id);
+	 * $this->model_account_customer->deleteHistories($customer_id);
 	 */
-	public function deleteHistory(int $customer_id): void {
+	public function deleteHistories(int $customer_id): void {
 		$this->db->query("DELETE FROM `" . DB_PREFIX . "customer_history` WHERE `customer_id` = '" . (int)$customer_id . "'");
 	}
 
 	/**
-	 * Delete Ip
+	 * Delete Ips
 	 *
-	 * Delete customer ip record in the database.
+	 * Delete customer ip records in the database.
 	 *
 	 * @param int $customer_id primary key of the customer record
 	 *
@@ -286,9 +286,9 @@ class Customer extends \Opencart\System\Engine\Model {
 	 *
 	 * $this->load->model('account/customer');
 	 *
-	 * $this->model_account_customer->deleteIp($customer_id);
+	 * $this->model_account_customer->deleteIps($customer_id);
 	 */
-	public function deleteIp(int $customer_id): void {
+	public function deleteIps(int $customer_id): void {
 		$this->db->query("DELETE FROM `" . DB_PREFIX . "customer_ip` WHERE `customer_id` = '" . (int)$customer_id . "'");
 	}
 
@@ -480,9 +480,9 @@ class Customer extends \Opencart\System\Engine\Model {
 	}
 
 	/**
-	 * Delete Customer Authorize
+	 * Delete Customer Authorizes
 	 *
-	 * Delete customer authorize record in the database.
+	 * Delete customer authorize records in the database.
 	 *
 	 * @param int $customer_id           primary key of the customer record
 	 * @param int $customer_authorize_id primary key of the customer authorize record
@@ -493,9 +493,9 @@ class Customer extends \Opencart\System\Engine\Model {
 	 *
 	 * $this->load->model('account/customer');
 	 *
-	 * $this->model_account_customer->deleteAuthorize($customer_id, $customer_authorize_id);
+	 * $this->model_account_customer->deleteAuthorizes($customer_id, $customer_authorize_id);
 	 */
-	public function deleteAuthorize(int $customer_id, int $customer_authorize_id = 0): void {
+	public function deleteAuthorizes(int $customer_id, int $customer_authorize_id = 0): void {
 		$sql = "DELETE FROM `" . DB_PREFIX . "customer_authorize` WHERE `customer_id` = '" . (int)$customer_id . "'";
 
 		if ($customer_authorize_id) {
@@ -519,7 +519,7 @@ class Customer extends \Opencart\System\Engine\Model {
 	 *
 	 * $this->load->model('account/customer');
 	 *
-	 * $this->model_account_customer->deleteAuthorizes($customer_id);
+	 * $this->model_account_customer->deleteAuthorizeByToken($customer_id);
 	 */
 	public function deleteAuthorizeByToken(int $customer_id, string $token): void {
 		$this->db->query("DELETE FROM `" . DB_PREFIX . "customer_authorize` WHERE `customer_id` = '" . (int)$customer_id . "' AND `token` = '" . $this->db->escape($token) . "'");

--- a/upload/catalog/model/account/reward.php
+++ b/upload/catalog/model/account/reward.php
@@ -31,9 +31,9 @@ class Reward extends \Opencart\System\Engine\Model {
 	}
 
 	/**
-	 * Delete Reward
+	 * Delete Rewards
 	 *
-	 * Delete customer reward record in the database.
+	 * Delete customer reward records in the database.
 	 *
 	 * @param int $customer_id primary key of the customer record
 	 * @param int $order_id    primary key of the order record
@@ -44,9 +44,9 @@ class Reward extends \Opencart\System\Engine\Model {
 	 *
 	 * $this->load->model('account/reward');
 	 *
-	 * $this->model_account_reward->deleteReward($customer_id, $order_id);
+	 * $this->model_account_reward->deleteRewards($customer_id, $order_id);
 	 */
-	public function deleteReward(int $customer_id, int $order_id = 0): void {
+	public function deleteRewards(int $customer_id, int $order_id = 0): void {
 		$sql = "DELETE FROM `" . DB_PREFIX . "customer_reward` WHERE `customer_id` = '" . (int)$customer_id . "'";
 
 		if ($order_id) {

--- a/upload/catalog/model/account/transaction.php
+++ b/upload/catalog/model/account/transaction.php
@@ -31,9 +31,9 @@ class Transaction extends \Opencart\System\Engine\Model {
 	}
 
 	/**
-	 * Delete Transaction
+	 * Delete Transactions
 	 *
-	 * Delete customer transaction record in the database.
+	 * Delete customer transaction records in the database.
 	 *
 	 * @param int $customer_id primary key of the customer record
 	 * @param int $order_id    primary key of the order record
@@ -44,9 +44,9 @@ class Transaction extends \Opencart\System\Engine\Model {
 	 *
 	 * $this->load->model('account/transaction');
 	 *
-	 * $this->model_account_transaction->deleteTransaction($customer_id, $order_id);
+	 * $this->model_account_transaction->deleteTransactions($customer_id, $order_id);
 	 */
-	public function deleteTransaction(int $customer_id, int $order_id = 0): void {
+	public function deleteTransactions(int $customer_id, int $order_id = 0): void {
 		$sql = "DELETE FROM `" . DB_PREFIX . "customer_transaction` WHERE `customer_id` = '" . (int)$customer_id . "'";
 
 		if ($order_id) {

--- a/upload/catalog/model/account/wishlist.php
+++ b/upload/catalog/model/account/wishlist.php
@@ -30,9 +30,9 @@ class Wishlist extends \Opencart\System\Engine\Model {
 	}
 
 	/**
-	 * Delete Wishlist
+	 * Delete Wishlists
 	 *
-	 * Delete customer wishlist record in the database.
+	 * Delete customer wishlist records in the database.
 	 *
 	 * @param int $customer_id primary key of the customer record
 	 * @param int $product_id  primary key of the product record
@@ -43,9 +43,9 @@ class Wishlist extends \Opencart\System\Engine\Model {
 	 *
 	 * $this->load->model('account/wishlist');
 	 *
-	 * $this->model_account_wishlist->deleteWishlist($customer_id, $product_id);
+	 * $this->model_account_wishlist->deleteWishlists($customer_id, $product_id);
 	 */
-	public function deleteWishlist(int $customer_id, int $product_id = 0): void {
+	public function deleteWishlists(int $customer_id, int $product_id = 0): void {
 		$sql = "DELETE FROM `" . DB_PREFIX . "customer_wishlist` WHERE `customer_id` = '" . (int)$customer_id . "' AND `store_id` = '" . (int)$this->config->get('config_store_id') . "'";
 
 		if ($product_id) {

--- a/upload/catalog/model/checkout/order.php
+++ b/upload/catalog/model/checkout/order.php
@@ -972,7 +972,7 @@ class Order extends \Opencart\System\Engine\Model {
 				if ($order_info['affiliate_id']) {
 					$this->load->model('account/transaction');
 
-					$this->model_account_transaction->deleteTransaction($order_info['customer_id'], $order_id);
+					$this->model_account_transaction->deleteTransactions($order_info['customer_id'], $order_id);
 				}
 			}
 


### PR DESCRIPTION
### PHPStan Spring Cleaning: Customer Model Method Names

Fix customer deletion functionality by correcting method names in account models to use plural forms for bulk delete operations.

#### Problem
The [`Customer::deleteCustomer()`](https://github.com/opencart/opencart/blob/master/upload/catalog/model/account/customer.php#L147) method was calling non-existent methods, causing related customer data (addresses, rewards, transactions, etc.) to not be properly cleaned up when deleting customers, leading to orphaned records in the database.

#### Changes
- **Address model**: `deleteAddress()` → `deleteAddresses()` 
- **Reward model**: `deleteReward()` → `deleteRewards()`
- **Transaction model**: `deleteTransaction()` → `deleteTransactions()`
- **Customer model**: `deleteHistory()` → `deleteHistories()`, `deleteIp()` → `deleteIps()`, `deleteAuthorize()` → `deleteAuthorizes()`
- Update PHPDoc comments to match plural method names and descriptions
- Aligns with OpenCart naming conventions for bulk delete operations (following `Api::deleteIps()` pattern)
- Customer deletion now properly removes all related data

#### PHPStan Errors Fixed
- `Call to an undefined method deleteAddresses()`
- `Call to an undefined method deleteRewards()`
- `Call to an undefined method deleteTransactions()`
- `Call to an undefined method deleteWishlists()`
- `Call to an undefined method deleteHistories()`
- `Call to an undefined method deleteIps()`
- `Call to an undefined method deleteAuthorizes()`

@danielkerr, please review this PR carefully. I proceeded with the assumption that customer deletion should cascade delete related records in one-to-many relationships. However, the previous methods were intentionally named in singular form for some reason...