### PR TITLE
fix(phpstan): add missing return types for controller methods

### DIFF
--- a/upload/admin/controller/ssr/admin/custom_field.php
+++ b/upload/admin/controller/ssr/admin/custom_field.php
@@ -26,7 +26,7 @@ class CustomField extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function clear() {
+	public function clear(): void {
 		$this->load->language('ssr/language');
 
 		$json = [];

--- a/upload/admin/controller/ssr/admin/customer_group.php
+++ b/upload/admin/controller/ssr/admin/customer_group.php
@@ -11,7 +11,7 @@ class CustomerGroup extends \Opencart\System\Engine\Controller {
 	 *
 	 * @return void
 	 */
-	public function index() {
+	public function index(): void {
 		$this->load->language('ssr/admin/customer_group');
 
 		$json = [];
@@ -66,7 +66,7 @@ class CustomerGroup extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function clear() {
+	public function clear(): void {
 		$this->load->language('ssr/admin/customer_group');
 
 		$json = [];

--- a/upload/admin/controller/ssr/admin/language.php
+++ b/upload/admin/controller/ssr/admin/language.php
@@ -11,7 +11,7 @@ class Language extends \Opencart\System\Engine\Controller {
 	 *
 	 * @return void
 	 */
-	public function index() {
+	public function index(): void {
 		$this->load->language('ssr/admin/language');
 
 		$json = [];
@@ -52,7 +52,7 @@ class Language extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function clear() {
+	public function clear(): void {
 		$this->load->language('ssr/admin/language');
 
 		$json = [];

--- a/upload/admin/controller/ssr/admin/length_class.php
+++ b/upload/admin/controller/ssr/admin/length_class.php
@@ -26,7 +26,7 @@ class CustomField extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function clear() {
+	public function clear(): void {
 		$this->load->language('ssr/language');
 
 		$json = [];

--- a/upload/admin/controller/ssr/admin/option.php
+++ b/upload/admin/controller/ssr/admin/option.php
@@ -26,7 +26,7 @@ class CustomField extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function clear() {
+	public function clear(): void {
 		$this->load->language('ssr/language');
 
 		$json = [];

--- a/upload/admin/controller/ssr/admin/order_status.php
+++ b/upload/admin/controller/ssr/admin/order_status.php
@@ -26,7 +26,7 @@ class CustomField extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function clear() {
+	public function clear(): void {
 		$this->load->language('ssr/language');
 
 		$json = [];

--- a/upload/admin/controller/ssr/admin/return_reason.php
+++ b/upload/admin/controller/ssr/admin/return_reason.php
@@ -26,7 +26,7 @@ class CustomField extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function clear() {
+	public function clear(): void {
 		$this->load->language('ssr/language');
 
 		$json = [];

--- a/upload/admin/controller/ssr/admin/store.php
+++ b/upload/admin/controller/ssr/admin/store.php
@@ -11,7 +11,7 @@ class Stores extends \Opencart\System\Engine\Controller {
 	 *
 	 * @return void
 	 */
-	public function index() {
+	public function index(): void {
 		$this->load->language('ssr/admin/store');
 
 		$json = [];
@@ -64,7 +64,7 @@ class Stores extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function clear() {
+	public function clear(): void {
 		$this->load->language('ssr/catalog/store');
 
 		$json = [];

--- a/upload/admin/controller/ssr/admin/translation.php
+++ b/upload/admin/controller/ssr/admin/translation.php
@@ -26,7 +26,7 @@ class CustomField extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function clear() {
+	public function clear(): void {
 		$this->load->language('ssr/language');
 
 		$json = [];

--- a/upload/admin/controller/ssr/admin/weight_class.php
+++ b/upload/admin/controller/ssr/admin/weight_class.php
@@ -26,7 +26,7 @@ class CustomField extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function clear() {
+	public function clear(): void {
 		$this->load->language('ssr/language');
 
 		$json = [];

--- a/upload/admin/controller/ssr/catalog/article.php
+++ b/upload/admin/controller/ssr/catalog/article.php
@@ -11,7 +11,7 @@ class Article extends \Opencart\System\Engine\Controller {
 	 *
 	 * @return void
 	 */
-	public function index() {
+	public function index(): void {
 		$this->load->language('ssr/article');
 
 		$json = [];
@@ -86,7 +86,7 @@ class Article extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function clear() {
+	public function clear(): void {
 		$this->load->language('ssr/category');
 
 		$json = [];

--- a/upload/admin/controller/ssr/catalog/banner.php
+++ b/upload/admin/controller/ssr/catalog/banner.php
@@ -26,7 +26,7 @@ class CustomField extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function clear() {
+	public function clear(): void {
 		$this->load->language('ssr/language');
 
 		$json = [];

--- a/upload/admin/controller/ssr/catalog/category.php
+++ b/upload/admin/controller/ssr/catalog/category.php
@@ -11,7 +11,7 @@ class Article extends \Opencart\System\Engine\Controller {
 	 *
 	 * @return void
 	 */
-	public function index() {
+	public function index(): void {
 		$this->load->language('ssr/category');
 
 		$json = [];
@@ -36,7 +36,7 @@ class Article extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function clear() {
+	public function clear(): void {
 		$this->load->language('ssr/category');
 
 		$json = [];

--- a/upload/admin/controller/ssr/catalog/country.php
+++ b/upload/admin/controller/ssr/catalog/country.php
@@ -96,7 +96,7 @@ class Country extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function info() {
+	public function info(): void {
 		$this->load->language('ssr/catalog/country');
 
 		$json = [];
@@ -206,7 +206,7 @@ class Country extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function clear() {
+	public function clear(): void {
 		$this->load->language('ssr/catalog/language');
 
 		$json = [];

--- a/upload/admin/controller/ssr/catalog/currency.php
+++ b/upload/admin/controller/ssr/catalog/currency.php
@@ -12,7 +12,7 @@ class Currency extends \Opencart\System\Engine\Controller {
 	 * @return void
 	 *
 	 */
-	public function index() {
+	public function index(): void {
 		$this->load->language('ssr/catalog/currency');
 
 		$json = [];
@@ -81,7 +81,7 @@ class Currency extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function clear() {
+	public function clear(): void {
 		$this->load->language('ssr/catalog/currency');
 
 		$json = [];

--- a/upload/admin/controller/ssr/catalog/custom_field.php
+++ b/upload/admin/controller/ssr/catalog/custom_field.php
@@ -26,7 +26,7 @@ class CustomField extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function clear() {
+	public function clear(): void {
 		$this->load->language('ssr/catalog/language');
 
 		$json = [];

--- a/upload/admin/controller/ssr/catalog/customer_group.php
+++ b/upload/admin/controller/ssr/catalog/customer_group.php
@@ -11,7 +11,7 @@ class CustomerGroup extends \Opencart\System\Engine\Controller {
 	 *
 	 * @return void
 	 */
-	public function index() {
+	public function index(): void {
 		$this->load->language('ssr/catalog/custom_group');
 
 		$json = [];
@@ -86,7 +86,7 @@ class CustomerGroup extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function clear() {
+	public function clear(): void {
 		$this->load->language('ssr/catalog/customer_group');
 
 		$json = [];

--- a/upload/admin/controller/ssr/catalog/information.php
+++ b/upload/admin/controller/ssr/catalog/information.php
@@ -11,7 +11,7 @@ class Information extends \Opencart\System\Engine\Controller {
 	 *
 	 * @return void
 	 */
-	public function index() {
+	public function index(): void {
 		$this->load->language('ssr/information');
 
 		$json = [];

--- a/upload/admin/controller/ssr/catalog/language.php
+++ b/upload/admin/controller/ssr/catalog/language.php
@@ -11,7 +11,7 @@ class Language extends \Opencart\System\Engine\Controller {
 	 *
 	 * @return void
 	 */
-	public function index() {
+	public function index(): void {
 		$this->load->language('ssr/catalog/language');
 
 		$json = [];
@@ -67,7 +67,7 @@ class Language extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function clear() {
+	public function clear(): void {
 		$this->load->language('ssr/catalog/language');
 
 		$json = [];

--- a/upload/admin/controller/ssr/catalog/length_class.php
+++ b/upload/admin/controller/ssr/catalog/length_class.php
@@ -26,7 +26,7 @@ class CustomField extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function clear() {
+	public function clear(): void {
 		$this->load->language('ssr/catalog/language');
 
 		$json = [];

--- a/upload/admin/controller/ssr/catalog/manufacturer.php
+++ b/upload/admin/controller/ssr/catalog/manufacturer.php
@@ -11,7 +11,7 @@ class Manufacturer extends \Opencart\System\Engine\Controller {
 	 *
 	 * @return void
 	 */
-	public function index() {
+	public function index(): void {
 		$this->load->language('ssr/manufacturer');
 
 		$json = [];
@@ -56,7 +56,7 @@ class Manufacturer extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function info() {
+	public function info(): void {
 		$this->load->language('ssr/manufacturer');
 
 		$json = [];
@@ -121,7 +121,7 @@ class Manufacturer extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function clear() {
+	public function clear(): void {
 		$this->load->language('catalog/manufacturer');
 
 		$json = [];

--- a/upload/admin/controller/ssr/catalog/product.php
+++ b/upload/admin/controller/ssr/catalog/product.php
@@ -11,7 +11,7 @@ class Manufacturer extends \Opencart\System\Engine\Controller {
 	 *
 	 * @return void
 	 */
-	public function index() {
+	public function index(): void {
 		$this->load->language('ssr/manufacturer');
 
 		$json = [];
@@ -24,7 +24,7 @@ class Manufacturer extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function clear() {
+	public function clear(): void {
 		$this->load->language('catalog/manufacturer');
 
 		$json = [];

--- a/upload/admin/controller/ssr/catalog/return_reason.php
+++ b/upload/admin/controller/ssr/catalog/return_reason.php
@@ -87,7 +87,7 @@ class Country extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function info() {
+	public function info(): void {
 		$this->load->language('ssr/country');
 
 		$json = [];
@@ -193,11 +193,11 @@ class Country extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function admin() {
+	public function admin(): void {
 
 	}
 
-	public function zone() {
+	public function zone(): void {
 		$this->load->language('ssr/country');
 
 		$json = [];
@@ -274,7 +274,7 @@ class Country extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function clear() {
+	public function clear(): void {
 		$this->load->language('ssr/language');
 
 		$json = [];

--- a/upload/admin/controller/ssr/catalog/store.php
+++ b/upload/admin/controller/ssr/catalog/store.php
@@ -11,7 +11,7 @@ class Currency extends \Opencart\System\Engine\Controller {
 	 *
 	 * @return void
 	 */
-	public function index() {
+	public function index(): void {
 		$this->load->language('ssr/currency');
 
 		$json = [];
@@ -69,7 +69,7 @@ class Currency extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function clear() {
+	public function clear(): void {
 		$this->load->language('ssr/currency');
 
 		$json = [];

--- a/upload/admin/controller/ssr/catalog/topic.php
+++ b/upload/admin/controller/ssr/catalog/topic.php
@@ -11,7 +11,7 @@ class Topic extends \Opencart\System\Engine\Controller {
 	 *
 	 * @return void
 	 */
-	public function index() {
+	public function index(): void {
 		$this->load->language('ssr/topic');
 
 		$json = [];

--- a/upload/admin/controller/ssr/catalog/translation.php
+++ b/upload/admin/controller/ssr/catalog/translation.php
@@ -26,7 +26,7 @@ class CustomField extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function clear() {
+	public function clear(): void {
 		$this->load->language('ssr/catalog/language');
 
 		$json = [];

--- a/upload/admin/controller/ssr/catalog/weight_class.php
+++ b/upload/admin/controller/ssr/catalog/weight_class.php
@@ -26,7 +26,7 @@ class CustomField extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function clear() {
+	public function clear(): void {
 		$this->load->language('ssr/catalog/language');
 
 		$json = [];

--- a/upload/admin/language/en-gb/ssr/admin/store.php
+++ b/upload/admin/language/en-gb/ssr/admin/store.php
@@ -11,7 +11,7 @@ class Currency extends \Opencart\System\Engine\Controller {
 	 *
 	 * @return void
 	 */
-	public function index() {
+	public function index(): void {
 		$this->load->language('ssr/currency');
 
 		$json = [];
@@ -69,7 +69,7 @@ class Currency extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function clear() {
+	public function clear(): void {
 		$this->load->language('ssr/currency');
 
 		$json = [];

--- a/upload/admin/language/en-gb/ssr/catalog/customer_group.php
+++ b/upload/admin/language/en-gb/ssr/catalog/customer_group.php
@@ -11,7 +11,7 @@ class Currency extends \Opencart\System\Engine\Controller {
 	 *
 	 * @return void
 	 */
-	public function index() {
+	public function index(): void {
 		$this->load->language('ssr/currency');
 
 		$json = [];
@@ -69,7 +69,7 @@ class Currency extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function clear() {
+	public function clear(): void {
 		$this->load->language('ssr/currency');
 
 		$json = [];

--- a/upload/admin/language/en-gb/ssr/catalog/store.php
+++ b/upload/admin/language/en-gb/ssr/catalog/store.php
@@ -11,7 +11,7 @@ class Currency extends \Opencart\System\Engine\Controller {
 	 *
 	 * @return void
 	 */
-	public function index() {
+	public function index(): void {
 		$this->load->language('ssr/currency');
 
 		$json = [];
@@ -69,7 +69,7 @@ class Currency extends \Opencart\System\Engine\Controller {
 		$this->response->setOutput(json_encode($json));
 	}
 
-	public function clear() {
+	public function clear(): void {
 		$this->load->language('ssr/currency');
 
 		$json = [];


### PR DESCRIPTION
### PHPStan Spring Cleaning: Add Missing Return Types for SSR Controller Methods

Add void return types to controller methods in SSR (Server-Side Rendering) modules to resolve PHPStan missingType.return errors.

#### PHPStan Errors Fixed
- `Method clear() has no return type specified` across multiple SSR admin controllers (custom_field.php, customer_group.php, language.php, etc.)
- `Method clear() has no return type specified` across multiple SSR catalog controllers (article.php, country.php, currency.php, etc.) 
- `Method info() has no return type specified` in SSR catalog controllers (country.php, manufacturer.php)
- `Method admin() has no return type specified` in catalog/return_reason.php
- `Method zone() has no return type specified` in catalog/return_reason.php

> [!NOTE]
> 
> **Note on Misplaced Files**
> During this fix, discovered controller files in language directories:
> - [`admin/language/en-gb/ssr/admin/store.php`](https://github.com/opencart/opencart/blob/master/upload/admin/language/en-gb/ssr/admin/store.php)
> - [`admin/language/en-gb/ssr/catalog/customer_group.php`](https://github.com/opencart/opencart/blob/master/upload/admin/language/en-gb/ssr/catalog/customer_group.php)
> - [`admin/language/en-gb/ssr/catalog/store.php`](https://github.com/opencart/opencart/blob/master/upload/admin/language/en-gb/ssr/catalog/store.php)
>
> These files appear to be misplaced during refactoring and likely should not be there.


