### PR TITLE
fix(phpstan): remove unreachable statements after throw

### DIFF
--- a/upload/install/cli_install.php
+++ b/upload/install/cli_install.php
@@ -87,8 +87,6 @@ set_error_handler(function(int $code, string $message, string $file, int $line) 
 	}
 
 	throw new \ErrorException($message, 0, $code, $file, $line);
-
-	return true;
 });
 
 /**

--- a/upload/system/library/db.php
+++ b/upload/system/library/db.php
@@ -63,7 +63,6 @@ class DB {
 		foreach ($required as $key) {
 			if (empty($option[$key])) {
 				throw new \Exception('Error: Database ' . $key . ' required!');
-				exit();
 			}
 		}
 
@@ -73,7 +72,6 @@ class DB {
 			$this->adaptor = new $class($option);
 		} else {
 			throw new \Exception('Error: Could not load database adaptor ' . $option['engine'] . '!');
-			exit();
 		}
 	}
 


### PR DESCRIPTION
### PHPStan Spring Cleaning: Remove Unreachable Statements

Remove code statements that are never executed due to preceding throw statements, resolving PHPStan "deadCode.unreachable" warnings.

#### PHPStan Errors Fixed
- `Unreachable statement - code above always terminates` in system/library/db.php:66
- `Unreachable statement - code above always terminates` in system/library/db.php:76
- `Unreachable statement - code above always terminates` in install/cli_install.php:91