### PR TITLE
[php 8.5 Compatibility] promotion.php

### DIFF
--- a/upload/admin/controller/extension/extension/promotion.php
+++ b/upload/admin/controller/extension/extension/promotion.php
@@ -13,10 +13,8 @@ class ControllerExtensionExtensionPromotion extends Controller {
 		$response = curl_exec($curl);
 
 		if ($response && curl_getinfo($curl, CURLINFO_HTTP_CODE) === 200) {
-			curl_close($curl);
 			return $response;
 		} else {
-			curl_close($curl);
 			return '';
 		}
 	}


### PR DESCRIPTION
Removed deprecated curl_close(), has no effect since php 8.0