### PR TITLE
[Master] Update framework.php > correct timezone value

### DIFF
--- a/upload/system/framework.php
+++ b/upload/system/framework.php
@@ -27,7 +27,7 @@ $registry->set('config', $config);
 $config->set('application', APPLICATION);
 
 // Set the default time zone
-date_default_timezone_set($config->get('date_timezone'));
+date_default_timezone_set($config->get('config_timezone'));
 
 // Logging
 $log = new \Opencart\System\Library\Log($config->get('error_filename'));


### PR DESCRIPTION
Fix incorrect value **date_timezone** to config value **config_timezone** to show also correct timestamp on all log files when using the log library.