### PR TITLE
Replace glob() with GLOB_BRACE using scandir() for Alpine Linux compatibility

### DIFF
--- a/upload/admin/controller/common/developer.php
+++ b/upload/admin/controller/common/developer.php
@@ -265,16 +265,26 @@ class Developer extends \Opencart\System\Engine\Controller {
 								$next = array_shift($directories);
 
 								if (is_dir($next)) {
-									foreach (glob(trim($next, '/') . '/{*,.[!.]*,..?*}', GLOB_BRACE) as $file) {
-										if (is_dir($file)) {
-											$directories[] = $file . '/';
-										}
+									$files = scandir($next);
 
-										if (is_file($file)) {
-											$namespace = substr(dirname($file), strlen(DIR_STORAGE . 'vendor/' . $directory . $classmap) + 1);
+									if ($files !== false) {
+										foreach ($files as $filename) {											
+											if ($filename == '.' || $filename == '..') {
+												continue;
+											}
 
-											if ($namespace) {
-												$autoload[$namespace] = substr(dirname($file), strlen(DIR_STORAGE . 'vendor/'));
+											$file = rtrim($next, '/') . '/' . $filename;
+
+											if (is_dir($file)) {
+												$directories[] = $file . '/';
+											}
+
+											if (is_file($file)) {
+												$namespace = substr(dirname($file), strlen(DIR_STORAGE . 'vendor/' . $directory . $classmap) + 1);
+
+												if ($namespace) {
+													$autoload[$namespace] = substr(dirname($file), strlen(DIR_STORAGE . 'vendor/'));
+												}
 											}
 										}
 									}

--- a/upload/install/controller/upgrade/upgrade_1.php
+++ b/upload/install/controller/upgrade/upgrade_1.php
@@ -240,9 +240,17 @@ class Upgrade1 extends \Opencart\System\Engine\Controller {
 					$next = array_shift($directory);
 
 					if (is_dir($next)) {
-						foreach (glob(trim($next, '/') . '/{*,.[!.]*,..?*}', GLOB_BRACE) as $delete) {
-							// If directory add to path array
-							$directory[] = $delete;
+						// Fix for Alpine Linux: Replace glob with GLOB_BRACE using scandir
+						$files_scanned = scandir($next);
+						
+						if ($files_scanned !== false) {
+							foreach ($files_scanned as $file) {
+								if ($file == '.' || $file == '..') {
+									continue;
+								}
+								
+								$directory[] = rtrim($next, '/') . '/' . $file;
+							}
 						}
 					}
 

--- a/upload/install/controller/upgrade/upgrade_2.php
+++ b/upload/install/controller/upgrade/upgrade_2.php
@@ -89,14 +89,27 @@ class Upgrade2 extends \Opencart\System\Engine\Controller {
 				while (count($directory) != 0) {
 					$next = array_shift($directory);
 
-					foreach (glob(rtrim($next, '/') . '/{*,.[!.]*,..?*}', GLOB_BRACE) as $file) {
-						// If directory add to path array
-						if (is_dir($file)) {
-							$directory[] = $file;
-						}
+					// Fix for Alpine Linux: Replace glob with GLOB_BRACE using scandir
+					if (is_dir($next)) {
+						$files_scanned = scandir($next);
 
-						// Add the file to the files to be deleted array
-						$files[] = $file;
+						if ($files_scanned !== false) {
+							foreach ($files_scanned as $file) {
+								if ($file == '.' || $file == '..') {
+									continue;
+								}
+
+								$file = rtrim($next, '/') . '/' . $file;
+
+								// If directory add to path array
+								if (is_dir($file)) {
+									$directory[] = $file;
+								}
+
+								// Add the file to the files to be deleted array
+								$files[] = $file;
+							}
+						}
 					}
 				}
 

--- a/upload/system/helper/vendor.php
+++ b/upload/system/helper/vendor.php
@@ -56,16 +56,27 @@ function oc_generate_vendor(): void {
 						$next = array_shift($directories);
 
 						if (is_dir($next)) {
-							foreach (glob(trim($next, '/') . '/{*,.[!.]*,..?*}', GLOB_BRACE) as $file) {
-								if (is_dir($file)) {
-									$directories[] = $file . '/';
-								}
+							// Fix for Alpine Linux: Replace glob with GLOB_BRACE using scandir
+							$scanned_files = scandir($next);
 
-								if (is_file($file)) {
-									$namespace = substr(dirname($file), strlen(DIR_STORAGE . 'vendor/' . $directory . $classmap) + 1);
+							if ($scanned_files !== false) {
+								foreach ($scanned_files as $filename) {
+									if ($filename == '.' || $filename == '..') {
+										continue;
+									}
 
-									if ($namespace) {
-										$autoload[$namespace] = substr(dirname($file), strlen(DIR_STORAGE . 'vendor/'));
+									$child_file = rtrim($next, '/') . '/' . $filename;
+
+									if (is_dir($child_file)) {
+										$directories[] = $child_file . '/';
+									}
+
+									if (is_file($child_file)) {
+										$namespace = substr(dirname($child_file), strlen(DIR_STORAGE . 'vendor/' . $directory . $classmap) + 1);
+
+										if ($namespace) {
+											$autoload[$namespace] = substr(dirname($child_file), strlen(DIR_STORAGE . 'vendor/'));
+										}
 									}
 								}
 							}


### PR DESCRIPTION
The GLOB_BRACE flag is not supported by the musl libc implementation used in Alpine Linux (and derived Docker images like FrankenPHP). Using it causes fatal errors or incorrect file listing on these systems.

This commit replaces glob() with scandir() and manual filtering in:
1. Developer tools (Vendor autoloader generation).
2. Upgrade scripts (Cleaning old directories and moving files to storage).
3. System Helper Vendor generator.

This ensures OpenCart 4 works correctly in modern containerized environments.