### PR TITLE
fix(phpstan): correct PHPDoc parameter types in task and menu models

### DIFF
--- a/upload/admin/model/setting/task.php
+++ b/upload/admin/model/setting/task.php
@@ -89,8 +89,8 @@ class Task extends \Opencart\System\Engine\Model {
 	 *
 	 * Edit task status record in the database.
 	 *
-	 * @param int  $task_id primary key of the task record
-	 * @param bool $status
+	 * @param int    $task_id primary key of the task record
+	 * @param string $status
 	 *
 	 * @return void
 	 *

--- a/upload/admin/model/tool/menu.php
+++ b/upload/admin/model/tool/menu.php
@@ -62,8 +62,7 @@ class Menu extends \Opencart\System\Engine\Model {
 	/**
 	 * Delete Menu By Code
 	 *
-	 * @param int $menu_id
-	 * @param string $menu_id primary key of the menu record
+	 * @param int $menu_id primary  key of the menu record
 	 *
 	 * @return void
 	 *


### PR DESCRIPTION
### PHPStan Spring Cleaning: Fix PHPDoc Parameter Types

Correct PHPDoc parameter type annotations to match actual function signatures and database schema, resolving "parameter.phpDocType" warnings.

#### PHPStan Errors Fixed
- `PHPDoc tag @param for parameter $status with type bool is incompatible with native type string` in admin/model/setting/task.php:103
- `PHPDoc tag @param for parameter $menu_id with type string is incompatible with native type int` in admin/model/tool/menu.php:76

#### Database Schema Reference
The corrections align PHPDoc with the actual database schema where:
- `task.status` is `varchar(16)` → requires `string` type

https://github.com/opencart/opencart/blob/master/upload/system/helper/db_schema.php#L7386
