### PR TITLE
fix(lint): resolve syntax error in subscription controller

### DIFF
--- a/upload/admin/controller/task/admin/subscription.php
+++ b/upload/admin/controller/task/admin/subscription.php
@@ -216,13 +216,8 @@ class Subscription extends \Opencart\System\Engine\Controller {
 
 		}
 
-
-
-
 		// Payment Address
-		if () {
-			$store->session->data['payment_address'] = $payment_address_info;
-		}
+		$store->session->data['payment_address'] = $payment_address_info;
 
 		// Payment Method
 		$store->session->data['payment_method'] = $subscription_info['payment_method'];


### PR DESCRIPTION
This PR fixes a bug in the subscription task controller where the payment address was not being assigned correctly due to a syntax error.