### PR TITLE
[php 8.5 Compatibility] notification.php

### DIFF
--- a/upload/admin/controller/task/system/notification.php
+++ b/upload/admin/controller/task/system/notification.php
@@ -26,8 +26,6 @@ class Notification extends \Opencart\System\Engine\Controller {
 
 			$status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
-			curl_close($curl);
-
 			// Notification
 			if ($status == 200) {
 				$notification = json_decode($response, true);


### PR DESCRIPTION
Removed deprecated curl_close()