### PR TITLE
[PROPOSAL] url.php

### DIFF
--- a/upload/system/library/url.php
+++ b/upload/system/library/url.php
@@ -90,6 +90,12 @@ class Url {
 	 * @return string
 	 */
 	public function link(string $route, $args = '', bool $js = false): string {
+		if (strpos('http', $route) !== false) {
+			return $route;
+		}
+
+		$route = str_replace('index.php?route=', '', $route);
+		
 		$url = $this->url . 'index.php?route=' . $route;
 
 		if ($args) {


### PR DESCRIPTION
Everytime when we deploy a new store and move the data to the live (client) server, we have to adopt the URLs (banner, etc.).

With that proposal, adding links in the dev-stage can be done without using absolute URLs.

For example instead adding the (SEO) link to a banner like https://myliveserver.com/My-Products we can use the standard link like index.php?route=product/category&path=61 or product/category&path=61 (as the link for SEO-URL would be finally).