### PR TITLE
Feature: Add authentication support to Redis Cache driver

### DIFF
--- a/upload/system/library/cache/redis.php
+++ b/upload/system/library/cache/redis.php
@@ -9,6 +9,10 @@ class Redis {
 
 		$this->cache = new \Redis();
 		$this->cache->pconnect(CACHE_HOSTNAME, CACHE_PORT);
+
+		if (defined('CACHE_PASSWORD') && CACHE_PASSWORD) {
+			$this->cache->auth(CACHE_PASSWORD);
+		}
 	}
 
 	public function get($key) {


### PR DESCRIPTION
### What is this PR for?
This PR addresses an issue in the `system/library/cache/redis.php` driver where the standard driver does not support Redis password authentication. This leads to `NOAUTH Authentication required` errors on secured Redis instances.

### Changes Proposed
**Added `CACHE_PASSWORD` support:**
- In `__construct()`, the driver now checks if the `CACHE_PASSWORD` constant is defined.
- If defined and not empty, it executes `$this->cache->auth(CACHE_PASSWORD)`.

### How to use
1. Define `CACHE_PASSWORD` in `config.php`:
   ```php
   define('CACHE_PASSWORD', 'your_secret_password');
2. Configure OpenCart to use Redis cache driver.
3. The connection will now succeed with authentication.

### Impact
**Backward Compatibility:** Fully compatible. If the constant is not defined, the behavior remains unchanged (no auth attempted).