### PR TITLE
[php 8.5 Compatibility] order.php

### DIFF
--- a/upload/admin/controller/sale/order.php
+++ b/upload/admin/controller/sale/order.php
@@ -918,8 +918,6 @@ class Order extends \Opencart\System\Engine\Controller {
 	 *
 	 * $status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 	 *
-	 * curl_close($curl);
-	 *
 	 * if ($status == 200) {
 	 *      $response_info = json_decode($response, true);
 	 * } else {


### PR DESCRIPTION
Removed deprecated curl_close()