### PR TITLE
refactor(document): improve meta tag handling with flexible attributes

### DIFF
--- a/upload/catalog/controller/common/header.php
+++ b/upload/catalog/controller/common/header.php
@@ -47,6 +47,7 @@ class Header extends \Opencart\System\Engine\Controller {
 		$data['links'] = $this->document->getLinks();
 		$data['styles'] = $this->document->getStyles();
 		$data['scripts'] = $this->document->getScripts('header');
+		$data['metas'] = $this->document->getMetas();
 
 		$data['name'] = $this->config->get('config_name');
 

--- a/upload/catalog/view/template/common/header.twig
+++ b/upload/catalog/view/template/common/header.twig
@@ -11,6 +11,9 @@
   {% if keywords %}
     <meta name="keywords" content="{{ keywords }}"/>
   {% endif %}
+  {% for meta in metas %}
+    <meta{% for attr, value in meta %} {{ attr|e('html_attr') }}="{{ value|e('html') }}"{% endfor %}>
+  {% endfor %}
   <link href="{{ stylesheet }}" type="text/css" rel="stylesheet"/>
   <script src="{{ jquery }}" type="text/javascript"></script>
   <script src="catalog/view/javascript/common.js" type="text/javascript"></script>

--- a/upload/system/library/document.php
+++ b/upload/system/library/document.php
@@ -38,9 +38,9 @@ class Document {
 	 */
 	private array $scripts = [];
 	/**
-	 * @var array<string, string>
+	 * @var array<int, array<string, string>> Meta tags with their attributes
 	 */
-	private array $meta = [];
+	private array $metas = [];
 
 	/**
 	 * Set Title
@@ -180,20 +180,32 @@ class Document {
 	/**
 	 * Add Meta
 	 *
-	 * @param string $meta
+	 * Adds a meta tag with specified attributes to the document.
+	 *
+	 * @param array<string, string> $attributes Associative array of meta tag attributes
+	 *                                          Common attributes:
+	 *                                          - 'name' => 'description' (for standard meta tags)
+	 *                                          - 'property' => 'og:title' (for Open Graph)
+	 *                                          - 'content' => 'The content value'
+	 *                                          - 'media' => '(prefers-color-scheme: dark)' (for conditional meta tags)
 	 *
 	 * @return void
+	 *
+	 * @example
+	 * $this->document->addMeta(['name' => 'description', 'content' => 'Page description']);
+	 * $this->document->addMeta(['property' => 'og:title', 'content' => 'Page Title']);
+	 * $this->document->addMeta(['name' => 'theme-color', 'content' => '#000', 'media' => '(prefers-color-scheme: dark)']);
 	 */
-	public function addMeta(string $meta): void {
-		$this->meta[$meta] = $meta;
+	public function addMeta(array $attributes): void {
+		$this->metas[] = $attributes;
 	}
 
 	/**
-	 * Get Meta
+	 * Get Metas
 	 *
-	 * @return array<string, string>
+	 * @return array<int, array<string, string>>
 	 */
-	public function getMeta() {
-		return $this->meta;
+	public function getMetas(): array {
+		return $this->metas;
 	}
 }


### PR DESCRIPTION
This commit refactors the `Document` library to handle meta tags as a collection of attributes rather than simple key-value pairs.

The key changes include:

- **Enhanced Flexibility**: The `addMeta()` method now accepts an associative array of attributes, allowing for the creation of complex meta tags like Open Graph (`og:`) tags or conditional tags with a `media` attribute.
- **Improved API**: Renamed the internal property to `$metas` and the getter method to `getMetas()` to reflect that it now returns a collection of meta tags.
- **Controller & View Integration**: Updated the `header` controller to pass the collection of meta tags to the view, and the `header.twig` template to render the attributes dynamically.

> [!WARNING]
> **BREAKING CHANGE:** The `getMeta()` method has been renamed to `getMetas()` and now returns an `array` of attribute arrays instead of key-value pairs.

Related to #15120

Example to use:

```php
$this->document->addMeta([
	'name'    => 'robots',
	'content' => 'noindex, nofollow'
]);
```

It will return:
```html
<meta name="robots" content="noindex, nofollow">
```
        
---

<img width="1050" height="413" alt="image" src="https://github.com/user-attachments/assets/3e1c7584-544f-45ba-ad33-1630622ffe4b" />

---

For more information on the `html_attr` filter used for dynamic HTML attribute names, you can refer to the official Twig documentation:
https://twig.symfony.com/doc/3.x/filters/escape.html#:~:text=Tip,attribute%20name%3A