### PR TITLE
Add action menu divider

### DIFF
--- a/upload/admin/view/template/catalog/category.twig
+++ b/upload/admin/view/template/catalog/category.twig
@@ -11,6 +11,7 @@
           <ul class="dropdown-menu">
             <li><button type="submit" form="form-category" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-category" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
+            <li><hr class="dropdown-divider"></li>
             <li><button type="submit" form="form-category" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>

--- a/upload/admin/view/template/catalog/information.twig
+++ b/upload/admin/view/template/catalog/information.twig
@@ -9,6 +9,7 @@
           <ul class="dropdown-menu">
             <li><button type="submit" form="form-information" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-information" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
+            <li><hr class="dropdown-divider"></li>
             <li><button type="submit" form="form-information" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>

--- a/upload/admin/view/template/catalog/manufacturer.twig
+++ b/upload/admin/view/template/catalog/manufacturer.twig
@@ -10,6 +10,7 @@
           <ul class="dropdown-menu">
             <li><button type="submit" form="form-manufacturer" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-manufacturer" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
+            <li><hr class="dropdown-divider"></li>
             <li><button type="submit" form="form-manufacturer" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>

--- a/upload/admin/view/template/catalog/product.twig
+++ b/upload/admin/view/template/catalog/product.twig
@@ -9,8 +9,10 @@
           <button type="button" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown"><i class="fa-solid fa-list-check"></i> {{ button_action }} <i class="fa-solid fa-caret-down fa-fw"></i></button>
           <ul class="dropdown-menu">
             <li><button type="submit" form="form-product" formaction="{{ copy }}" class="dropdown-item"><i class="fa-solid fa-copy"></i> {{ text_copy }}</button></li>
+            <li><hr class="dropdown-divider"></li>
             <li><button type="submit" form="form-product" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-product" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
+            <li><hr class="dropdown-divider"></li>
             <li><button type="submit" form="form-product" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>

--- a/upload/admin/view/template/catalog/review.twig
+++ b/upload/admin/view/template/catalog/review.twig
@@ -11,6 +11,7 @@
           <ul class="dropdown-menu">
             <li><button type="submit" form="form-review" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-review" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
+            <li><hr class="dropdown-divider"></li>
             <li><button type="submit" form="form-review" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>

--- a/upload/admin/view/template/cms/article.twig
+++ b/upload/admin/view/template/cms/article.twig
@@ -10,6 +10,7 @@
           <ul class="dropdown-menu">
             <li><button type="submit" form="form-article" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-article" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
+            <li><hr class="dropdown-divider"></li>
             <li><button type="submit" form="form-article" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>

--- a/upload/admin/view/template/cms/topic.twig
+++ b/upload/admin/view/template/cms/topic.twig
@@ -9,6 +9,7 @@
           <ul class="dropdown-menu">
             <li><button type="submit" form="form-topic" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-topic" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
+            <li><hr class="dropdown-divider"></li>
             <li><button type="submit" form="form-topic" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>

--- a/upload/admin/view/template/customer/custom_field.twig
+++ b/upload/admin/view/template/customer/custom_field.twig
@@ -9,6 +9,7 @@
           <ul class="dropdown-menu">
             <li><button type="submit" form="form-custom-field" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-custom-field" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
+            <li><hr class="dropdown-divider"></li>
             <li><button type="submit" form="form-custom-field" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>

--- a/upload/admin/view/template/customer/customer.twig
+++ b/upload/admin/view/template/customer/customer.twig
@@ -10,6 +10,7 @@
           <ul class="dropdown-menu">
             <li><button type="submit" form="form-customer" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-customer" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
+            <li><hr class="dropdown-divider"></li>
             <li><button type="submit" form="form-customer" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>

--- a/upload/admin/view/template/customer/gdpr.twig
+++ b/upload/admin/view/template/customer/gdpr.twig
@@ -6,6 +6,7 @@
         <button type="button" data-bs-toggle="tooltip" title="{{ button_filter }}" onclick="$('#filter-gdpr').toggleClass('d-none');" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
         <button type="submit" form="form-gdpr" formaction="{{ approve }}" data-bs-toggle="tooltip" title="{{ text_approve }}" class="btn btn-success"><i class="fa-solid fa-check"></i></button>
         <button type="submit" form="form-gdpr" formaction="{{ deny }}" data-bs-toggle="tooltip" title="{{ text_deny }}" class="btn btn-warning"><i class="fa-solid fa-circle-xmark"></i></button>
+        <li><hr class="dropdown-divider"></li>
         <button type="submit" form="form-gdpr" formaction="{{ delete }}" data-bs-toggle="tooltip" title="{{ text_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>

--- a/upload/admin/view/template/design/banner.twig
+++ b/upload/admin/view/template/design/banner.twig
@@ -9,6 +9,7 @@
           <ul class="dropdown-menu">
             <li><button type="submit" form="form-banner" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-banner" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
+            <li><hr class="dropdown-divider"></li>
             <li><button type="submit" form="form-banner" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>

--- a/upload/admin/view/template/design/theme.twig
+++ b/upload/admin/view/template/design/theme.twig
@@ -9,6 +9,7 @@
           <ul class="dropdown-menu">
             <li><button type="submit" form="form-theme" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-theme" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
+            <li><hr class="dropdown-divider"></li>
             <li><button type="submit" form="form-theme" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>

--- a/upload/admin/view/template/design/translation.twig
+++ b/upload/admin/view/template/design/translation.twig
@@ -8,6 +8,7 @@
           <ul class="dropdown-menu">
             <li><button type="submit" form="form-translation" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-translation" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
+            <li><hr class="dropdown-divider"></li>
             <li><button type="submit" form="form-translation" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>

--- a/upload/admin/view/template/localisation/country.twig
+++ b/upload/admin/view/template/localisation/country.twig
@@ -10,6 +10,7 @@
           <ul class="dropdown-menu">
             <li><button type="submit" form="form-country" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-country" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
+            <li><hr class="dropdown-divider"></li>
             <li><button type="submit" form="form-country" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>

--- a/upload/admin/view/template/localisation/currency.twig
+++ b/upload/admin/view/template/localisation/currency.twig
@@ -10,6 +10,7 @@
           <ul class="dropdown-menu">
             <li><button type="submit" form="form-currency" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-currency" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
+            <li><hr class="dropdown-divider"></li>
             <li><button type="submit" form="form-currency" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>

--- a/upload/admin/view/template/localisation/language.twig
+++ b/upload/admin/view/template/localisation/language.twig
@@ -9,6 +9,7 @@
           <ul class="dropdown-menu">
             <li><button type="submit" form="form-language" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-language" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
+            <li><hr class="dropdown-divider"></li>
             <li><button type="submit" form="form-language" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>

--- a/upload/admin/view/template/localisation/zone.twig
+++ b/upload/admin/view/template/localisation/zone.twig
@@ -10,6 +10,7 @@
           <ul class="dropdown-menu">
             <li><button type="submit" form="form-zone" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-zone" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
+            <li><hr class="dropdown-divider"></li>
             <li><button type="submit" form="form-zone" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>

--- a/upload/admin/view/template/marketing/affiliate.twig
+++ b/upload/admin/view/template/marketing/affiliate.twig
@@ -11,8 +11,10 @@
           <ul class="dropdown-menu">
             <li><button type="submit" form="form-affiliate" formaction="{{ csv }}" class="dropdown-item"><i class="fa-solid fa-file-csv"></i> {{ text_csv }}</button></li>
             <li><button type="submit" form="form-affiliate" formaction="{{ complete }}" class="dropdown-item"><i class="fa-solid fa-credit-card"></i> {{ text_complete }}</button></li>
+            <li><hr class="dropdown-divider"></li>
             <li><button type="submit" form="form-affiliate" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-affiliate" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
+            <li><hr class="dropdown-divider"></li>
             <li><button type="submit" form="form-affiliate" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>

--- a/upload/admin/view/template/marketing/coupon.twig
+++ b/upload/admin/view/template/marketing/coupon.twig
@@ -9,6 +9,7 @@
           <ul class="dropdown-menu">
             <li><button type="submit" form="form-coupon" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-coupon" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
+            <li><hr class="dropdown-divider"></li>
             <li><button type="submit" form="form-coupon" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>

--- a/upload/admin/view/template/marketplace/cron.twig
+++ b/upload/admin/view/template/marketplace/cron.twig
@@ -8,6 +8,7 @@
           <ul class="dropdown-menu">
             <li><button type="submit" form="form-cron" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-cron" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
+            <li><hr class="dropdown-divider"></li>
             <li><button type="submit" form="form-cron" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>

--- a/upload/admin/view/template/marketplace/event.twig
+++ b/upload/admin/view/template/marketplace/event.twig
@@ -8,6 +8,7 @@
           <ul class="dropdown-menu">
             <li><button type="submit" form="form-event" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-event" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
+            <li><hr class="dropdown-divider"></li>
             <li><button type="submit" form="form-event" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>

--- a/upload/admin/view/template/marketplace/ssr.twig
+++ b/upload/admin/view/template/marketplace/ssr.twig
@@ -8,6 +8,7 @@
           <ul class="dropdown-menu">
             <li><button type="submit" form="form-ssr" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-ssr" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
+            <li><hr class="dropdown-divider"></li>
             <li><button type="submit" form="form-ssr" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>

--- a/upload/admin/view/template/marketplace/startup.twig
+++ b/upload/admin/view/template/marketplace/startup.twig
@@ -8,6 +8,7 @@
           <ul class="dropdown-menu">
             <li><button type="submit" form="form-startup" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-startup" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
+            <li><hr class="dropdown-divider"></li>
             <li><button type="submit" form="form-startup" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>

--- a/upload/admin/view/template/marketplace/task.twig
+++ b/upload/admin/view/template/marketplace/task.twig
@@ -8,6 +8,7 @@
           <ul class="dropdown-menu">
             <li><button type="submit" form="form-task" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-task" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
+            <li><hr class="dropdown-divider"></li>
             <li><button type="submit" form="form-task" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>

--- a/upload/admin/view/template/user/user.twig
+++ b/upload/admin/view/template/user/user.twig
@@ -10,6 +10,7 @@
           <ul class="dropdown-menu">
             <li><button type="submit" form="form-user" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-user" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
+            <li><hr class="dropdown-divider"></li>
             <li><button type="submit" form="form-user" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>


### PR DESCRIPTION
Using dividers and grouping actions lists makes menus much more convenient and pretty

Before:
<img width="430" height="347" alt="image" src="https://github.com/user-attachments/assets/93675e6d-5f7f-44e1-81cd-6249ac59cea5" />

After:
<img width="423" height="364" alt="image" src="https://github.com/user-attachments/assets/a12f92c9-94c3-4f12-926f-c96855468687" />
