### PR TITLE
[3.0.x.x]Bugfix cardinity payment

### DIFF
--- a/upload/admin/model/extension/payment/cardinity.php
+++ b/upload/admin/model/extension/payment/cardinity.php
@@ -1,5 +1,4 @@
 <?php
-require_once DIR_SYSTEM . 'library/cardinity/cardinity-php-sdk.php';
 
 use Cardinity\Client;
 use Cardinity\Method\Payment;


### PR DESCRIPTION
it now uses the OpenCart vendor folder for the cardinity-sdk-php library.