### PR TITLE
Update coupon.php

### DIFF
--- a/upload/admin/controller/marketing/coupon.php
+++ b/upload/admin/controller/marketing/coupon.php
@@ -330,7 +330,7 @@ class Coupon extends \Opencart\System\Engine\Controller {
 		if (!empty($coupon_info)) {
 			$data['uses_total'] = $coupon_info['uses_total'];
 		} else {
-			$data['uses_total'] = 1;
+			$data['uses_total'] = '';
 		}
 
 		if (!empty($coupon_info)) {


### PR DESCRIPTION
Default for 'uses total' should be blank, as its much less likely that this option would be needed regularly, if ever. As it limits the discount code to be used only once regardless of customer.