### PR TITLE
fix(types): correct argument types in method calls

### DIFF
--- a/upload/admin/controller/tool/menu.php
+++ b/upload/admin/controller/tool/menu.php
@@ -414,7 +414,7 @@ class Menu extends \Opencart\System\Engine\Controller {
 			$this->load->model('tool/menu');
 
 			foreach ($selected as $menu_id) {
-				$this->model_tool_menu->deleteMenu($menu_id);
+				$this->model_tool_menu->deleteMenu((int)$menu_id);
 			}
 
 			$json['success'] = $this->language->get('text_success');

--- a/upload/admin/model/design/seo_url.php
+++ b/upload/admin/model/design/seo_url.php
@@ -297,8 +297,8 @@ class SeoUrl extends \Opencart\System\Engine\Model {
 	/**
 	 * Get Seo Urls By Key Value
 	 *
-	 * @param string $key
-	 * @param string $value
+	 * @param string     $key
+	 * @param int|string $value
 	 *
 	 * @return array<int, array<int, string>>
 	 *
@@ -308,7 +308,7 @@ class SeoUrl extends \Opencart\System\Engine\Model {
 	 *
 	 * $results = $this->model_design_seo_url->getSeoUrlsByKeyValue($key, $value);
 	 */
-	public function getSeoUrlsByKeyValue(string $key, string $value): array {
+	public function getSeoUrlsByKeyValue(string $key, int|string $value): array {
 		$seo_url_data = [];
 
 		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "seo_url` WHERE `key` = '" . $this->db->escape($key) . "' AND `value` LIKE '" . $this->db->escape($value) . "'");

--- a/upload/admin/model/tool/menu.php
+++ b/upload/admin/model/tool/menu.php
@@ -56,7 +56,7 @@ class Menu extends \Opencart\System\Engine\Model {
 	/**
 	 * Delete Menu By Code
 	 *
-	 * @param string $code
+	 * @param int $menu_id
 	 *
 	 * @return void
 	 *
@@ -64,9 +64,9 @@ class Menu extends \Opencart\System\Engine\Model {
 	 *
 	 * $this->load->model('tool/menu');
 	 *
-	 * $this->model_tool_menu->deleteMenuByCode($code);
+	 * $this->model_tool_menu->deleteMenu($menu_id);
 	 */
-	public function deleteMenu(string $menu_id): void {
+	public function deleteMenu(int $menu_id): void {
 		$menu_info = $this->getMenu($menu_id);
 
 		if ($menu_info) {
@@ -96,7 +96,7 @@ class Menu extends \Opencart\System\Engine\Model {
 		$results = $this->getMenuByCode($code);
 
 		foreach ($results as $result) {
-			$this->model_tool_menu->deleteMenu($result['menu_id']);
+			$this->model_tool_menu->deleteMenu((int)$result['menu_id']);
 		}
 	}
 

--- a/upload/catalog/model/account/returns.php
+++ b/upload/catalog/model/account/returns.php
@@ -122,6 +122,8 @@ class Returns extends \Opencart\System\Engine\Model {
 	 * Get the record of the return history records in the database.
 	 *
 	 * @param int $return_id primary key of the return record
+	 * @param int $start
+	 * @param int $limit
 	 *
 	 * @return array<int, array<string, mixed>> history records
 	 *
@@ -129,10 +131,18 @@ class Returns extends \Opencart\System\Engine\Model {
 	 *
 	 * $this->load->model('account/returns');
 	 *
-	 * $results = $this->model_account_returns->getHistories($return_id);
+	 * $results = $this->model_account_returns->getHistories($return_id, $start, $limit);
 	 */
-	public function getHistories(int $return_id): array {
-		$query = $this->db->query("SELECT `rh`.`date_added`, `rs`.`name` AS `status`, `rh`.`comment` FROM `" . DB_PREFIX . "return_history` `rh` LEFT JOIN `" . DB_PREFIX . "return_status` `rs` ON (`rh`.`return_status_id` = `rs`.`return_status_id`) WHERE `rh`.`return_id` = '" . (int)$return_id . "' AND `rs`.`language_id` = '" . (int)$this->config->get('config_language_id') . "' ORDER BY `rh`.`date_added` ASC");
+	public function getHistories(int $return_id, int $start = 0, int $limit = 10): array {
+		if ($start < 0) {
+			$start = 0;
+		}
+
+		if ($limit < 1) {
+			$limit = 10;
+		}
+
+		$query = $this->db->query("SELECT `rh`.`date_added`, `rs`.`name` AS `status`, `rh`.`comment` FROM `" . DB_PREFIX . "return_history` `rh` LEFT JOIN `" . DB_PREFIX . "return_status` `rs` ON (`rh`.`return_status_id` = `rs`.`return_status_id`) WHERE `rh`.`return_id` = '" . (int)$return_id . "' AND `rs`.`language_id` = '" . (int)$this->config->get('config_language_id') . "' ORDER BY `rh`.`date_added` ASC LIMIT " . (int)$start . "," . (int)$limit);
 
 		return $query->rows;
 	}

--- a/upload/extension/opencart/catalog/model/payment/free_checkout.php
+++ b/upload/extension/opencart/catalog/model/payment/free_checkout.php
@@ -28,7 +28,7 @@ class FreeCheckout extends \Opencart\System\Engine\Model {
 
 		($this->model_checkout_cart->getTotals)($totals, $taxes, $total);
 
-		if ($this->currency->format($total, $this->config->get('config_currency'), false, false) <= 0.00) {
+		if ($this->currency->format($total, $this->config->get('config_currency'), 0.0, false) <= 0.00) {
 			$status = true;
 		} elseif ($this->cart->hasSubscription()) {
 			$status = false;


### PR DESCRIPTION
### PHPStan Spring Cleaning: Fix Incorrect Argument Types in Method Calls

Correct argument types passed to methods that were causing PHPStan type mismatch errors across multiple models and controllers.

#### PHPStan Errors Fixed
- `Parameter #2 $value of method getSeoUrlsByKeyValue() expects string, int given` in admin/controller/catalog/product.php:1217
- `Parameter #3 $value of method Currency::format() expects float, false given` in extension/opencart/catalog/model/payment/free_checkout.php:31
- `Parameter #1 $menu_id of method getMenu() expects int, string given` in admin/model/tool/menu.php:76
- `Parameter #1 $menu_id of method deleteDescriptions() expects int, string given` in admin/model/tool/menu.php:84
- `Method getHistories() invoked with 3 parameters, 1 required` in catalog/controller/account/returns.php:513
