### PR TITLE
fix(types): correct parameter types from string to int in language model

### DIFF
--- a/upload/admin/model/localisation/language.php
+++ b/upload/admin/model/localisation/language.php
@@ -45,7 +45,7 @@ class Language extends \Opencart\System\Engine\Model {
 		$results = $this->model_catalog_attribute->getDescriptionsByLanguageId($this->config->get('config_language_id'));
 
 		foreach ($results as $attribute) {
-			$this->model_catalog_attribute->addDescription($attribute['attribute_id'], $language_id, $attribute);
+			$this->model_catalog_attribute->addDescription((int)$attribute['attribute_id'], $language_id, $attribute);
 		}
 
 		// Attribute Group
@@ -54,7 +54,7 @@ class Language extends \Opencart\System\Engine\Model {
 		$results = $this->model_catalog_attribute_group->getDescriptionsByLanguageId($this->config->get('config_language_id'));
 
 		foreach ($results as $attribute_group) {
-			$this->model_catalog_attribute_group->addDescription($attribute_group['attribute_group_id'], $language_id, $attribute_group);
+			$this->model_catalog_attribute_group->addDescription((int)$attribute_group['attribute_group_id'], $language_id, $attribute_group);
 		}
 
 		// Banner
@@ -72,7 +72,7 @@ class Language extends \Opencart\System\Engine\Model {
 		$results = $this->model_catalog_category->getDescriptionsByLanguageId($this->config->get('config_language_id'));
 
 		foreach ($results as $category) {
-			$this->model_catalog_category->addDescription($category['category_id'], $language_id, $category);
+			$this->model_catalog_category->addDescription((int)$category['category_id'], $language_id, $category);
 		}
 
 		// Country
@@ -81,7 +81,7 @@ class Language extends \Opencart\System\Engine\Model {
 		$results = $this->model_localisation_country->getDescriptionsByLanguageId($this->config->get('config_language_id'));
 
 		foreach ($results as $country) {
-			$this->model_localisation_country->addDescription($country['country_id'], $language_id, $country);
+			$this->model_localisation_country->addDescription((int)$country['country_id'], $language_id, $country);
 		}
 
 		// Customer Group
@@ -90,7 +90,7 @@ class Language extends \Opencart\System\Engine\Model {
 		$results = $this->model_customer_customer_group->getDescriptionsByLanguageId($this->config->get('config_language_id'));
 
 		foreach ($results as $customer_group) {
-			$this->model_customer_customer_group->addDescription($customer_group['customer_group_id'], $language_id, $customer_group);
+			$this->model_customer_customer_group->addDescription((int)$customer_group['customer_group_id'], $language_id, $customer_group);
 		}
 
 		// Custom Field
@@ -99,14 +99,14 @@ class Language extends \Opencart\System\Engine\Model {
 		$results = $this->model_customer_custom_field->getDescriptionsByLanguageId($this->config->get('config_language_id'));
 
 		foreach ($results as $custom_field) {
-			$this->model_customer_custom_field->addDescription($custom_field['custom_field_id'], $language_id, $custom_field);
+			$this->model_customer_custom_field->addDescription((int)$custom_field['custom_field_id'], $language_id, $custom_field);
 		}
 
 		// Custom Field Value
 		$results = $this->model_customer_custom_field->getValueDescriptionsByLanguageId($this->config->get('config_language_id'));
 
 		foreach ($results as $custom_field_value) {
-			$this->model_customer_custom_field->addValueDescription($custom_field_value['custom_field_value_id'], $custom_field_value['custom_field_id'], $language_id, $custom_field_value);
+			$this->model_customer_custom_field->addValueDescription((int)$custom_field_value['custom_field_value_id'], (int)$custom_field_value['custom_field_id'], $language_id, $custom_field_value);
 		}
 
 		// Download
@@ -115,7 +115,7 @@ class Language extends \Opencart\System\Engine\Model {
 		$results = $this->model_catalog_download->getDescriptionsByLanguageId($this->config->get('config_language_id'));
 
 		foreach ($results as $download) {
-			$this->model_catalog_download->addDescription($download['download_id'], $language_id, $download);
+			$this->model_catalog_download->addDescription((int)$download['download_id'], $language_id, $download);
 		}
 
 		// Filter
@@ -124,7 +124,7 @@ class Language extends \Opencart\System\Engine\Model {
 		$results = $this->model_catalog_filter->getDescriptionsByLanguageId($this->config->get('config_language_id'));
 
 		foreach ($results as $filter) {
-			$this->model_catalog_filter->addDescription($filter['filter_id'], $language_id, $filter);
+			$this->model_catalog_filter->addDescription((int)$filter['filter_id'], $language_id, $filter);
 		}
 
 		// Filter Group
@@ -133,7 +133,7 @@ class Language extends \Opencart\System\Engine\Model {
 		$results = $this->model_catalog_filter_group->getDescriptionsByLanguageId($this->config->get('config_language_id'));
 
 		foreach ($results as $filter_group) {
-			$this->model_catalog_filter_group->addDescription($filter_group['filter_group_id'], $language_id, $filter_group);
+			$this->model_catalog_filter_group->addDescription((int)$filter_group['filter_group_id'], $language_id, $filter_group);
 		}
 
 		// Information
@@ -142,7 +142,7 @@ class Language extends \Opencart\System\Engine\Model {
 		$results = $this->model_catalog_information->getDescriptionsByLanguageId($this->config->get('config_language_id'));
 
 		foreach ($results as $information) {
-			$this->model_catalog_information->addDescription($information['information_id'], $language_id, $information);
+			$this->model_catalog_information->addDescription((int)$information['information_id'], $language_id, $information);
 		}
 
 		// Length
@@ -151,7 +151,7 @@ class Language extends \Opencart\System\Engine\Model {
 		$results = $this->model_localisation_length_class->getDescriptionsByLanguageId($this->config->get('config_language_id'));
 
 		foreach ($results as $length) {
-			$this->model_localisation_length_class->addDescription($length['length_class_id'], $language_id, $length);
+			$this->model_localisation_length_class->addDescription((int)$length['length_class_id'], $language_id, $length);
 		}
 
 		// Manufacturer
@@ -160,7 +160,7 @@ class Language extends \Opencart\System\Engine\Model {
 		$results = $this->model_catalog_manufacturer->getDescriptionsByLanguageId($this->config->get('config_language_id'));
 
 		foreach ($results as $manufacturer) {
-			$this->model_catalog_manufacturer->addDescription($manufacturer['manufacturer_id'], $language_id, $manufacturer);
+			$this->model_catalog_manufacturer->addDescription((int)$manufacturer['manufacturer_id'], $language_id, $manufacturer);
 		}
 
 		// Option
@@ -169,14 +169,14 @@ class Language extends \Opencart\System\Engine\Model {
 		$results = $this->model_catalog_option->getDescriptionsByLanguageId($this->config->get('config_language_id'));
 
 		foreach ($results as $option) {
-			$this->model_catalog_option->addDescription($option['option_id'], $language_id, $option);
+			$this->model_catalog_option->addDescription((int)$option['option_id'], $language_id, $option);
 		}
 
 		// Option Value
 		$results = $this->model_catalog_option->getValueDescriptionsByLanguageId($this->config->get('config_language_id'));
 
 		foreach ($results as $option_value) {
-			$this->model_catalog_option->addValueDescription($option_value['option_value_id'], $option_value['option_id'], $language_id, $option_value);
+			$this->model_catalog_option->addValueDescription((int)$option_value['option_value_id'], (int)$option_value['option_id'], $language_id, $option_value);
 		}
 
 		// Order Status
@@ -185,7 +185,7 @@ class Language extends \Opencart\System\Engine\Model {
 		$results = $this->model_localisation_order_status->getDescriptionsByLanguageId($this->config->get('config_language_id'));
 
 		foreach ($results as $order_status) {
-			$this->model_localisation_order_status->addDescription($order_status['order_status_id'], $language_id, $order_status);
+			$this->model_localisation_order_status->addDescription((int)$order_status['order_status_id'], $language_id, $order_status);
 		}
 
 		// Product
@@ -194,14 +194,14 @@ class Language extends \Opencart\System\Engine\Model {
 		$results = $this->model_catalog_product->getDescriptionsByLanguageId($this->config->get('config_language_id'));
 
 		foreach ($results as $product) {
-			$this->model_catalog_product->addDescription($product['product_id'], $language_id, $product);
+			$this->model_catalog_product->addDescription((int)$product['product_id'], $language_id, $product);
 		}
 
 		// Product Attribute
 		$results = $this->model_catalog_product->getAttributesByLanguageId($this->config->get('config_language_id'));
 
 		foreach ($results as $product_attribute) {
-			$this->model_catalog_product->addAttribute($product_attribute['product_id'], $product_attribute['attribute_id'], $language_id, $product_attribute);
+			$this->model_catalog_product->addAttribute((int)$product_attribute['product_id'], (int)$product_attribute['attribute_id'], $language_id, $product_attribute);
 		}
 
 		// Return Action
@@ -210,7 +210,7 @@ class Language extends \Opencart\System\Engine\Model {
 		$results = $this->model_localisation_return_action->getDescriptionsByLanguageId($this->config->get('config_language_id'));
 
 		foreach ($results as $return_action) {
-			$this->model_localisation_return_action->addDescription($return_action['return_action_id'], $language_id, $return_action);
+			$this->model_localisation_return_action->addDescription((int)$return_action['return_action_id'], $language_id, $return_action);
 		}
 
 		// Return Reason
@@ -219,7 +219,7 @@ class Language extends \Opencart\System\Engine\Model {
 		$results = $this->model_localisation_return_reason->getDescriptionsByLanguageId($this->config->get('config_language_id'));
 
 		foreach ($results as $return_reason) {
-			$this->model_localisation_return_reason->addDescription($return_reason['return_reason_id'], $language_id, $return_reason);
+			$this->model_localisation_return_reason->addDescription((int)$return_reason['return_reason_id'], $language_id, $return_reason);
 		}
 
 		// Return Status
@@ -228,7 +228,7 @@ class Language extends \Opencart\System\Engine\Model {
 		$results = $this->model_localisation_return_status->getDescriptionsByLanguageId($this->config->get('config_language_id'));
 
 		foreach ($results as $return_status) {
-			$this->model_localisation_return_status->addDescription($return_status['return_status_id'], $language_id, $return_status);
+			$this->model_localisation_return_status->addDescription((int)$return_status['return_status_id'], $language_id, $return_status);
 		}
 
 		// Stock Status
@@ -237,7 +237,7 @@ class Language extends \Opencart\System\Engine\Model {
 		$results = $this->model_localisation_stock_status->getDescriptionsByLanguageId($this->config->get('config_language_id'));
 
 		foreach ($results as $stock_status) {
-			$this->model_localisation_stock_status->addDescription($stock_status['stock_status_id'], $language_id, $stock_status);
+			$this->model_localisation_stock_status->addDescription((int)$stock_status['stock_status_id'], $language_id, $stock_status);
 		}
 
 		// Weight Class
@@ -246,7 +246,7 @@ class Language extends \Opencart\System\Engine\Model {
 		$results = $this->model_localisation_weight_class->getDescriptionsByLanguageId($this->config->get('config_language_id'));
 
 		foreach ($results as $weight_class) {
-			$this->model_localisation_weight_class->addDescription($weight_class['weight_class_id'], $language_id, $weight_class);
+			$this->model_localisation_weight_class->addDescription((int)$weight_class['weight_class_id'], $language_id, $weight_class);
 		}
 
 		// Subscription Plan
@@ -255,7 +255,7 @@ class Language extends \Opencart\System\Engine\Model {
 		$results = $this->model_catalog_subscription_plan->getDescriptionsByLanguageId($this->config->get('config_language_id'));
 
 		foreach ($results as $subscription_plan) {
-			$this->model_catalog_subscription_plan->addDescription($subscription_plan['subscription_plan_id'], $language_id, $subscription_plan);
+			$this->model_catalog_subscription_plan->addDescription((int)$subscription_plan['subscription_plan_id'], $language_id, $subscription_plan);
 		}
 
 		// Subscription Status
@@ -264,7 +264,7 @@ class Language extends \Opencart\System\Engine\Model {
 		$results = $this->model_localisation_subscription_status->getDescriptionsByLanguageId($this->config->get('config_language_id'));
 
 		foreach ($results as $subscription) {
-			$this->model_localisation_subscription_status->addDescription($subscription['subscription_status_id'], $language_id, $subscription);
+			$this->model_localisation_subscription_status->addDescription((int)$subscription['subscription_status_id'], $language_id, $subscription);
 		}
 
 		// SEO
@@ -301,7 +301,7 @@ class Language extends \Opencart\System\Engine\Model {
 		$results = $this->model_cms_topic->getDescriptionsByLanguageId($this->config->get('config_language_id'));
 
 		foreach ($results as $topic) {
-			$this->model_cms_topic->addDescription($topic['topic_id'], $language_id, $topic);
+			$this->model_cms_topic->addDescription((int)$topic['topic_id'], $language_id, $topic);
 		}
 
 		// Zone
@@ -310,7 +310,7 @@ class Language extends \Opencart\System\Engine\Model {
 		$results = $this->model_localisation_zone->getDescriptionsByLanguageId($this->config->get('config_language_id'));
 
 		foreach ($results as $zone) {
-			$this->model_localisation_zone->addDescription($zone['zone_id'], $language_id, $zone);
+			$this->model_localisation_zone->addDescription((int)$zone['zone_id'], $language_id, $zone);
 		}
 
 		return $language_id;


### PR DESCRIPTION
### PHPStan Spring Cleaning: Fix Parameter Types in Language Model

Convert string ID parameters to `int` type when calling model methods in the language model `addLanguage()` method.

#### Problem
Database query results return ID values as strings, but model methods like `addDescription()` and `addAttribute()` expect `int` parameters. This causes type mismatch errors throughout the language model.

#### PHPStan Errors Fixed
- `Parameter #1 $attribute_id of method addDescription() expects int, string given` (×22 occurrences)
- `Parameter #1 $product_id of method addAttribute() expects int, string given` 
- `Parameter #2 $attribute_id of method addAttribute() expects int, string given`