### PR TITLE
fix(phpdoc): remove references to non-existent parameters

### DIFF
--- a/upload/admin/model/customer/customer.php
+++ b/upload/admin/model/customer/customer.php
@@ -1374,7 +1374,6 @@ class Customer extends \Opencart\System\Engine\Model {
 	 * Get the record of the customer authorize record in the database.
 	 *
 	 * @param int $customer_authorize_id
-	 * @param int $user_authorize_id     primary key of the user authorize record
 	 *
 	 * @return array<string, mixed> authorize record that has user authorize ID
 	 *
@@ -1489,7 +1488,6 @@ class Customer extends \Opencart\System\Engine\Model {
 	 * Delete Token By Code
 	 *
 	 * @param string $code
-	 * @param int    $customer_id primary key of the customer record
 	 *
 	 * @return void
 	 *

--- a/upload/admin/model/sale/subscription.php
+++ b/upload/admin/model/sale/subscription.php
@@ -435,10 +435,8 @@ class Subscription extends \Opencart\System\Engine\Model {
 	 *
 	 * Get the record of the subscription option records in the database.
 	 *
-	 * @param int $subscription_id         primary key of the subscription record
-	 * @param int $subscription_product_id primary key of the subscription product record
-	 * @param int $order_id                primary key of the order record
-	 * @param int $order_product_id        primary key of the order product record
+	 * @param  int  $subscription_id  primary key of the subscription record
+	 * @param  int  $subscription_product_id  primary key of the subscription product record
 	 *
 	 * @return array<int, array<string, mixed>> option records that have subscription ID, subscription product ID
 	 *

--- a/upload/admin/model/tool/menu.php
+++ b/upload/admin/model/tool/menu.php
@@ -13,9 +13,7 @@ class Menu extends \Opencart\System\Engine\Model {
 	 *
 	 * Create a new menu record in the database.
 	 *
-	 * @param string $code
-	 * @param string $route
-	 * @param bool   $status
+	 * @param array<string, mixed> $data
 	 *
 	 * @return int
 	 *
@@ -37,6 +35,14 @@ class Menu extends \Opencart\System\Engine\Model {
 		return $menu_id;
 	}
 
+	/**
+	 * Edit Menu
+	 *
+	 * @param int                  $menu_id primary key of the menu record
+	 * @param array<string, mixed> $data    array of data
+	 *
+	 * @return void
+	 */
 	public function editMenu(int $menu_id, array $data): void {
 		$menu_info = $this->getMenu($menu_id);
 
@@ -56,7 +62,7 @@ class Menu extends \Opencart\System\Engine\Model {
 	/**
 	 * Delete Menu By Code
 	 *
-	 * @param string $code
+	 * @param string $menu_id primary key of the menu record
 	 *
 	 * @return void
 	 *

--- a/upload/admin/model/user/user.php
+++ b/upload/admin/model/user/user.php
@@ -663,11 +663,9 @@ class User extends \Opencart\System\Engine\Model {
 	 *
 	 * Get the record of the user authorize records in the database.
 	 *
-	 * @param int $user_id
-	 * @param int $start
-	 * @param int $limit
-	 * @param int $us      \
-	 *                     'er_id primary key of the user record
+	 * @param  int  $user_id  primary key of the user record
+	 * @param  int  $start
+	 * @param  int  $limit
 	 *
 	 * @return array<int, array<string, mixed>> authorize records
 	 *
@@ -721,33 +719,19 @@ class User extends \Opencart\System\Engine\Model {
 	}
 
 	/**
-	 * Reset Customer Au
-	 * th
-	 * o
-	 * ri
-	 * zes
+	 * Reset User Authorizes
 	 *
-	 * @
-	 * para
-	 * m
-	 * int
-	 * $
-	 * us
-	 * er
-	 * _id pr
-	 * imary
-	 * key of th
-	 * e customer recor
-	 * d
+	 * Reset user authorize record in the database.
 	 *
-	 * @ret
-	 * urn void
+	 * @param int $user_id primary key of the user record
 	 *
-	 * @
-	 * exa
-	 * mple
+	 * @return void
 	 *
-	 * @param int $user_id
+	 * @example
+	 *
+	 * $this->load->model('user/user');
+	 *
+	 * $this->model_user_user->resetAuthorizes($user_id);
 	 */
 	public function resetAuthorizes(int $user_id): void {
 		$this->db->query("UPDATE `" . DB_PREFIX . "user_authorize` SET `total` = '0' WHERE `user_id` = '" . (int)$user_id . "'");
@@ -758,12 +742,11 @@ class User extends \Opencart\System\Engine\Model {
 	 *
 	 * Create a new user token record in the database.
 	 *
-	 * @param int    $user_id primary key of the user record
-	 * @param string $type
-	 * @param string $code
-	 * @param string $codev
+	 * @param  int  $user_id  primary key of the user record
+	 * @param  string  $type
+	 * @param  string  $code
 	 *
-	 * @return int total number of authorize records that have user ID, token
+	 * @return void
 	 *
 	 * @example
 	 *
@@ -802,7 +785,6 @@ class User extends \Opencart\System\Engine\Model {
 	 * Delete Token By Code
 	 *
 	 * @param string $code
-	 * @param int    $customer_id primary key of the customer record
 	 *
 	 * @return void
 	 *


### PR DESCRIPTION
### PHPStan Spring Cleaning: Remove References to Non-Existent Parameters

Remove PHPDoc `@param` tags that reference parameters not present in method signatures across multiple model classes.

#### Problem
PHPDoc blocks contained `@param` tags for parameters that don't exist in the actual method signatures, causing PHPStan to report "PHPDoc tag `@param` references unknown parameter" errors.

#### PHPStan Errors Fixed
- `PHPDoc tag @param references unknown parameter: $user_authorize_id` in customer model
- `PHPDoc tag @param references unknown parameter: $customer_id` in customer model  
- `PHPDoc tag @param references unknown parameter: $order_id` in subscription model
- `PHPDoc tag @param references unknown parameter: $order_product_id` in subscription model
- `PHPDoc tag @param references unknown parameter: $us` in user model
- `PHPDoc tag @param references unknown parameter: $codev` in user model
- `PHPDoc tag @param references unknown parameter: $customer_id` in user model
- `PHPDoc tag @param references unknown parameter: $code` in menu model
- `PHPDoc tag @param references unknown parameter: $route` in menu model
- `PHPDoc tag @param references unknown parameter: $status` in menu model

#### Additional Fixes
- Restored corrupted PHPDoc block for `resetAuthorizes()` method in user model
- Corrected incorrect `@return` type from int to void in `addToken()` method