### PR TITLE
[3.0.x.x] Removal of imagedestroy

### DIFF
--- a/upload/catalog/controller/extension/captcha/basic.php
+++ b/upload/catalog/controller/extension/captcha/basic.php
@@ -51,7 +51,6 @@ class ControllerExtensionCaptchaBasic extends Controller {
 
 		imagejpeg($image);
 
-		imagedestroy($image);
 		exit();
 	}
 }


### PR DESCRIPTION
imagedestroy has been deprecated since PHP 8.0