### PR TITLE
fix(typo): correct $thid to $this in api/order controller

### DIFF
--- a/upload/catalog/controller/api/order.php
+++ b/upload/catalog/controller/api/order.php
@@ -415,7 +415,7 @@ class Order extends \Opencart\System\Engine\Controller {
 		}
 
 		// 7. Validate affiliate if set
-		if (isset($thid->request->post['affiliate_id']) && !isset($this->session->data['affiliate_id'])) {
+		if (isset($this->request->post['affiliate_id']) && !isset($this->session->data['affiliate_id'])) {
 			$output['error']['affiliate'] = $this->language->get('error_affiliate');
 		}
 


### PR DESCRIPTION
### PHPStan Spring Cleaning: Simple Typo Fix

Fix obvious typo `$thid` → `$this` in api/order controller.

#### PHPStan Error Fixed
- `Variable $thid in isset() is never defined`