### PR TITLE
[3.0.x.x] Update forgotten.php

### DIFF
--- a/upload/catalog/controller/account/forgotten.php
+++ b/upload/catalog/controller/account/forgotten.php
@@ -75,10 +75,12 @@ class ControllerAccountForgotten extends Controller {
 		}
 		
 		// Check if customer has been approved.
-		$customer_info = $this->model_account_customer->getCustomerByEmail($this->request->post['email']);
+		if (!$this->error) {
+			$customer_info = $this->model_account_customer->getCustomerByEmail($this->request->post['email']);
 
-		if ($customer_info && !$customer_info['status']) {
-			$this->error['warning'] = $this->language->get('error_approved');
+			if ($customer_info && !$customer_info['status']) {
+				$this->error['warning'] = $this->language->get('error_approved');
+			}
 		}
 
 		return !$this->error;


### PR DESCRIPTION
Due massive bot attacks, missing proper validation and if no further extensions (like a honeypot is installed), the error log file fills up with unneeded messages.