### PR TITLE
[php 8.5 Compatibility] curl.php

### DIFF
--- a/upload/system/library/curl.php
+++ b/upload/system/library/curl.php
@@ -67,8 +67,6 @@ class Curl {
 
 		$status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
-		curl_close($curl);
-
 		if ($status == 200) {
 			$response_info = json_decode($response, true);
 		} else {


### PR DESCRIPTION
Removed deprecated curl_close()