### PR TITLE
Non full validation PDO library

### DIFF
--- a/upload/system/library/db/pdo.php
+++ b/upload/system/library/db/pdo.php
@@ -45,7 +45,8 @@ class PDO {
 		$required = [
 			'hostname',
 			'username',
-			'database'
+			'database',
+			'password'
 		];
 
 		foreach ($required as $key) {


### PR DESCRIPTION
Add addintional-missing required field avoiding error and for full validation protection

protection fully not works, because if the password is not provided, the next step will be interrupted already