### PR TITLE
style(request): remove unreachable break statements

### DIFF
--- a/upload/system/library/request.php
+++ b/upload/system/library/request.php
@@ -55,19 +55,14 @@ class Request {
 		switch ($type) {
 			case 'string':
 				return (string)$value;
-				break;
 			case 'int':
 				return (int)$value;
-				break;
 			case 'float':
 				return (float)$value;
-				break;
 			case 'bool':
 				return (bool)$value;
-				break;
 			case 'array':
 				return (array)$value;
-				break;
 			default:
 				return $value;
 		}
@@ -83,19 +78,14 @@ class Request {
 		switch ($type) {
 			case 'string':
 				return (string)$value;
-				break;
 			case 'int':
 				return (int)$value;
-				break;
 			case 'float':
 				return (float)$value;
-				break;
 			case 'bool':
 				return (bool)$value;
-				break;
 			case 'array':
 				return (array)$value;
-				break;
 			default:
 				return $value;
 		}


### PR DESCRIPTION
### PHPStan Spring Cleaning: Remove Unreachable Break Statements in Switch Cases

Remove unreachable `break` statements that follow `return` statements in switch cases within request parameter type casting methods.

#### Problem
Switch cases contained `break` statements immediately after `return` statements. Since `return` terminates function execution, these `break` statements are never reached, causing PHPStan to report multiple "Unreachable statement - code above always terminates" errors.

#### PHPStan Errors Fixed
- 10 "Unreachable statement" errors in `system/library/request.php` (lines 58, 61, 64, 67, 70, 86, 89, 92, 95, 98)
- Affects both `get()` and `post()` methods with identical switch case structures

#### Code Quality Impact
- Cleaner, more maintainable code structure
- Eliminates dead code that could confuse developers
- Follows PHP best practices for switch statements with early returns
- No functional changes - behavior remains identical