### PR TITLE
Fix PDO invalid parameter number

### DIFF
--- a/upload/system/library/db/pdo.php
+++ b/upload/system/library/db/pdo.php
@@ -113,9 +113,11 @@ class PDO {
 					return true;
 				}
 			} else {
+				$this->data = [];
 				return true;
 			}
 		} catch (\PDOException $e) {
+			$this->data = [];
 			throw new \Exception('Error: ' . $e->getMessage() . ' <br/>Error Code : ' . $e->getCode() . ' <br/>' . $sql);
 		}
 	}


### PR DESCRIPTION
When a given query fails, the `$data` property is left alone. If a caller somewhere up the stack catches the exception, the `$data` property maintains the state from the failed query while the application continues to run. The data gets included in subsequent queries, thus causing the `SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match number of tokens` exception.

This fix resets the `$data` property no matter the outcome.