### PR TITLE
Fix SSR counting

### DIFF
--- a/upload/admin/controller/ssr/admin/country.php
+++ b/upload/admin/controller/ssr/admin/country.php
@@ -144,7 +144,7 @@ class Country extends \Opencart\System\Engine\Controller {
 			$end = $start > ($country_total - $limit) ? $country_total : ($start + $limit);
 
 			if ($end < $country_total) {
-				$json['text'] = sprintf($this->language->get('text_next'), !$start ?? 1, $end, $country_total);
+				$json['text'] = sprintf($this->language->get('text_next'), $start ?: 1, $end, $country_total);
 
 				$json['next'] = $this->url->link('ssr/admin/country.info', 'user_token=' . $this->session->data['user_token'] . '&page=' . ($page + 1), true);
 			} else {

--- a/upload/admin/controller/ssr/catalog/country.php
+++ b/upload/admin/controller/ssr/catalog/country.php
@@ -194,7 +194,7 @@ class Country extends \Opencart\System\Engine\Controller {
 			$end = $start > ($country_total - $limit) ? $country_total : ($start + $limit);
 
 			if ($end < $country_total) {
-				$json['text'] = sprintf($this->language->get('text_next'), !$start ?? 1, $end, $country_total);
+				$json['text'] = sprintf($this->language->get('text_next'), $start ?: 1, $end, $country_total);
 
 				$json['next'] = $this->url->link('ssr/catalog/country.info', 'user_token=' . $this->session->data['user_token'] . '&page=' . ($page + 1), true);
 			} else {

--- a/upload/admin/controller/ssr/catalog/return_reason.php
+++ b/upload/admin/controller/ssr/catalog/return_reason.php
@@ -180,7 +180,7 @@ class Country extends \Opencart\System\Engine\Controller {
 
 			$end = $start > ($country_total - $limit) ? $country_total : ($start + $limit);
 
-			$json['text'] = sprintf($this->language->get('text_next'), !$start ?? 1, $end, $country_total);
+			$json['text'] = sprintf($this->language->get('text_next'), $start ?: 1, $end, $country_total);
 
 			if ($end < $country_total) {
 				$json['next'] = $this->url->link('ssr/country.info', 'user_token=' . $this->session->data['user_token'] . '&page=' . ($page + 1), true);
@@ -261,7 +261,7 @@ class Country extends \Opencart\System\Engine\Controller {
 
 			$end = $start > ($country_total - $limit) ? $country_total : ($start + $limit);
 
-			$json['text'] = sprintf($this->language->get('text_next'), !$start ?? 1, $end, $country_total);
+			$json['text'] = sprintf($this->language->get('text_next'), $start ?: 1, $end, $country_total);
 
 			if ($end < $country_total) {
 				$json['next'] = $this->url->link('ssr/country.info', 'user_token=' . $this->session->data['user_token'] . '&page=' . ($page + 1), true);


### PR DESCRIPTION
When SSR is counting past the first iteration, the `!$start` results in `false`, which does not trigger the null coalescing operator, and thus gets pass up to `sprintf()` as an empty string.

Removing the boolean operator and switching the null coalescing to a ternary operator allows both the first iteration (`$start` = 0) and subsequent iterations to populate the string with a valid number.