### PR TITLE
Bugfix (Admin): Correct pagination route in sales order report

### DIFF
--- a/upload/extension/opencart/admin/controller/report/sale_order.php
+++ b/upload/extension/opencart/admin/controller/report/sale_order.php
@@ -212,7 +212,7 @@ class SaleOrder extends \Opencart\System\Engine\Controller {
 			'total' => $order_total,
 			'page'  => $page,
 			'limit' => $this->config->get('config_pagination'),
-			'url'   => $this->url->link('extension/opencart/report/sale_order', 'user_token=' . $this->session->data['user_token'] . '&code=sale_order' . $url . '&page={page}')
+			'url'   => $this->url->link('extension/opencart/report/sale_order.list', 'user_token=' . $this->session->data['user_token'] . '&code=sale_order' . $url . '&page={page}')
 		]);
 
 		$data['results'] = sprintf($this->language->get('text_pagination'), ($order_total) ? (($page - 1) * $this->config->get('config_pagination')) + 1 : 0, ((($page - 1) * $this->config->get('config_pagination')) > ($order_total - $this->config->get('config_pagination'))) ? $order_total : ((($page - 1) * $this->config->get('config_pagination')) + $this->config->get('config_pagination')), $order_total, ceil($order_total / $this->config->get('config_pagination')));


### PR DESCRIPTION
### Issue
Without .list, clicking pagination links in the Sales Order report redirected to the report extension settings page instead of showing the next set of results in the report list table.

### Steps to reproduce
Go to: https://yourdomain.com/admin/index.php?route=report/report
From the dropdown, select Sales Report.
Click Next Page in pagination.
Instead of showing the next set of results, it redirects to the report extension settings page within the table view.