### PR TITLE
fix(marketplace): remove undefined $response_info check

### DIFF
--- a/upload/admin/controller/marketplace/marketplace.php
+++ b/upload/admin/controller/marketplace/marketplace.php
@@ -114,8 +114,6 @@ class Marketplace extends \Opencart\System\Engine\Controller {
 
 		if (!$this->config->get('opencart_username') || !$this->config->get('opencart_secret')) {
 			$data['error_warning'] = $this->language->get('error_api');
-		} elseif (isset($response_info['error'])) {
-			$data['error_warning'] = $response_info['error'];
 		} else {
 			$data['error_warning'] = '';
 		}


### PR DESCRIPTION
### PHPStan Spring Cleaning: Remove Undefined Variable Check

Remove elseif block checking undefined `$response_info` variable in marketplace controller index() method.

#### Problem
The `$response_info` variable is only defined in the `getList()` method, but was being checked in the `index()` method where it doesn't exist. This appears to be leftover code from copy-paste.

#### PHPStan Error Fixed
- `Variable $response_info in isset() is never defined`
- `Undefined variable: $response_info`