### PR TITLE
fix(phpdoc): remove invalid `@param` references across multiple files

### DIFF
--- a/upload/admin/model/catalog/review.php
+++ b/upload/admin/model/catalog/review.php
@@ -345,7 +345,7 @@ class Review extends \Opencart\System\Engine\Model {
 	 *
 	 * Edit review status record in the database.
 	 *
-	 * @param int  $product_id primary key of the product record
+	 * @param int  $review_id primary key of the product record
 	 * @param bool $status
 	 *
 	 * @return void

--- a/upload/admin/model/customer/customer_group.php
+++ b/upload/admin/model/customer/customer_group.php
@@ -250,7 +250,7 @@ class CustomerGroup extends \Opencart\System\Engine\Model {
 	}
 
 	/*
-     * Get Description
+	 * Get Description
 	 *
 	 * Get the record of the country description records in the database.
 	 *

--- a/upload/admin/model/localisation/country.php
+++ b/upload/admin/model/localisation/country.php
@@ -521,7 +521,7 @@ class Country extends \Opencart\System\Engine\Model {
 	 *
 	 * Get the record of the information store records in the database.
 	 *
-	 * @param int $information_id primary key of the store record
+	 * @param int $country_id primary key of the store record
 	 *
 	 * @return array<int, int> store records that have store ID
 	 *
@@ -529,7 +529,7 @@ class Country extends \Opencart\System\Engine\Model {
 	 *
 	 * $this->load->model('catalog/information');
 	 *
-	 * $stores = $this->model_catalog_information->getStores($istore_id);
+	 * $stores = $this->model_catalog_information->getStores($country_id);
 	 */
 	public function getStores(int $country_id): array {
 		$country_store_data = [];

--- a/upload/admin/model/localisation/identifier.php
+++ b/upload/admin/model/localisation/identifier.php
@@ -173,8 +173,6 @@ class Identifier extends \Opencart\System\Engine\Model {
 	 *
 	 * Get the total number of identifier records in the database.
 	 *
-	 * @param array<string, mixed> $data array of filters
-	 *
 	 * @return int total number of identifier records
 	 *
 	 * @example

--- a/upload/admin/model/localisation/zone.php
+++ b/upload/admin/model/localisation/zone.php
@@ -300,6 +300,22 @@ class Zone extends \Opencart\System\Engine\Model {
 		$this->db->query("DELETE FROM `" . DB_PREFIX . "zone_description` WHERE `language_id` = '" . (int)$language_id . "'");
 	}
 
+	/**
+	 * Get Description
+	 *
+	 * Get the record of the zone description record in the database.
+	 *
+	 * @param int $zone_id primary key of the zone record
+	 * @param int $language_id primary key of the language record
+	 *
+	 * @return array<string, mixed> description record that has zone ID and language ID
+	 *
+	 * @example
+	 *
+	 * $this->load->model('localisation/zone');
+	 *
+	 * $zone_description = $this->model_localisation_zone->getDescription($zone_id, $language_id);
+	 */
 	public function getDescription(int $zone_id, $language_id): array {
 		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "zone_description` WHERE `zone_id` = '" . (int)$zone_id . "' AND `language_id` = '" . (int)$language_id . "'");
 

--- a/upload/admin/model/tool/menu.php
+++ b/upload/admin/model/tool/menu.php
@@ -133,8 +133,6 @@ class Menu extends \Opencart\System\Engine\Model {
 	 *
 	 * Get the record of the menu records in the database.
 	 *
-	 * @param array<string, mixed> $data array of filters
-	 *
 	 * @return array<int, array<string, mixed>> menu records
 	 *
 	 * @example

--- a/upload/catalog/model/account/customer.php
+++ b/upload/catalog/model/account/customer.php
@@ -589,7 +589,6 @@ class Customer extends \Opencart\System\Engine\Model {
 	 * Delete Token By Code
 	 *
 	 * @param string $code
-	 * @param int    $customer_id primary key of the customer record
 	 *
 	 * @return void
 	 *
@@ -597,7 +596,7 @@ class Customer extends \Opencart\System\Engine\Model {
 	 *
 	 * $this->load->model('account/customer');
 	 *
-	 * $this->model_account_customer->deleteToken($customer_id);
+	 * $this->model_account_customer->deleteTokenByCode($code);
 	 */
 	public function deleteTokenByCode(string $code): void {
 		$this->db->query("DELETE FROM `" . DB_PREFIX . "customer_token` WHERE `code` = '" . $this->db->escape($code) . "'");

--- a/upload/catalog/model/catalog/product.php
+++ b/upload/catalog/model/catalog/product.php
@@ -25,16 +25,16 @@ class Product extends \Opencart\System\Engine\Model {
 		$this->statement['discount'] = "(SELECT (CASE WHEN `pd2`.`type` = 'P' THEN (`p`.`price` - (`p`.`price` * (`pd2`.`price` / 100))) WHEN `pd2`.`type` = 'S' THEN (`p`.`price` - `pd2`.`price`) ELSE `pd2`.`price` END) FROM `" . DB_PREFIX . "product_discount` `pd2` WHERE `pd2`.`product_id` = `p`.`product_id` AND `pd2`.`customer_group_id` = '" . (int)$this->config->get('config_customer_group_id') . "' AND `pd2`.`quantity` = '1' AND `pd2`.`special` = '0' AND ((`pd2`.`date_start` = '0000-00-00' OR `pd2`.`date_start` < NOW()) AND (`pd2`.`date_end` = '0000-00-00' OR `pd2`.`date_end` > NOW())) ORDER BY `pd2`.`priority` ASC, `pd2`.`price` ASC LIMIT 1) AS `discount`";
 
 		$this->statement['special'] = "(SELECT (
-		CASE WHEN `ps`.`type` = 'P' 
-		THEN (`p`.`price` - (`p`.`price` * (`ps`.`price` / 100))) 
-		WHEN `ps`.`type` = 'S' THEN (`p`.`price` - `ps`.`price`) 
+		CASE WHEN `ps`.`type` = 'P'
+		THEN (`p`.`price` - (`p`.`price` * (`ps`.`price` / 100)))
+		WHEN `ps`.`type` = 'S' THEN (`p`.`price` - `ps`.`price`)
 		ELSE `ps`.`price` END)
-		FROM `" . DB_PREFIX . "product_discount` `ps` 
-		WHERE `ps`.`product_id` = `p`.`product_id` 
-		AND `ps`.`customer_group_id` = '" . (int)$this->config->get('config_customer_group_id') . "' 
-		AND `ps`.`quantity` = '1' 
-		AND `ps`.`special` = '1' 
-		AND ((`ps`.`date_start` = '0000-00-00' OR `ps`.`date_start` < NOW()) AND (`ps`.`date_end` = '0000-00-00' OR `ps`.`date_end` > NOW())) 
+		FROM `" . DB_PREFIX . "product_discount` `ps`
+		WHERE `ps`.`product_id` = `p`.`product_id`
+		AND `ps`.`customer_group_id` = '" . (int)$this->config->get('config_customer_group_id') . "'
+		AND `ps`.`quantity` = '1'
+		AND `ps`.`special` = '1'
+		AND ((`ps`.`date_start` = '0000-00-00' OR `ps`.`date_start` < NOW()) AND (`ps`.`date_end` = '0000-00-00' OR `ps`.`date_end` > NOW()))
 		ORDER BY `ps`.`priority` ASC, `ps`.`price` ASC LIMIT 1) AS `special`";
 
 
@@ -47,11 +47,10 @@ class Product extends \Opencart\System\Engine\Model {
 	 *
 	 * Edit product quantity record in the database.
 	 *
-	 * @param int                  $product_id primary key of the product record
-	 * @param int                  $quantity
-	 * @param array<string, mixed> $data       array of data
+	 * @param int $product_id primary key of the product record
+	 * @param int $quantity
 	 *
-	 * @return int
+	 * @return void
 	 *
 	 * @example
 	 *

--- a/upload/catalog/model/checkout/order.php
+++ b/upload/catalog/model/checkout/order.php
@@ -440,8 +440,7 @@ class Order extends \Opencart\System\Engine\Model {
 	 *
 	 * Delete order product record in the database.
 	 *
-	 * @param int $order_id         primary key of the order record
-	 * @param int $order_product_id primary key of the order product record
+	 * @param int $order_id primary key of the order record
 	 *
 	 * @return void
 	 *
@@ -535,8 +534,7 @@ class Order extends \Opencart\System\Engine\Model {
 	 *
 	 * Delete order option records in the database.
 	 *
-	 * @param int $order_id         primary key of the order record
-	 * @param int $order_product_id primary key of the order product record
+	 * @param int $order_id primary key of the order record
 	 *
 	 * @return void
 	 *
@@ -614,8 +612,7 @@ class Order extends \Opencart\System\Engine\Model {
 	 *
 	 * Delete order subscription record in the database.
 	 *
-	 * @param int $order_id         primary key of the order record
-	 * @param int $order_product_id primary key of the order product record
+	 * @param int $order_id primary key of the order record
 	 *
 	 * @return void
 	 *

--- a/upload/system/library/cart/cart.php
+++ b/upload/system/library/cart/cart.php
@@ -306,12 +306,11 @@ class Cart {
 	/**
 	 * Add
 	 *
-	 * @param int          $product_id           primary key of the product record
-	 * @param int          $quantity
-	 * @param array<mixed> $option
-	 * @param int          $subscription_plan_id primary key of the subscription plan record
-	 * @param array        $override
-	 * @param float        $price
+	 * @param int   $product_id primary key of the product record
+	 * @param int   $quantity
+	 * @param array $option
+	 * @param int   $subscription_plan_id primary key of the subscription plan record
+	 * @param array $override
 	 *
 	 * @return void
 	 *


### PR DESCRIPTION
### PHPStan Spring Cleaning: Fix Invalid PHPDoc Parameter References

Remove incorrect `@param` tags that reference non-existent parameters across models and system libraries to eliminate PHPStan parameter.notFound errors.

#### PHPStan Errors Fixed
- Invalid `@param $product_id` reference in `editStatus()` method (expects `$review_id`) in `admin/model/catalog/review.php`
- Invalid `@param $information_id` reference in `getStores()` method (expects `$country_id`) in `admin/model/localisation/country.php`
- Invalid `@param $data` references in parameterless methods `getTotalIdentifiers()` and `getMenus()` in `admin/model/localisation/identifier.php` and `admin/model/tool/menu.php`
- Invalid `@param $customer_id` reference in `deleteTokenByCode()` method (not used) in `catalog/model/account/customer.php`
- Invalid `@param $data` and incorrect `@return int` (should be `void`) in `editQuantity()` method in `catalog/model/catalog/product.php`
- Invalid `@param $order_product_id` references in order deletion methods (`deleteProducts()`, `deleteOptions()`, `deleteSubscription()`) in `catalog/model/checkout/order.php`
- Invalid `@param $price` reference in `add()` method (not used) in `system/library/cart/cart.php`