### PR TITLE
Fix: Use password input type for admin password in installer

### DIFF
--- a/upload/install/view/template/install/step_3.twig
+++ b/upload/install/view/template/install/step_3.twig
@@ -113,7 +113,7 @@
                   </div>
                   <div class="col-12 col-md-6 required">
                     <label for="input-password" class="form-label">{{ entry_password }}</label>
-                    <input type="text" name="password" value="" id="input-password" class="form-control"/>
+                    <input type="password" name="password" value="" id="input-password" class="form-control"/>
                     <div id="error-password" class="invalid-feedback"></div>
                   </div>
                 </div>


### PR DESCRIPTION
This pull request updates the administrator password field in the installer from
<input type="text"> to <input type="password">.

The previous implementation caused browsers to treat the administrator password as a normal text field, allowing it to be stored in autofill history and later displayed in autocomplete suggestions. This unintended behavior could expose sensitive credentials to anyone with access to the browser or local profile.

By switching to type="password", the installer prevents browsers from saving or suggesting the password in plain text. This change aligns the installation process with standard security practices, reduces the risk of accidental credential disclosure, and improves overall user safety.