### PR TITLE
[php 8.5 Compatibility] install/promotion.php

### DIFF
--- a/upload/install/controller/install/promotion.php
+++ b/upload/install/controller/install/promotion.php
@@ -18,8 +18,6 @@ class ControllerInstallPromotion extends Controller {
 			$response = '';
 		}
 
-		curl_close($curl);
-
 		return $response;
 	}
 }


### PR DESCRIPTION
Removed deprecated curl_close() (no effect since php 8.0)