### PR TITLE
feat(docker): add Makefile for simplified Docker operations and update documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,143 @@
+# Makefile for OpenCart Docker Environment
+
+# Use bash for command execution for its advanced features like arrays and functions.
+SHELL := /bin/bash
+
+# --- Color Codes ---
+# Using the 8-bit (256-color) palette for maximum compatibility.
+OPENCART_COLOR := \033[38;5;45m
+COLOR_RESET := \033[0m
+
+# --- Docker Compose Setup ---
+# Define the base docker compose command to avoid repetition.
+COMPOSE := docker compose --env-file=./docker/.env.docker
+
+# --- Variable Handling for Options ---
+# For passing extra arguments to docker compose commands.
+# Example: make down options="-v --remove-orphans"
+options ?=
+# For optional profiles.
+# Example: make up profiles="adminer redis"
+profiles ?=
+PROFILES_FLAGS := $(foreach p,$(profiles),--profile $(p))
+
+# --- Helper Functions ---
+# Check if a service is running
+define check_service_running
+	@if ! $(COMPOSE) ps --services --filter "status=running" | grep -q "^$(1)$$"; then \
+		echo "Error: Service '$(1)' is not running."; \
+		echo "Run 'make up' first or check 'make ps' for service status."; \
+		exit 1; \
+	fi
+endef
+
+# List of all known targets.
+KNOWN_TARGETS := help setup build up down restart logs apache php mysql exec ps
+
+# Phony targets are not files.
+.PHONY: $(KNOWN_TARGETS)
+
+# Default target to run when 'make' is called without arguments.
+.DEFAULT_GOAL := help
+
+help: ## Show this help message
+	@echo "OpenCart Docker Environment"
+	@echo "---------------------------"
+	@echo "Usage: make <target> [options=\"...\"] [profiles=\"...\"]"
+	@echo ""
+	@echo "Core Commands:"
+	@echo -e "  $(OPENCART_COLOR)make setup$(COLOR_RESET)          - Initialize the project (copies .env.docker)"
+	@echo -e "  $(OPENCART_COLOR)make build$(COLOR_RESET)          - Build or rebuild Docker images"
+	@echo -e "  $(OPENCART_COLOR)make up$(COLOR_RESET)             - Start all services"
+	@echo -e "  $(OPENCART_COLOR)make down$(COLOR_RESET)           - Stop and remove all containers"
+	@echo -e "  $(OPENCART_COLOR)make restart$(COLOR_RESET)        - Restart all services"
+	@echo -e "  $(OPENCART_COLOR)make ps$(COLOR_RESET)             - Show status of all services"
+	@echo -e "  $(OPENCART_COLOR)make logs$(COLOR_RESET)           - Show logs from all running services"
+	@echo ""
+	@echo "Service Interaction:"
+	@echo -e "  $(OPENCART_COLOR)make php$(COLOR_RESET)            - Enter the PHP container (bash)"
+	@echo -e "  $(OPENCART_COLOR)make apache$(COLOR_RESET)         - Enter the Apache container (sh)"
+	@echo -e "  $(OPENCART_COLOR)make mysql$(COLOR_RESET)          - Enter the MySQL container (bash)"
+	@echo -e "  $(OPENCART_COLOR)make exec$(COLOR_RESET)           - Execute a command in a service"
+	@echo ""
+	@echo "Examples:"
+	@echo "  make up profiles=\"adminer redis\""
+	@echo "  make down options=\"-v\""
+	@echo "  make build options=\"--no-cache\""
+	@echo "  make logs options=\"php\""
+	@echo "  make exec service=php command=\"composer --version\""
+	@echo ""
+	@echo "Links:"
+	@echo "  GitHub:        https://github.com/opencart/opencart"
+	@echo "  Documentation: https://docs.opencart.com/"
+	@echo "  Live Demo:     https://www.opencart.com/index.php?route=cms/demo"
+
+# --- Project Lifecycle Targets ---
+setup: ## Initialize the project (copies .env.docker)
+	@if [ ! -f ./docker/.env.docker ]; then \
+		echo "Copying docker/.env.docker.example to docker/.env.docker..."; \
+		cp docker/.env.docker.example docker/.env.docker; \
+	else \
+		echo "docker/.env.docker already exists. Skipping."; \
+	fi
+
+build: ## Build images. Use 'options' for flags (e.g., --no-cache)
+	$(COMPOSE) build $(options)
+
+up: ## Start services. Use 'profiles' and 'options'
+	@echo "Starting services..."
+	$(COMPOSE) $(PROFILES_FLAGS) up -d $(options)
+
+down: ## Stop containers. Use 'options' for flags (e.g., -v)
+	@echo "Stopping services..."
+	$(COMPOSE) down $(options)
+
+restart: ## Restart services. Passes 'options' and 'profiles'
+	@$(MAKE) down options="$(options)"
+	@$(MAKE) up profiles="$(profiles)" options="$(options)"
+
+# --- Service Status Commands ---
+ps: ## Show status of all services
+	@$(COMPOSE) ps
+
+logs: ## Show logs. Use 'options' to specify services (e.g., php)
+	@# If specific service provided, check if it exists
+	@if [ -n "$(options)" ] && ! echo "$(options)" | grep -q "^-"; then \
+		if ! $(COMPOSE) config --services | grep -q "^$(options)$$"; then \
+			echo "Error: Service '$(options)' not found."; \
+			echo "Available services:"; \
+			$(COMPOSE) config --services | sed 's/^/  - /'; \
+			exit 1; \
+		fi; \
+	fi
+	$(COMPOSE) logs -f $(options)
+
+# --- Service Interaction Targets ---
+exec: ## Execute a command. Usage: make exec service=<name> command="<command>"
+	@if [ -z "$(service)" ] || [ -z "$(command)" ]; then \
+		echo "Error: 'service' and 'command' variables are required."; \
+		echo "Usage: make exec service=<name> command=\"<command>\""; \
+		exit 1; \
+	fi
+	@# Validate service exists in docker-compose
+	@if ! $(COMPOSE) config --services | grep -q "^$(service)$$"; then \
+		echo "Error: Service '$(service)' not found in docker-compose configuration."; \
+		echo "Available services:"; \
+		$(COMPOSE) config --services | sed 's/^/  - /'; \
+		exit 1; \
+	fi
+	$(call check_service_running,$(service))
+	@# Use -- to prevent command injection
+	@$(COMPOSE) exec $(service) sh -c "$(command)"
+
+apache: ## Enter the Apache container (sh)
+	$(call check_service_running,apache)
+	$(COMPOSE) exec apache sh
+
+php: ## Enter the PHP container (bash)
+	$(call check_service_running,php)
+	@$(COMPOSE) exec php bash
+
+mysql: ## Enter the MySQL container (bash)
+	$(call check_service_running,mysql)
+	@$(COMPOSE) exec mysql bash

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ define check_service_running
 endef
 
 # List of all known targets.
-KNOWN_TARGETS := help setup build up down restart logs apache php mysql exec ps
+KNOWN_TARGETS := help init build up down restart logs apache php mysql exec ps
 
 # Phony targets are not files.
 .PHONY: $(KNOWN_TARGETS)
@@ -46,7 +46,7 @@ help: ## Show this help message
 	@echo "Usage: make <target> [options=\"...\"] [profiles=\"...\"]"
 	@echo ""
 	@echo "Core Commands:"
-	@echo -e "  $(OPENCART_COLOR)make setup$(COLOR_RESET)          - Initialize the project (copies .env.docker)"
+	@echo -e "  $(OPENCART_COLOR)make init$(COLOR_RESET)           - Initialize the project (copies .env.docker)"
 	@echo -e "  $(OPENCART_COLOR)make build$(COLOR_RESET)          - Build or rebuild Docker images"
 	@echo -e "  $(OPENCART_COLOR)make up$(COLOR_RESET)             - Start all services"
 	@echo -e "  $(OPENCART_COLOR)make down$(COLOR_RESET)           - Stop and remove all containers"
@@ -68,12 +68,14 @@ help: ## Show this help message
 	@echo "  make exec service=php command=\"composer --version\""
 	@echo ""
 	@echo "Links:"
-	@echo "  GitHub:        https://github.com/opencart/opencart"
-	@echo "  Documentation: https://docs.opencart.com/"
-	@echo "  Live Demo:     https://www.opencart.com/index.php?route=cms/demo"
+	@echo "  OpenCart:       https://www.opencart.com"
+	@echo "  Live Demo:      https://www.opencart.com/index.php?route=cms/demo"
+	@echo "  Documentation:  https://docs.opencart.com"
+	@echo "  Support Forums: https://forum.opencart.com"
+	@echo "  GitHub:         https://github.com/opencart/opencart"
 
 # --- Project Lifecycle Targets ---
-setup: ## Initialize the project (copies .env.docker)
+init: ## Initialize the project (copies .env.docker)
 	@if [ ! -f ./docker/.env.docker ]; then \
 		echo "Copying docker/.env.docker.example to docker/.env.docker..."; \
 		cp docker/.env.docker.example docker/.env.docker; \

--- a/README.md
+++ b/README.md
@@ -49,13 +49,14 @@ This project includes a Docker-based environment for local development.
 ### Prerequisites
 
 * You must have Docker and Docker Compose installed on your machine. [Docker Desktop](https://www.docker.com/products/docker-desktop/) is the easiest way to get them.
+* You must have `make` installed on your system (usually pre-installed on macOS and Linux distributions).
 
 > [!IMPORTANT]
 >
 > **For Windows Users:**
 > It is **strongly recommended** to use the WSL 2 (Windows Subsystem for Linux) backend for Docker Desktop.
-> **You should install Docker _inside_ your WSL distribution (e.g., Ubuntu 24.04) for best performance.**
-> `\\wsl$\Ubuntu-24.04\home\youruser\opencart` (from Windows Explorer)
+> **You should clone this project _inside_ your WSL distribution (e.g., Ubuntu 24.04) for best performance.**
+> Access your project via `\\wsl$\Ubuntu-24.04\home\youruser\opencart` from Windows Explorer if needed.
 > Without WSL 2, file system performance will be extremely slow, making the application nearly unusable.
 > Docker Desktop will typically prompt you to enable WSL 2 during installation.
 
@@ -64,40 +65,42 @@ This project includes a Docker-based environment for local development.
 > OpenCart itself does **not** use any `.env` file for its configuration.
 > The provided `.env.docker` file is **only** for configuring the Docker Compose environment.
 > To avoid confusion with classic development workflows, this file is named `.env.docker` and placed inside the `docker` directory.
-> Since Docker Compose looks for `.env` in the project root by default, you must always specify the path to the env file manually using `--env-file=./docker/.env.docker`.
 
 ### Getting Started
 
 1. Clone the repository to your local machine.
-2. Copy the example environment file:
+2. Initialize the project:
     ```bash
-    cp docker/.env.docker.example docker/.env.docker
+    make init
     ```
-3. Navigate to the project's root directory in your terminal.
-4. Build the images:
+3. Build the images:
     ```bash
-    docker compose --env-file=./docker/.env.docker build
+    make build
     ```
-5. Start all services:
+4. Start all services:
     ```bash
-    docker compose --env-file=./docker/.env.docker up -d
+    make up
     ```
 
-After the process is complete, your OpenCart store will be available at `http://localhost`. The Adminer database management tool will be available at `http://localhost:8080`.
+After the process is complete, your OpenCart store will be available at `http://localhost`.
 
 ### Common Commands
 
 * **To stop the environment:**
     ```bash
-    docker compose down
+    make down
     ```
 * **To view the logs from all services:**
     ```bash
-    docker compose logs -f
+    make logs
     ```
 * **To enter the PHP container:**
     ```bash
-    docker compose exec php bash
+    make php
+    ```
+* **To see all available commands:**
+    ```bash
+    make help
     ```
 
 ### Changing the PHP Version
@@ -114,7 +117,7 @@ PHP_VERSION=8.2
 After changing the version, rebuild the images:
 
 ```bash
-docker compose --env-file=./docker/.env.docker build
+make build
 ```
 
 ### Using Docker Compose Profiles for Optional Services
@@ -126,18 +129,16 @@ To enable one or more optional services, use the `--profile` flag and specify yo
 
 - **Start with Adminer:**
     ```bash
-    docker compose --env-file=./docker/.env.docker --profile adminer up -d
+    make up profiles="adminer"
     ```
 - **Start with Redis and Memcached:**
     ```bash
-    docker compose --env-file=./docker/.env.docker --profile redis --profile memcached up -d
+    make up profiles="redis memcached"
     ```
 - **Start all optional services:**
     ```bash
-    docker compose --env-file=./docker/.env.docker --profile adminer --profile redis --profile memcached --profile postgres up -d
+   make up profiles="adminer redis memcached postgres"
     ```
-
-If you do not specify the `--profile` flag, only the core services will be started.
 
 > [!TIP]
 >


### PR DESCRIPTION
### Summary

This PR introduces a comprehensive Makefile to simplify Docker Compose operations for OpenCart development and updates the documentation accordingly:

- Adds feature-rich Makefile with intuitive commands like `make up`, `make php`, `make logs`
- Replaces lengthy docker compose commands with simple make targets
- Includes service validation, error handling, and color-coded help system
- Updates README documentation to use make commands instead of docker compose

### Why

This significantly improves developer experience by:
- Reducing command complexity (`make up` vs `docker compose --env-file=./docker/.env.docker up -d`)
- Providing consistent interface across different environments
- Adding helpful validation and error messages
- Offering comprehensive help system with `make help`

<img width="619" height="866" alt="image" src="https://github.com/user-attachments/assets/0887c34f-8705-4960-8526-0fe85388ef89" />

> [!NOTE]
> ### Notes for developers
> 
> This PR focuses on improving the internal structure of the Docker setup. The **Docker configuration is still not considered production-ready** and further work will continue on enhancing its robustness and features.