### PR TITLE
fix(phpstan): remove unused variables from error handler closure

### DIFF
--- a/upload/system/framework.php
+++ b/upload/system/framework.php
@@ -33,7 +33,7 @@ $log = new \Opencart\System\Library\Log($config->get('error_filename'));
 $registry->set('log', $log);
 
 // Error Handler
-set_error_handler(function(int $code, string $message, string $file, int $line) use ($log, $config) {
+set_error_handler(function(int $code, string $message, string $file, int $line) {
 	// error suppressed with @
 	if (!(error_reporting() & $code)) {
 		return false;


### PR DESCRIPTION
### PHPStan Spring Cleaning: Remove Unused Closure Variables

Remove unused variables from closure `use` statement in error handler function, resolving PHPStan "closure.unusedUse" warnings.

#### PHPStan Errors Fixed
- `Anonymous function has an unused use $config` in system/framework.php:36
- `Anonymous function has an unused use $log` in system/framework.php:36
