### PR TITLE
fix(phpstan): correct return types in report models

### DIFF
--- a/upload/extension/opencart/admin/model/report/customer.php
+++ b/upload/extension/opencart/admin/model/report/customer.php
@@ -42,7 +42,7 @@ class Customer extends \Opencart\System\Engine\Model {
 	/**
 	 * Get Total Customers By Week
 	 *
-	 * @return array<int, array<string, int>>
+	 * @return array<int, array<string, string|int>>
 	 *
 	 * @example
 	 *
@@ -67,7 +67,7 @@ class Customer extends \Opencart\System\Engine\Model {
 		foreach ($query->rows as $result) {
 			$customer_data[date('w', strtotime($result['date_added']))] = [
 				'day'   => date('D', strtotime($result['date_added'])),
-				'total' => $result['total']
+				'total' => (int)$result['total']
 			];
 		}
 
@@ -77,7 +77,7 @@ class Customer extends \Opencart\System\Engine\Model {
 	/**
 	 * Get Total Customers By Month
 	 *
-	 * @return array<int, array<string, int>>
+	 * @return array<int, array<string, string|int>>
 	 *
 	 * @example
 	 *
@@ -100,7 +100,7 @@ class Customer extends \Opencart\System\Engine\Model {
 		foreach ($query->rows as $result) {
 			$customer_data[date('j', strtotime($result['date_added']))] = [
 				'day'   => date('d', strtotime($result['date_added'])),
-				'total' => $result['total']
+				'total' => (int)$result['total']
 			];
 		}
 
@@ -110,7 +110,7 @@ class Customer extends \Opencart\System\Engine\Model {
 	/**
 	 * Get Total Customers By Year
 	 *
-	 * @return array<int, array<string, int>>
+	 * @return array<int, array<string, string|int>>
 	 *
 	 * @example
 	 *
@@ -131,7 +131,7 @@ class Customer extends \Opencart\System\Engine\Model {
 		foreach ($query->rows as $result) {
 			$customer_data[date('n', strtotime($result['date_added']))] = [
 				'month' => date('M', strtotime($result['date_added'])),
-				'total' => $result['total']
+				'total' => (int)$result['total']
 			];
 		}
 

--- a/upload/extension/opencart/admin/model/report/sale.php
+++ b/upload/extension/opencart/admin/model/report/sale.php
@@ -49,7 +49,7 @@ class Sale extends \Opencart\System\Engine\Model {
 	/**
 	 * Get Total Orders By Day
 	 *
-	 * @return array<int, array<string, int>> total number of order records by day
+	 * @return array<int, array<string, string|int>> total number of order records by day
 	 *
 	 * @example
 	 *
@@ -76,7 +76,7 @@ class Sale extends \Opencart\System\Engine\Model {
 		foreach ($query->rows as $result) {
 			$order_data[$result['hour']] = [
 				'hour'  => $result['hour'],
-				'total' => $result['total']
+				'total' => (int)$result['total']
 			];
 		}
 
@@ -86,7 +86,7 @@ class Sale extends \Opencart\System\Engine\Model {
 	/**
 	 * Get Total Orders By Week
 	 *
-	 * @return array<int, array<string, int>> total number of order records by week
+	 * @return array<int, array<string, string|int>> total number of order records by week
 	 *
 	 * @example
 	 *
@@ -117,7 +117,7 @@ class Sale extends \Opencart\System\Engine\Model {
 		foreach ($query->rows as $result) {
 			$order_data[date('w', strtotime($result['date_added']))] = [
 				'day'   => date('D', strtotime($result['date_added'])),
-				'total' => $result['total']
+				'total' => (int)$result['total']
 			];
 		}
 
@@ -127,7 +127,7 @@ class Sale extends \Opencart\System\Engine\Model {
 	/**
 	 * Get Total Orders By Month
 	 *
-	 * @return array<int, array<string, int>> total number of order records by month
+	 * @return array<int, array<string, string|int>> total number of order records by month
 	 *
 	 * @example
 	 *
@@ -156,7 +156,7 @@ class Sale extends \Opencart\System\Engine\Model {
 		foreach ($query->rows as $result) {
 			$order_data[date('j', strtotime($result['date_added']))] = [
 				'day'   => date('d', strtotime($result['date_added'])),
-				'total' => $result['total']
+				'total' => (int)$result['total']
 			];
 		}
 
@@ -166,7 +166,7 @@ class Sale extends \Opencart\System\Engine\Model {
 	/**
 	 * Get Total Orders By Year
 	 *
-	 * @return array<int, array<string, int>> total number of order records by year
+	 * @return array<int, array<string, string|int>> total number of order records by year
 	 *
 	 * @example
 	 *
@@ -193,7 +193,7 @@ class Sale extends \Opencart\System\Engine\Model {
 		foreach ($query->rows as $result) {
 			$order_data[date('n', strtotime($result['date_added']))] = [
 				'month' => date('M', strtotime($result['date_added'])),
-				'total' => $result['total']
+				'total' => (int)$result['total']
 			];
 		}
 


### PR DESCRIPTION
### PHPStan Spring Cleaning: Fix Return Type Mismatches in Report Models

Convert database string results to integers in report aggregation methods to match PHPDoc return type declarations from `array<int, array<string, mixed>>` to `array<int, array<string, int>>`.

#### PHPStan Errors Fixed
- `Method Opencart\Admin\Model\Extension\Opencart\Report\Customer::getTotalCustomersByWeek() should return array<int, array<string, int>> but returns array<int, array<string, mixed>>` in extension/opencart/admin/model/report/customer.php:74
- `Method Opencart\Admin\Model\Extension\Opencart\Report\Customer::getTotalCustomersByMonth() should return array<int, array<string, int>> but returns array<int, array<string, mixed>>` in extension/opencart/admin/model/report/customer.php:107
- `Method Opencart\Admin\Model\Extension\Opencart\Report\Customer::getTotalCustomersByYear() should return array<int, array<string, int>> but returns array<int, array<string, mixed>>` in extension/opencart/admin/model/report/customer.php:138
- `Method Opencart\Admin\Model\Extension\Opencart\Report\Sale::getTotalOrdersByWeek() should return array<int, array<string, int>> but returns array<int, array<string, mixed>>` in extension/opencart/admin/model/report/sale.php:124
- `Method Opencart\Admin\Model\Extension\Opencart\Report\Sale::getTotalOrdersByMonth() should return array<int, array<string, int>> but returns array<int, array<string, mixed>>` in extension/opencart/admin/model/report/sale.php:163
- `Method Opencart\Admin\Model\Extension\Opencart\Report\Sale::getTotalOrdersByYear() should return array<int, array<string, int>> but returns array<int, array<string, mixed>>` in extension/opencart/admin/model/report/sale.php:200
