### PR TITLE
fix(phpdoc): correct return type documentation mismatches

### DIFF
--- a/upload/catalog/controller/product/related.php
+++ b/upload/catalog/controller/product/related.php
@@ -11,7 +11,7 @@ class Related extends \Opencart\System\Engine\Controller {
 	/**
 	 * Index
 	 *
-	 * @return ?\Opencart\System\Engine\Action
+	 * @return string
 	 */
 	public function index(): string {
 		$this->load->language('product/related');
@@ -71,6 +71,5 @@ class Related extends \Opencart\System\Engine\Controller {
 		}
 
 		return $this->load->view('product/related', $data);
-
 	}
 }

--- a/upload/catalog/controller/startup/language.php
+++ b/upload/catalog/controller/startup/language.php
@@ -15,7 +15,7 @@ class Language extends \Opencart\System\Engine\Controller {
 	/**
 	 * Index
 	 *
-	 * @return void
+	 * @return ?\Opencart\System\Engine\Action
 	 */
 	public function index(): ?\Opencart\System\Engine\Action {
 		// Languages


### PR DESCRIPTION
### PHPStan Spring Cleaning: Fix PHPDoc Return Type Documentation Mismatches

Correct PHPDoc `@return` type annotations to match actual method return types, eliminating PHPStan "incompatible with native type" errors.

#### PHPStan Errors Fixed
- `PHPDoc tag @return with type Opencart\System\Engine\Action|null is incompatible with native type string` in catalog/controller/product/related.php:16
- `PHPDoc tag @return with type void is incompatible with native type Opencart\System\Engine\Action|null` in catalog/controller/startup/language.php:20