### PR TITLE
fix(error-handling): remove unreachable return statements after throw

### DIFF
--- a/upload/admin/controller/startup/error.php
+++ b/upload/admin/controller/startup/error.php
@@ -27,6 +27,7 @@ class Error extends \Opencart\System\Engine\Controller {
 	 * @param int    $line
 	 *
 	 * @return bool
+	 * @throws \ErrorException
 	 */
 	public function error(int $code, string $message, string $file, int $line): bool {
 		// error suppressed with @
@@ -35,8 +36,6 @@ class Error extends \Opencart\System\Engine\Controller {
 		}
 
 		throw new \ErrorException($message, 0, $code, $file, $line);
-
-		return true;
 	}
 
 	/**

--- a/upload/catalog/controller/startup/error.php
+++ b/upload/catalog/controller/startup/error.php
@@ -27,6 +27,7 @@ class Error extends \Opencart\System\Engine\Controller {
 	 * @param int    $line
 	 *
 	 * @return bool
+	 * @throws \ErrorException
 	 */
 	public function error(int $code, string $message, string $file, int $line): bool {
 		// error suppressed with @
@@ -35,8 +36,6 @@ class Error extends \Opencart\System\Engine\Controller {
 		}
 
 		throw new \ErrorException($message, 0, $code, $file, $line);
-
-		return true;
 	}
 
 	/**

--- a/upload/system/framework.php
+++ b/upload/system/framework.php
@@ -40,8 +40,6 @@ set_error_handler(function(int $code, string $message, string $file, int $line) 
 	}
 
 	throw new \ErrorException($message, 0, $code, $file, $line);
-
-	return true;
 });
 
 // Exception Handler


### PR DESCRIPTION
### PHPStan Spring Cleaning: Remove Unreachable Return Statements After Throw

Remove unreachable `return true;` statements that follow `throw new \ErrorException()` in error handlers and improve PHPDoc documentation.

#### PHPStan Errors Fixed
- `Unreachable statement - code above always terminates` in admin/controller/startup/error.php:39
- `Unreachable statement - code above always terminates` in catalog/controller/startup/error.php:39  
- `Unreachable statement - code above always terminates` in system/framework.php:44

#### Additional Improvements
- Added `@throws \ErrorException` documentation to PHPDoc blocks