### PR TITLE
feat(response): improve compression with brotli and zstd support

### DIFF
--- a/upload/system/config/default.php
+++ b/upload/system/config/default.php
@@ -1,16 +1,16 @@
 <?php
 // Site
-$_['site_url']             = '';
+$_['site_url']                   = '';
 
 // Language
-$_['language_code']        = 'en-gb';
+$_['language_code']              = 'en-gb';
 
 // Date
-$_['date_timezone']        = 'UTC';
+$_['date_timezone']              = 'UTC';
 
 // Database
-$_['db_autostart']         = false;
-$_['db_option']            = [
+$_['db_autostart']               = false;
+$_['db_option']                  = [
 	'engine'   => 'mysqli', // mysqli, pdo or pgsql
 	'hostname' => 'localhost',
 	'username' => 'root',
@@ -23,50 +23,51 @@ $_['db_option']            = [
 ];
 
 // Mail
-$_['mail_engine']          = 'mail'; // mail or smtp
-$_['mail_from']            = ''; // Your E-Mail
-$_['mail_sender']          = ''; // Your name or company name
-$_['mail_reply_to']        = ''; // Reply to E-Mail
-$_['mail_smtp_hostname']   = '';
-$_['mail_smtp_username']   = '';
-$_['mail_smtp_password']   = '';
-$_['mail_smtp_port']       = 25;
-$_['mail_smtp_timeout']    = 5;
-$_['mail_verp']            = false;
-$_['mail_parameter']       = '';
+$_['mail_engine']                = 'mail'; // mail or smtp
+$_['mail_from']                  = ''; // Your E-Mail
+$_['mail_sender']                = ''; // Your name or company name
+$_['mail_reply_to']              = ''; // Reply to E-Mail
+$_['mail_smtp_hostname']         = '';
+$_['mail_smtp_username']         = '';
+$_['mail_smtp_password']         = '';
+$_['mail_smtp_port']             = 25;
+$_['mail_smtp_timeout']          = 5;
+$_['mail_verp']                  = false;
+$_['mail_parameter']             = '';
 
 // Cache
-$_['cache_engine']         = 'file'; // apc, file, mem, memcached or redis
-$_['cache_expire']         = 3600;
+$_['cache_engine']               = 'file'; // apc, file, mem, memcached or redis
+$_['cache_expire']               = 3600;
 
 // Session
-$_['session_autostart']    = false;
-$_['session_engine']       = 'file'; // db or file
-$_['session_name']         = 'OCSESSID';
-$_['session_domain']       = '';
-$_['session_path']         = !empty($_SERVER['PHP_SELF']) ? rtrim(dirname($_SERVER['PHP_SELF']), '/') . '/' : '/';
-$_['session_expire']       = 86400;
-$_['session_probability']  = 1;
-$_['session_divisor']      = 5;
-$_['session_samesite']     = 'Strict';
+$_['session_autostart']          = false;
+$_['session_engine']             = 'file'; // db or file
+$_['session_name']               = 'OCSESSID';
+$_['session_domain']             = '';
+$_['session_path']               = !empty($_SERVER['PHP_SELF']) ? rtrim(dirname($_SERVER['PHP_SELF']), '/') . '/' : '/';
+$_['session_expire']             = 86400;
+$_['session_probability']        = 1;
+$_['session_divisor']            = 5;
+$_['session_samesite']           = 'Strict';
 
 // Template
-$_['template_engine']      = 'twig';
-$_['template_extension']   = '.twig';
+$_['template_engine']            = 'twig';
+$_['template_extension']         = '.twig';
 
 // Error
-$_['error_display']        = true; // You need to change this to false on a live site.
-$_['error_log']            = true;
-$_['error_debug']          = false;
-$_['error_filename']       = 'error.log';
-$_['error_page']           = 'error.html';
+$_['error_display']              = true; // You need to change this to false on a live site.
+$_['error_log']                  = true;
+$_['error_debug']                = false;
+$_['error_filename']             = 'error.log';
+$_['error_page']                 = 'error.html';
 
 // Response
-$_['response_header']      = ['Content-Type: text/html; charset=utf-8'];
-$_['response_compression'] = 0;
+$_['response_header']            = ['Content-Type: text/html; charset=utf-8'];
+$_['response_compression']       = 0;
+$_['response_min_compress_size'] = 1024; // Minimum size for compression (bytes)
 
 // Actions
-$_['action_default']       = 'common/home';
-$_['action_error']         = 'error/not_found';
-$_['action_pre_action']    = [];
-$_['action_event']         = [];
+$_['action_default']             = 'common/home';
+$_['action_error']               = 'error/not_found';
+$_['action_pre_action']          = [];
+$_['action_event']               = [];

--- a/upload/system/framework.php
+++ b/upload/system/framework.php
@@ -104,6 +104,7 @@ $response->addHeader('Access-Control-Allow-Methods: PUT, POST, GET, OPTIONS, DEL
 $response->addHeader('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0');
 $response->addHeader('Pragma: no-cache');
 $response->setCompression((int)$config->get('response_compression'));
+$response->setMinCompressSize((int)$config->get('response_min_compress_size'));
 
 // Database
 if ($config->get('db_autostart')) {

--- a/upload/system/library/response.php
+++ b/upload/system/library/response.php
@@ -27,6 +27,10 @@ class Response {
 	 * @var string
 	 */
 	private string $output = '';
+	/**
+	 * @var int Minimum size (bytes) for compression to avoid CPU overhead on small files
+	 */
+	private int $min_compress_size = 1024;
 
 	/**
 	 * Constructor
@@ -35,6 +39,27 @@ class Response {
 	 */
 	public function addHeader(string $header): void {
 		$this->headers[] = $header;
+	}
+
+	/**
+	 * Remove header by name
+	 *
+	 * Example: removeHeader('Content-Length') will remove "Content-Length: 1234"
+	 *
+	 * @param string $header_name Header name to remove
+	 *
+	 * @return void
+	 */
+	public function removeHeader(string $header_name): void {
+		foreach ($this->headers as $key => $header) {
+			// Check if header starts with the name followed by colon
+			if (stripos($header, $header_name . ':') === 0) {
+				unset($this->headers[$key]);
+			}
+		}
+
+		// Reindex array to maintain sequential keys
+		$this->headers = array_values($this->headers);
 	}
 
 	/**
@@ -71,6 +96,16 @@ class Response {
 	}
 
 	/**
+	 * Set minimum size for compression
+	 *
+	 * @param int $size Minimum size in bytes
+	 * @return void
+	 */
+	public function setMinCompressSize(int $size): void {
+		$this->min_compress_size = max(0, $size);
+	}
+
+	/**
 	 * Set Output
 	 *
 	 * @param string $output
@@ -91,41 +126,169 @@ class Response {
 	}
 
 	/**
-	 * Compress
+	 * Parse Accept-Encoding header
+	 * Follows RFC 9110 Section 12.5.3: https://www.rfc-editor.org/rfc/rfc9110.html#name-accept-encoding
+	 * Example: "gzip, deflate, br;q=0.8, zstd;q=0.9" -> ['gzip' => 1.0, 'deflate' => 1.0, 'br' => 0.8, 'zstd' => 0.9]
 	 *
-	 * @param string $data
-	 * @param int    $level
+	 * @param string $accept_encoding
+	 *
+	 * @return array<string, float>
+	 */
+	private function parseAcceptEncoding(string $accept_encoding): array {
+		$encodings = [];
+		$parts = explode(',', $accept_encoding);
+
+		foreach ($parts as $part) {
+			$part = trim($part);
+
+			if (str_contains($part, ';')) {
+				[$encoding, $quality] = explode(';', $part, 2);
+				$encoding = trim($encoding);
+				$q_value = 1.0;
+
+				// Parse quality value (q=0.8)
+				if (preg_match('/q=([0-9.]+)/', $quality, $matches)) {
+					$q_value = (float)$matches[1];
+				}
+
+				$encodings[$encoding] = $q_value;
+			} else {
+				$encodings[trim($part)] = 1.0;
+			}
+		}
+
+		// Handle wildcard '*' (RFC 9110: means any encoding is acceptable)
+		// Add missing algorithms with wildcard quality, but don't overwrite explicit ones
+		if (isset($encodings['*']) && $encodings['*'] > 0) {
+			$wildcard_quality = $encodings['*'];
+			$supported_algorithms = ['zstd', 'br', 'gzip', 'deflate'];
+
+			foreach ($supported_algorithms as $algorithm) {
+				// Only add if not explicitly specified
+				if (!isset($encodings[$algorithm])) {
+					$encodings[$algorithm] = $wildcard_quality;
+				}
+			}
+
+			// Remove wildcard - it's not a real compression algorithm
+			// and would interfere with getBestEncoding() logic
+			unset($encodings['*']);
+		}
+
+		return $encodings;
+	}
+
+	/**
+	 * Get the best available encoding
+	 * Priority order: zstd > br > gzip > deflate
+	 *
+	 * @param array<string, float> $accepted_encodings
+	 * @return string|null
+	 */
+	private function getBestEncoding(array $accepted_encodings): ?string {
+		$priority = [
+			'zstd'    => 4,
+			'br'      => 3,
+			'gzip'    => 2,
+			'deflate' => 1
+		];
+
+		$best_encoding = null;
+		$best_priority = 0;
+		$best_quality = 0;
+
+		foreach ($accepted_encodings as $encoding => $quality) {
+			// Skip encodings with zero or negative quality
+			if ($quality <= 0) {
+				continue;
+			}
+
+			$current_priority = $priority[$encoding] ?? 0;
+
+			// Skip if this encoding has lower priority
+			if ($current_priority < $best_priority) {
+				continue;
+			}
+
+			// If same priority, check quality value
+			if ($current_priority === $best_priority && $quality <= $best_quality) {
+				continue;
+			}
+
+			// Check if encoding extension is available on the server
+			$is_available = match($encoding) {
+				'zstd'            => extension_loaded('zstd'),
+				'br'              => extension_loaded('brotli'),
+				'gzip', 'deflate' => extension_loaded('zlib'),
+				default => false
+			};
+
+			if ($is_available) {
+				$best_encoding = $encoding;
+				$best_priority = $current_priority;
+				$best_quality = $quality;
+			}
+		}
+
+		return $best_encoding;
+	}
+
+	/**
+	 * Compress data using the best available compression algorithm
+	 * Supports zstd, brotli, gzip, and deflate compression
+	 *
+	 * @param  string  $data
+	 * @param  int     $level  Compression level (0-9, where 0 = no compression)
 	 *
 	 * @return string
 	 */
 	private function compress(string $data, int $level = 0): string {
-		if (isset($_SERVER['HTTP_ACCEPT_ENCODING']) && (strpos($_SERVER['HTTP_ACCEPT_ENCODING'], 'gzip') !== false)) {
-			$encoding = 'gzip';
-		}
-
-		if (isset($_SERVER['HTTP_ACCEPT_ENCODING']) && (strpos($_SERVER['HTTP_ACCEPT_ENCODING'], 'x-gzip') !== false)) {
-			$encoding = 'x-gzip';
-		}
-
-		if (!isset($encoding) || ($level < -1 || $level > 9)) {
+		if (!isset($_SERVER['HTTP_ACCEPT_ENCODING']) || ($level < -1 || $level > 9)) {
 			return $data;
 		}
 
-		if (!extension_loaded('zlib') || ini_get('zlib.output_compression')) {
+		if (headers_sent() || connection_status()) {
 			return $data;
 		}
 
-		if (headers_sent()) {
+		// Skip compression for small data to avoid unnecessary CPU overhead
+		if ($this->min_compress_size > 0 && strlen($data) < $this->min_compress_size) {
 			return $data;
 		}
 
-		if (connection_status()) {
+		// Parse browser's accepted encodings
+		$accepted_encodings = $this->parseAcceptEncoding($_SERVER['HTTP_ACCEPT_ENCODING']);
+		$best_encoding = $this->getBestEncoding($accepted_encodings);
+
+		if (!$best_encoding) {
 			return $data;
 		}
 
-		$this->addHeader('Content-Encoding: ' . $encoding);
+		$compressed_data = match($best_encoding) {
+			'zstd'    => zstd_compress($data, $level),
+			'br'      => brotli_compress($data, $level),
+			'gzip'    => !ini_get('zlib.output_compression') ? gzencode($data, $level) : false,
+			'deflate' => !ini_get('zlib.output_compression') ? gzdeflate($data, $level) : false,
+			default => false
+		};
 
-		return gzencode($data, $level);
+		// Check for successful compression
+		// false = compression failed or zlib.output_compression is enabled
+		if ($compressed_data !== false) {
+			// Remove Content-Length header as compressed size will differ
+			$this->removeHeader('Content-Length');
+
+			$this->addHeader('Content-Encoding: ' . $best_encoding);
+			$this->addHeader('Content-Length: ' . strlen($compressed_data));
+
+			// Add Vary for proper caching (proxies/CDNs need to know encoding varies)
+			$this->addHeader('Vary: Accept-Encoding');
+
+			return $compressed_data;
+		}
+
+		// Return original data if compression unavailable or failed
+		return $data;
 	}
 
 	/**
@@ -141,7 +304,7 @@ class Response {
 
 			if (!headers_sent()) {
 				foreach ($this->headers as $header) {
-					header($header, true);
+					header($header);
 				}
 			}
 


### PR DESCRIPTION
### Overview
Add support for modern compression algorithms with proper Accept-Encoding header parsing and automatic algorithm selection.

### Changes
- ✅ Add support for zstd and brotli compression
- ✅ Implement proper Accept-Encoding parsing with q-values and wildcard support
- ✅ Add priority-based algorithm selection (zstd > brotli > gzip > deflate)
- ✅ Add minimum compression size threshold to avoid CPU overhead on small files
- ✅ Add removeHeader() method for proper Content-Length management
- ✅ Add Vary: Accept-Encoding header for CDN/proxy compatibility
- ✅ Remove deprecated x-gzip support

### Test Results

#### Environment
- **Hardware**: MacBook Air 13-inch, M3 (8-core CPU: 4 performance + 4 efficiency; 8-core GPU), 16GB Unified Memory, 250GB SSD (2024)
- **Browser**: Firefox 140.0.4 (aarch64)
- **Setup**: OpenCart Docker Compose with `zstd` and `brotli` extensions
- **Test Page**: HTML home page (32.62 kB original size)

#### Compression Performance by Level

| Level | zstd (kB) | Brotli (kB) | Gzip (kB) | Best Algorithm |
|-------|-----------|-------------|-----------|----------------|
| 1     | 5.32      | 5.72        | 5.85      | **zstd**       |
| 2     | 5.37      | 5.19        | 5.70      | **brotli**     |
| 3     | 5.26      | 5.06        | 5.54      | **brotli**     |
| 4     | 5.27      | 4.76        | 5.21      | **brotli**     |
| 5     | 4.96      | 4.48        | 5.02      | **brotli**     |
| 6     | 4.90      | 4.46        | 4.93      | **brotli**     |
| 7     | 4.88      | 4.42        | 4.89      | **brotli**     |
| 8     | 4.85      | 4.41        | 4.88      | **brotli**     |
| 9     | 4.82      | 4.41        | 4.88      | **brotli**     |

#### Compression Ratios (Level 6 - Recommended)

| Algorithm | Original Size | Compressed Size | Compression Ratio | Bandwidth Saved |
|-----------|---------------|-----------------|-------------------|-----------------|
| **None**  | 32.62 kB      | 32.62 kB        | 0%                | 0%              |
| **Gzip**  | 32.62 kB      | 4.93 kB         | 84.9%             | 84.9%           |
| **Brotli**| 32.62 kB      | 4.46 kB         | 86.3%             | 86.3%           |
| **Zstd**  | 32.62 kB      | 4.90 kB         | 85.0%             | 85.0%           |

### How to Reproduce

#### Setup Requirements
1. Install PHP extensions: `zstd` and `brotli`
2. In `upload/system/config/default.php`:
   - Find `$_['response_compression'] = 0;` and change value to 1-9
   - Add `$_['response_min_compress_size'] = 1024;` (optional, for minimum compression size)

#### Testing Method
1. Set compression level in config: `$_['response_compression'] = 6;`
2. Temporarily disable algorithms in `getBestEncoding()` method to force specific compression
3. Test each compression level individually  
4. Measure in Firefox Dev Tools → Network tab → Size vs Transferred

![image](https://github.com/user-attachments/assets/e970786c-5a14-407d-a22d-9f47701eba0e)

### Performance Testing Results (Apache Benchmark)

**Test Configuration:**
- **Requests**: 1000 total, 10 concurrent
- **Hardware**: MacBook Air M3 (8-core CPU, 16GB RAM)  
- **Compression Level**: 6 (recommended balanced setting)
- **Test Page**: OpenCart home page (32.6 KB uncompressed)

| Algorithm | RPS | Document Size | Compression Ratio | Performance Impact | Comments |
|-----------|-----|---------------|-------------------|-------------------|----------|
| None      | 40.06 | 32618 bytes | 0% | Baseline | No compression |
| **Zstd**  | 30.78 | 4119 bytes | 87.4% | -23% RPS | Best balance |
| **Brotli**| 24.49 | 3675 bytes | 88.7% | -39% RPS | Best compression |
| **Gzip**  | 21.36 | 4146 bytes | 87.3% | -47% RPS | Legacy fallback |

**Performance Analysis:**
- **Zstd (Level 6)**: Optimal choice for production - excellent compression with minimal CPU overhead
- **Brotli (Level 6)**: Best compression ratio but higher CPU cost
- **Gzip (Level 6)**: Surprisingly CPU-intensive, validates priority placement below zstd/brotli
- **Bandwidth Savings**: 87-89% reduction in data transfer across all algorithms

#### How to Reproduce Apache Benchmark

```bash
docker run --rm --network host httpd:alpine ab -n 1000 -c 10 http://localhost/

echo "=== GZIP ===" && docker run --rm --network host httpd:alpine ab -n 1000 -c 10 -H "Accept-Encoding: gzip" http://localhost/ | grep -E "(Requests per second|Document Length|Transfer rate)"

echo "=== BROTLI ===" && docker run --rm --network host httpd:alpine ab -n 1000 -c 10 -H "Accept-Encoding: br" http://localhost/ | grep -E "(Requests per second|Document Length|Transfer rate)"

echo "=== ZSTD ===" && docker run --rm --network host httpd:alpine ab -n 1000 -c 10 -H "Accept-Encoding: zstd" http://localhost/ | grep -E "(Requests per second|Document Length|Transfer rate)"
```

### Conclusion

While **brotli showed better compression ratios** in these tests, **zstd is considered a more advanced algorithm** with better performance characteristics in production environments.

> [!NOTE]
> #### Important Notes
> - **Testing limitations**: Measurements were performed without server load and CPU usage was not measured
> - **Server-level compression recommended**: While PHP/OpenCart compression is useful and convenient, **server-level compression (nginx, Apache) is recommended** for production environments for better performance
> - **Algorithm priority**: Despite test results, zstd maintains highest priority due to its superior speed/compression balance under load
> - **Automatic selection**: The implementation automatically selects the best available algorithm based on browser support and server capabilities 

#### Production Recommendations
1. **Primary**: Use server-level compression (nginx gzip/brotli modules)
2. **Fallback**: Enable this PHP compression for dynamic content not handled by server
3. **Monitoring**: Monitor CPU usage in production when enabling higher compression levels

### References
- [RFC 9110 Accept-Encoding](https://www.rfc-editor.org/rfc/rfc9110.html#name-accept-encoding) - HTTP Accept-Encoding specification
- [Zstandard Compression Algorithm](https://facebook.github.io/zstd/) - Facebook's official documentation
- [Brotli Compression Format](https://github.com/google/brotli) - Google's official repository  
- [HTTP Compression - MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Compression) - Comprehensive overview
- [Can I Use brotli](https://caniuse.com/brotli)
- [Can I Use zstd](https://caniuse.com/zstd)

### Future Improvements

If this PR is accepted, there are several areas for potential enhancement:

#### Compression Level Optimization

Currently, compression levels are limited to 0-9 for compatibility. However, different algorithms support different ranges:

| Algorithm | Current Range | Native Range | Recommendation |
|-----------|---------------|--------------|----------------|
| **Gzip**  | 0-9 ✅       | 0-9          | Optimal as-is  |
| **Deflate** | 0-9 ✅     | 0-9          | Optimal as-is  |
| **Brotli** | 0-9 ⚠️      | 0-11         | Consider extending to 0-11 |
| **Zstd**  | 0-9 ⚠️       | -7 to 22     | Consider extending to 0-22 |

**References:**
- [Zstd compression levels documentation](https://facebook.github.io/zstd/zstd_manual.html) - supports levels 1-22
- [Brotli quality levels](https://github.com/google/brotli/issues/725) - supports levels 0-11
- [Cloudflare Brotli implementation](https://blog.cloudflare.com/this-is-brotli-from-origin/) - uses level 11 in production

#### Proposed Enhancement

```php
private function getOptimalLevel(string $encoding, int $requested_level): int {
    return match($encoding) {
        'zstd' => min($requested_level, 22),
        'br' => min($requested_level, 11), 
        'gzip', 'deflate' => min($requested_level, 9),
        default => $requested_level
    };
}
```

These improvements would be suitable for future PRs to maintain focused, reviewable changes.