### PR TITLE
fix(url-class): Declare missing properties for parse_url

### DIFF
--- a/upload/system/library/url.php
+++ b/upload/system/library/url.php
@@ -24,6 +24,8 @@ class Url {
 	private string $path;
 	private string $query;
 	private string $fragment;
+	private ?string $user = null;
+	private ?string $pass = null;
 
 	/**
 	 * @var array<int, object>
@@ -33,7 +35,9 @@ class Url {
 	/**
 	 * Constructor
 	 *
-	 * @param string $url
+	 * Parses the URL string and sets the corresponding properties of the class.
+	 *
+	 * @param string $url The URL string to parse.
 	 */
 	public function __construct(string $url) {
 		$this->url = $url;
@@ -41,7 +45,9 @@ class Url {
 		$parts = parse_url($url);
 
 		foreach ($parts as $key => $value) {
-			$this->{$key} = $value;
+			if (property_exists($this, $key)) {
+				$this->{$key} = $value;
+			}
 		}
 	}
 


### PR DESCRIPTION
### Fix: Declare Missing Properties in URL Class for PHPStan Compliance

This commit addresses PHPStan warnings related to undefined properties (`property.notFound`) in the `Url` class. It declares the `$user` and `$pass` properties, which are potentially returned by `parse_url()`, ensuring the class is more robust and complies with static analysis.

The constructor has also been refactored to safely assign values from `parse_url()` using `property_exists()`, preventing potential runtime errors if `parse_url()` returns unexpected keys or if properties are not declared.

#### PHPStan Errors Fixed:
- `property.notFound` for `$user` in `system/library/url.php`
- `property.notFound` for `$pass` in `system/library/url.php`

#### Changes Made:
- Added declarations for `private ?string $user = null;` and `private ?string $pass = null;` to the `Url` class.
- Updated the constructor to use `property_exists()` for safer assignment of properties from `parse_url()`.

Signed-off-by: Anton Semenov <20430159+trydalcoholic@users.noreply.github.com>