### PR TITLE
fix(header): HTML characters(for example double quotes) break HTML

### DIFF
--- a/upload/catalog/view/template/common/header.twig
+++ b/upload/catalog/view/template/common/header.twig
@@ -6,7 +6,7 @@
   <title>{{ title }}</title>
   <base href="{{ base }}"/>
   {% if description %}
-    <meta name="description" content="{{ description }}"/>
+    <meta name="description" content="{{ description|e('html') }}"/>
   {% endif %}
   {% if keywords %}
     <meta name="keywords" content="{{ keywords }}"/>


### PR DESCRIPTION
To fix this I suggest using **escape** filter
https://twig.symfony.com/doc/3.x/filters/escape.html