### PR TITLE
[3.0.x.x ] Remove GLOB_BRACE for glob() to improve compatibility on musl-based systems

### DIFF
--- a/upload/admin/controller/marketplace/extension.php
+++ b/upload/admin/controller/marketplace/extension.php
@@ -29,7 +29,7 @@ class ControllerMarketplaceExtension extends Controller {
 		
 		$data['categories'] = array();
 		
-		$files = glob(DIR_APPLICATION . 'controller/extension/extension/*.php', GLOB_BRACE);
+		$files = glob(DIR_APPLICATION . 'controller/extension/extension/*.php');
 		
 		foreach ($files as $file) {
 			$extension = basename($file, '.php');
@@ -42,7 +42,7 @@ class ControllerMarketplaceExtension extends Controller {
 			$this->load->language('extension/extension/' . $extension, 'extension');
 		
 			if ($this->user->hasPermission('access', 'extension/extension/' . $extension)) {
-				$files = glob(DIR_APPLICATION . 'controller/extension/' . $extension . '/*.php', GLOB_BRACE);
+				$files = glob(DIR_APPLICATION . 'controller/extension/' . $extension . '/*.php');
 		
 				$data['categories'][] = array(
 					'code' => $extension,


### PR DESCRIPTION
GLOB_BRACE is not supported on some environments using musl libc (e.g., Alpine Linux, Docker images based on Alpine, FrankenPHP). 
Since the glob patterns here do not use braces (no {a,b} syntax), removing GLOB_BRACE does not affect functionality but improves cross-platform compatibility.