### PR TITLE
fix(phpstan): add missing array type specifications in PHPDoc

### DIFF
--- a/upload/admin/model/customer/customer_group.php
+++ b/upload/admin/model/customer/customer_group.php
@@ -249,20 +249,21 @@ class CustomerGroup extends \Opencart\System\Engine\Model {
 		$this->db->query("DELETE FROM `" . DB_PREFIX . "customer_group_description` WHERE `language_id` = '" . (int)$language_id . "'");
 	}
 
-	/*
+	/**
 	 * Get Description
 	 *
 	 * Get the record of the country description records in the database.
 	 *
-	 * @param int $country_id primary key of the country record
+	 * @param int $customer_group_id
+	 * @param int $language_id
 	 *
-	 * @return array<int, array<string, string>> description records that have country ID
+	 * @return array<string, mixed>
 	 *
 	 * @example
 	 *
 	 * $this->load->model('localisation/country');
 	 *
-	 * $country_description = $this->model_localisation_country->getDescriptions($country_id);
+	 * $country_description = $this->model_customer_customer_group->getDescriptions($customer_group_id, $language_id);
 	 */
 	public function getDescription(int $customer_group_id, int $language_id): array {
 		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "customer_group_description` WHERE `customer_group_id` = '" . (int)$customer_group_id . "' AND `language_id` = '" . (int)$language_id . "'");

--- a/upload/admin/model/localisation/country.php
+++ b/upload/admin/model/localisation/country.php
@@ -404,6 +404,22 @@ class Country extends \Opencart\System\Engine\Model {
 		$this->db->query("DELETE FROM `" . DB_PREFIX . "country_description` WHERE `language_id` = '" . (int)$language_id . "'");
 	}
 
+	/**
+	 * Get Description
+	 *
+	 * Get the record of the country description in the database.
+	 *
+	 * @param int $country_id  primary key of the country record
+	 * @param int $language_id primary key of the language record
+	 *
+	 * @return array<string, mixed> country description record
+	 *
+	 * @example
+	 *
+	 * $this->load->model('localisation/country');
+	 *
+	 * $description = $this->model_localisation_country->getDescription($country_id, $language_id);
+	 */
 	public function getDescription(int $country_id, int $language_id): array {
 		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "country_description` WHERE `country_id` = '" . (int)$country_id . "' AND `language_id` = '" . (int)$language_id . "'");
 
@@ -521,15 +537,15 @@ class Country extends \Opencart\System\Engine\Model {
 	 *
 	 * Get the record of the information store records in the database.
 	 *
-	 * @param int $country_id primary key of the store record
+	 * @param int $country_id primary key of the country record
 	 *
-	 * @return array<int, int> store records that have store ID
+	 * @return list<int> store IDs
 	 *
 	 * @example
 	 *
-	 * $this->load->model('catalog/information');
+	 * $this->load->model('localisation/country');
 	 *
-	 * $stores = $this->model_catalog_information->getStores($country_id);
+	 * $stores = $this->model_localisation_country->getStores($country_id);
 	 */
 	public function getStores(int $country_id): array {
 		$country_store_data = [];
@@ -537,12 +553,27 @@ class Country extends \Opencart\System\Engine\Model {
 		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "country_to_store` WHERE `country_id` = '" . (int)$country_id . "'");
 
 		foreach ($query->rows as $result) {
-			$country_store_data[] = $result['store_id'];
+			$country_store_data[] = (int)$result['store_id'];
 		}
 
 		return $country_store_data;
 	}
 
+	/**
+	 * Get Countries By Store ID
+	 *
+	 * Get the record of countries associated with a specific store.
+	 *
+	 * @param int $store_id primary key of the store record
+	 *
+	 * @return array<string, mixed> country records with store associations
+	 *
+	 * @example
+	 *
+	 * $this->load->model('localisation/country');
+	 *
+	 * $countries = $this->model_localisation_country->getCountriesByStoreId($store_id);
+	 */
 	public function getCountriesByStoreId(int $store_id): array {
 		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "country_to_store` `c2s` LEFT JOIN `" . DB_PREFIX . "country` `c` ON (`c2s`.`country_id` = `c`.`country_id`) WHERE `c2s`.`store_id` = '" . (int)$store_id . "'");
 

--- a/upload/admin/model/setting/cron.php
+++ b/upload/admin/model/setting/cron.php
@@ -13,7 +13,7 @@ class Cron extends \Opencart\System\Engine\Model {
 	 *
 	 * Create a new cron record in the database.
 	 *
-	 * @param array $data
+	 * @param array<string, mixed> $data
 	 *
 	 * @return int
 	 *

--- a/upload/admin/model/setting/ssr.php
+++ b/upload/admin/model/setting/ssr.php
@@ -13,7 +13,7 @@ class Ssr extends \Opencart\System\Engine\Model {
 	 *
 	 * Create a new ssr record in the database.
 	 *
-	 * @param array $data
+	 * @param array<string, mixed> $data
 	 *
 	 * @return int
 	 *

--- a/upload/admin/model/setting/task.php
+++ b/upload/admin/model/setting/task.php
@@ -13,9 +13,7 @@ class Task extends \Opencart\System\Engine\Model {
 	 *
 	 * Create a new task record in the database.
 	 *
-	 * @param string $code
-	 * @param string $action
-	 * @param bool   $status
+	 * @param array{code: string, description: string, action: string, args?: mixed, status: string} $data
 	 *
 	 * @return int
 	 *
@@ -23,7 +21,7 @@ class Task extends \Opencart\System\Engine\Model {
 	 *
 	 * $this->load->model('setting/task');
 	 *
-	 * $task_id = $this->model_setting_task->addTask($code, $description, $cycle, $action, $status);
+	 * $task_id = $this->model_setting_task->addTask($data);
 	 */
 	public function addTask(array $data): int {
 		$this->db->query("INSERT INTO `" . DB_PREFIX . "task` SET `code` = '" . $this->db->escape($data['code']) . "', `description` = '" . $this->db->escape($data['description']) . "', `action` = '" . $this->db->escape($data['action']) . "', `args` = '" . $this->db->escape(!empty($data['args']) ? json_encode($data['args']) : '') . "', `status` = '" . $this->db->escape($data['status']) . "', `date_added` = NOW()");

--- a/upload/admin/model/tool/menu.php
+++ b/upload/admin/model/tool/menu.php
@@ -128,7 +128,21 @@ class Menu extends \Opencart\System\Engine\Model {
 		return $query->row;
 	}
 
-
+	/**
+	 * Get Menu By Code
+	 *
+	 * Get the record of the menu by code in the database.
+	 *
+	 * @param string $code menu code
+	 *
+	 * @return array<string, mixed> menu record with description
+	 *
+	 * @example
+	 *
+	 * $this->load->model('tool/menu');
+	 *
+	 * $menu_info = $this->model_tool_menu->getMenuByCode($code);
+	 */
 	public function getMenuByCode(string $code): array {
 		$query = $this->db->query("SELECT DISTINCT * FROM `" . DB_PREFIX . "menu` `m` LEFT JOIN `" . DB_PREFIX . "menu_description` `md` ON (`m`.`menu_id` = `md`.`menu_id`) WHERE `m`.`code` = '" . $this->db->escape($code) . "' AND `md`.`language_id` = '" . (int)$this->config->get('config_language_id') . "'");
 

--- a/upload/catalog/controller/api/order.php
+++ b/upload/catalog/controller/api/order.php
@@ -75,7 +75,7 @@ class Order extends \Opencart\System\Engine\Controller {
 	/**
 	 * Set customer
 	 *
-	 * @return array
+	 * @return array<string, mixed>
 	 */
 	protected function setCustomer(): array {
 		return $this->load->controller('api/customer');
@@ -84,7 +84,7 @@ class Order extends \Opencart\System\Engine\Controller {
 	/**
 	 * Set Payment Address
 	 *
-	 * @return array
+	 * @return array<string, mixed>
 	 */
 	protected function setPaymentAddress(): array {
 		return $this->load->controller('api/payment_address');
@@ -93,7 +93,7 @@ class Order extends \Opencart\System\Engine\Controller {
 	/**
 	 * Set Shipping Address
 	 *
-	 * @return array
+	 * @return array<string, mixed>
 	 */
 	protected function setShippingAddress(): array {
 		$output = $this->load->controller('api/cart');
@@ -108,7 +108,7 @@ class Order extends \Opencart\System\Engine\Controller {
 	/**
 	 * Get Shipping Methods
 	 *
-	 * @return array
+	 * @return array<string, mixed>
 	 */
 	protected function getShippingMethods(): array {
 		$this->load->controller('api/customer');
@@ -128,7 +128,7 @@ class Order extends \Opencart\System\Engine\Controller {
 	/**
 	 * Set Shipping Method
 	 *
-	 * @return array
+	 * @return array<string, mixed>
 	 */
 	protected function setShippingMethod(): array {
 		$this->load->controller('api/customer');
@@ -163,7 +163,7 @@ class Order extends \Opencart\System\Engine\Controller {
 	/**
 	 * Get Payment Methods
 	 *
-	 * @return array
+	 * @return array<string, mixed>
 	 */
 	protected function getPaymentMethods(): array {
 		$this->load->controller('api/customer');
@@ -184,7 +184,7 @@ class Order extends \Opencart\System\Engine\Controller {
 	/**
 	 * Set Payment Method
 	 *
-	 * @return array
+	 * @return array<string, mixed>
 	 */
 	protected function setPaymentMethod(): array {
 		$this->load->controller('api/customer');
@@ -220,7 +220,7 @@ class Order extends \Opencart\System\Engine\Controller {
 	/**
 	 * Extension
 	 *
-	 * @return array
+	 * @return array<string, mixed>
 	 */
 	protected function extension(): array {
 		$this->load->controller('api/customer');
@@ -262,7 +262,7 @@ class Order extends \Opencart\System\Engine\Controller {
 	/**
 	 * Set Affiliate
 	 *
-	 * @return array
+	 * @return array<string, mixed>
 	 */
 	protected function setAffiliate(): array {
 		return $this->load->controller('api/affiliate');
@@ -271,7 +271,7 @@ class Order extends \Opencart\System\Engine\Controller {
 	/**
 	 * Get Cart
 	 *
-	 * @return array
+	 * @return array<string, mixed>
 	 */
 	protected function getCart(): array {
 		$this->load->controller('api/customer');
@@ -304,7 +304,7 @@ class Order extends \Opencart\System\Engine\Controller {
 	/**
 	 * Add Product
 	 *
-	 * @return array
+	 * @return array<string, mixed>
 	 */
 	protected function addProduct(): array {
 		$this->load->controller('api/customer');
@@ -342,7 +342,7 @@ class Order extends \Opencart\System\Engine\Controller {
 	/**
 	 * Confirm Order
 	 *
-	 * @return array
+	 * @return array<string, mixed>
 	 */
 	protected function confirm(): array {
 		$this->load->controller('api/customer');
@@ -674,7 +674,7 @@ class Order extends \Opencart\System\Engine\Controller {
 	/**
 	 * Add History
 	 *
-	 * @return array
+	 * @return array<string, mixed>
 	 */
 	protected function addHistory(): array {
 		$this->load->language('api/order');

--- a/upload/catalog/controller/api/subscription.php
+++ b/upload/catalog/controller/api/subscription.php
@@ -162,7 +162,7 @@ class Subscription extends \Opencart\System\Engine\Controller {
 	/**
 	 * Get Shipping Methods
 	 *
-	 * @return array
+	 * @return array<string, mixed>
 	 */
 	protected function getShippingMethods(): array {
 		$this->setCustomer();
@@ -182,7 +182,7 @@ class Subscription extends \Opencart\System\Engine\Controller {
 	/**
 	 * Get Payment Methods
 	 *
-	 * @return array
+	 * @return array<string, mixed>
 	 */
 	protected function getPaymentMethods(): array {
 		$this->setCustomer();
@@ -279,7 +279,7 @@ class Subscription extends \Opencart\System\Engine\Controller {
 	/**
 	 * Confirm
 	 *
-	 * @return array
+	 * @return array<string, mixed>
 	 */
 	protected function confirm(): array {
 		$this->setCustomer();

--- a/upload/system/library/cart/api.php
+++ b/upload/system/library/cart/api.php
@@ -35,7 +35,15 @@ class Api {
 		$this->language = $language;
 	}
 
-	public function send(string $route, $data = []): array {
+	/**
+	 * Send
+	 *
+	 * @param string               $route
+	 * @param array<string, mixed> $data
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function send(string $route, array $data = []): array {
 		$time = time();
 
 		// Build hash string

--- a/upload/system/library/cart/cart.php
+++ b/upload/system/library/cart/cart.php
@@ -306,11 +306,11 @@ class Cart {
 	/**
 	 * Add
 	 *
-	 * @param int   $product_id primary key of the product record
-	 * @param int   $quantity
-	 * @param array $option
-	 * @param int   $subscription_plan_id primary key of the subscription plan record
-	 * @param array $override
+	 * @param int                  $product_id primary key of the product record
+	 * @param int                  $quantity
+	 * @param array<string, mixed> $option
+	 * @param int                  $subscription_plan_id primary key of the subscription plan record
+	 * @param array<string, mixed> $override
 	 *
 	 * @return void
 	 *

--- a/upload/system/library/curl.php
+++ b/upload/system/library/curl.php
@@ -27,8 +27,8 @@ class Curl {
 	/**
 	 * Set Option
 	 *
-	 * @param string $key
-	 * @param array  $data<string, mixed> array of data
+	 * @param string               $key
+	 * @param array<string, mixed> $data array of data
 	 *
 	 * @return void
 	 */
@@ -36,7 +36,15 @@ class Curl {
 		$this->option[$key] = $data;
 	}
 
-	public function send(string $route, $data = []): array {
+	/**
+	 * Send
+	 *
+	 * @param string               $route
+	 * @param array<string, mixed> $data
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function send(string $route, array $data = []): array {
 		// Make remote call
 		$url  = 'http://' . $this->domain . $this->path . 'index.php?route=' . $route;
 

--- a/upload/system/library/db.php
+++ b/upload/system/library/db.php
@@ -23,15 +23,33 @@ class DB {
 	/**
 	 * Constructor
 	 *
-	 * @param string $adaptor
-	 * @param string $hostname
-	 * @param string $username
-	 * @param string $password
-	 * @param string $database
-	 * @param string $port
-	 * @param string $ssl_key
-	 * @param string $ssl_cert
-	 * @param string $ssl_ca
+	 * Initialize database connection with provided options.
+	 *
+	 * @param array<string, mixed> $option database connection options
+	 *                                     - engine: Database engine (required)
+	 *                                     - hostname: Database server hostname (required)
+	 *                                     - username: Database username (required)
+	 *                                     - password: Database password (optional)
+	 *                                     - database: Database name (required)
+	 *                                     - port: Database port (required)
+	 *                                     - ssl_key: SSL key file path (optional)
+	 *                                     - ssl_cert: SSL certificate file path (optional)
+	 *                                     - ssl_ca: SSL CA file path (optional)
+	 *
+	 * @throws \Exception when required database parameters are missing or database engine cannot be loaded
+	 *
+	 * @example
+	 *
+	 * $db_config = [
+	 *     'engine'   => 'mysqli',
+	 *     'hostname' => 'localhost',
+	 *     'username' => 'user',
+	 *     'password' => 'pass',
+	 *     'database' => 'opencart',
+	 *     'port'     => '3306'
+	 * ];
+	 *
+	 * $db = new DB($db_config);
 	 */
 	public function __construct(array $option = []) {
 		$required = [


### PR DESCRIPTION
### PHPStan Spring Cleaning: Add Missing Array Type Specifications in PHPDoc

Add `array<string, mixed>` type annotations to method parameters and return types to resolve PHPStan missingType.iterableValue errors.

#### PHPStan Errors Fixed
- `Method addCron() has parameter $data with no value type specified in iterable type array` in admin/model/setting/cron.php:31
- `Method addSsr() has parameter $data with no value type specified in iterable type array` in admin/model/setting/ssr.php:26
- `Method getDescription() return type has no value type specified in iterable type array` in admin/model/customer/customer_group.php:267
- `Method getDescription() return type has no value type specified in iterable type array` in admin/model/localisation/country.php:407
- `Method getCountriesByStoreId() return type has no value type specified in iterable type array` in admin/model/localisation/country.php:546
- `Method getMenuByCode() return type has no value type specified in iterable type array` in admin/model/tool/menu.php:132
- Plus 15 similar errors in API controller methods (catalog/controller/api/order.php)