### PR TITLE
fix(phpstan): ignore missing config.php files in static analysis

### DIFF
--- a/upload/admin/index.php
+++ b/upload/admin/index.php
@@ -4,6 +4,7 @@ define('VERSION', '4.1.0.4');
 
 // Configuration
 if (is_file('config.php')) {
+	/** @phpstan-ignore-next-line requireOnce.fileNotFound */
 	require_once('config.php');
 }
 

--- a/upload/cron.php
+++ b/upload/cron.php
@@ -5,6 +5,7 @@ if (!is_file('config.php')) {
 }
 
 // Config
+/** @phpstan-ignore-next-line requireOnce.fileNotFound */
 require_once('config.php');
 
 // Startup

--- a/upload/index.php
+++ b/upload/index.php
@@ -4,6 +4,7 @@ define('VERSION', '4.1.0.4');
 
 // Configuration
 if (is_file('config.php')) {
+	/** @phpstan-ignore-next-line requireOnce.fileNotFound */
 	require_once('config.php');
 }
 


### PR DESCRIPTION
### PHPStan Spring Cleaning: Ignore Missing Config Files

Add PHPStan ignore annotations for `config.php` require statements, resolving "requireOnce.fileNotFound" warnings for environment-specific configuration files.

#### PHPStan Errors Fixed
- `Path in require_once() "config.php" is not a file or it does not exist` in admin/index.php:7
- `Path in require_once() "config.php" is not a file or it does not exist` in index.php:6
- `Path in require_once() "config.php" is not a file or it does not exist` in cron.php:8
