### PR TITLE
Fix viewing embedded Youtube video

### DIFF
--- a/upload/.htaccess.txt
+++ b/upload/.htaccess.txt
@@ -21,7 +21,7 @@
 
 ## No-Referrer-Header
 <IfModule mod_headers.c>
-  Header set Referrer-Policy "no-referrer"
+  Header set Referrer-Policy "strict-origin-when-cross-origin"
 </IfModule>
 
 ## Suppress mime type detection in browsers for unknown types and prevent FLOC


### PR DESCRIPTION
Recently, Youtube has tightened its policy for embedded videos.
The existing .htaccess configuration will prevent viewing and you will see error 153 instead of the video.

This fix fixes the problem.