### PR TITLE
fix(docs): remove space and fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,4 +180,4 @@ To receive developer notifications about release information, sign up to the new
 - [How to documents](http://docs.opencart.com/en-gb/introduction/)
 - [Newsletter](https://newsletter.opencart.com/h/r/B660EBBE4980C85C)
 - [Discussions](https://github.com/opencart/opencart/discussions)
-- [Chat] (https://teams.live.com/l/community/FEAMBRGMM2X2wz82gI)
+- [Chat](https://teams.live.com/l/community/FEAMBRGMM2X2wz82gI)


### PR DESCRIPTION
Removes an extra space in the `[Chat]` link to fix the broken URL.

<img width="585" height="265" alt="image" src="https://github.com/user-attachments/assets/c4c61376-4a00-4d68-a143-90422a8c5ee8" />
