### PR TITLE
[OC 3.x.x.x] Update framework.php > correct timezone

### DIFF
--- a/upload/system/framework.php
+++ b/upload/system/framework.php
@@ -12,7 +12,7 @@ $registry->set('config', $config);
 $log = new Log($config->get('error_filename'));
 $registry->set('log', $log);
 
-date_default_timezone_set($config->get('date_timezone'));
+date_default_timezone_set($config->get('config_timezone'));
 
 set_error_handler(function($code, $message, $file, $line) use($log, $config) {
 	// error suppressed with @


### PR DESCRIPTION
Fix incorrect value **date_timezone** to config value **config_timezone** to show also correct timestamp on all log files when using the log library.