### PR TITLE
Use constant-time comparison for API HMAC signature validation

### DIFF
--- a/test_functional_regression.php
+++ b/test_functional_regression.php
@@ -1,0 +1,237 @@
+<?php
+/**
+ * Functional Regression Test for OpenCart API Authentication Fix
+ * 
+ * This test validates that the security fix doesn't break legitimate API functionality.
+ */
+
+echo "=== OpenCart API Authentication - Functional Regression Test ===\n\n";
+
+// Simulate the fixed API authentication logic
+class ApiAuthSimulator {
+    private $api_key = 'test_api_key_for_regression_testing';
+    
+    public function validateRequest($request_params, $server_params, $post_data = []) {
+        echo "  Testing request validation...\n";
+        
+        // Simulate the OpenCart API authentication flow
+        $api_info = ['username' => 'test_api_user', 'key' => $this->api_key];
+        
+        // Build the HMAC string (matches OpenCart logic)
+        $string  = (string)$request_params['route'] . "\n";
+        $string .= (string)$request_params['call'] . "\n";
+        $string .= $api_info['username'] . "\n";
+        $string .= (string)$server_params['HTTP_HOST'] . "\n";
+        $string .= (!empty($server_params['PHP_SELF']) ? rtrim(dirname($server_params['PHP_SELF']), '/') . '/' : '/') . "\n";
+        $string .= (int)$request_params['store_id'] . "\n";
+        $string .= (string)$request_params['language'] . "\n";
+        $string .= (string)$request_params['currency'] . "\n";
+        $string .= md5(http_build_query($post_data)) . "\n";
+        $string .= (string)$request_params['time'] . "\n";
+        
+        // NEW SECURE CODE: Using hash_equals() for constant-time comparison
+        $expected_signature = base64_encode(hash_hmac('sha1', $string, $api_info['key'], true));
+        $provided_signature = rawurldecode((string)$request_params['signature']);
+        
+        if (!hash_equals($expected_signature, $provided_signature)) {
+            return false;
+        }
+        
+        return true;
+    }
+    
+    public function generateValidSignature($request_params, $server_params, $post_data = []) {
+        $api_info = ['username' => 'test_api_user', 'key' => $this->api_key];
+        
+        $string  = (string)$request_params['route'] . "\n";
+        $string .= (string)$request_params['call'] . "\n";
+        $string .= $api_info['username'] . "\n";
+        $string .= (string)$server_params['HTTP_HOST'] . "\n";
+        $string .= (!empty($server_params['PHP_SELF']) ? rtrim(dirname($server_params['PHP_SELF']), '/') . '/' : '/') . "\n";
+        $string .= (int)$request_params['store_id'] . "\n";
+        $string .= (string)$request_params['language'] . "\n";
+        $string .= (string)$request_params['currency'] . "\n";
+        $string .= md5(http_build_query($post_data)) . "\n";
+        $string .= (string)$request_params['time'] . "\n";
+        
+        return base64_encode(hash_hmac('sha1', $string, $api_info['key'], true));
+    }
+}
+
+$simulator = new ApiAuthSimulator();
+
+// Test Case 1: Valid API request with correct signature
+echo "Test 1: Valid API request with correct signature\n";
+$request = [
+    'route' => 'api/order',
+    'call' => 'customer',
+    'username' => 'test_api_user',
+    'store_id' => 0,
+    'language' => 'en-gb',
+    'currency' => 'USD',
+    'time' => time(),
+];
+$server = [
+    'HTTP_HOST' => 'example.com',
+    'PHP_SELF' => '/index.php',
+];
+$post = [];
+
+$valid_signature = $simulator->generateValidSignature($request, $server, $post);
+$request['signature'] = rawurlencode($valid_signature);
+
+if ($simulator->validateRequest($request, $server, $post)) {
+    echo "✓ PASS: Valid request accepted\n\n";
+} else {
+    echo "❌ FAIL: Valid request rejected - REGRESSION DETECTED\n";
+    exit(1);
+}
+
+// Test Case 2: Invalid signature - should be rejected
+echo "Test 2: Invalid signature rejection\n";
+$request['signature'] = 'invalid_signature_12345';
+
+if (!$simulator->validateRequest($request, $server, $post)) {
+    echo "✓ PASS: Invalid signature correctly rejected\n\n";
+} else {
+    echo "❌ FAIL: Invalid signature accepted - SECURITY FAILURE\n";
+    exit(1);
+}
+
+// Test Case 3: URL-encoded signature (common scenario)
+echo "Test 3: URL-encoded signature handling\n";
+$valid_signature = $simulator->generateValidSignature($request, $server, $post);
+$request['signature'] = rawurlencode($valid_signature);  // Simulate URL encoding
+
+if ($simulator->validateRequest($request, $server, $post)) {
+    echo "✓ PASS: URL-encoded signature correctly handled\n\n";
+} else {
+    echo "❌ FAIL: URL-encoded signature rejected - REGRESSION DETECTED\n";
+    exit(1);
+}
+
+// Test Case 4: Different POST data changes signature
+echo "Test 4: POST data integrity verification\n";
+$post_data_1 = ['product_id' => 123, 'quantity' => 2];
+$post_data_2 = ['product_id' => 456, 'quantity' => 1];
+
+$sig_with_post1 = $simulator->generateValidSignature($request, $server, $post_data_1);
+$sig_with_post2 = $simulator->generateValidSignature($request, $server, $post_data_2);
+
+if ($sig_with_post1 !== $sig_with_post2) {
+    echo "  ✓ Different POST data produces different signatures\n";
+} else {
+    echo "  ❌ FAIL: POST data not included in signature\n";
+    exit(1);
+}
+
+// Validate with correct POST data
+$request['signature'] = rawurlencode($sig_with_post1);
+if ($simulator->validateRequest($request, $server, $post_data_1)) {
+    echo "  ✓ Signature valid for matching POST data\n";
+} else {
+    echo "  ❌ FAIL: Valid signature with POST data rejected\n";
+    exit(1);
+}
+
+// Should fail with different POST data
+if (!$simulator->validateRequest($request, $server, $post_data_2)) {
+    echo "  ✓ Signature invalid for different POST data\n";
+} else {
+    echo "  ❌ FAIL: Signature accepted with tampered POST data\n";
+    exit(1);
+}
+
+echo "✓ PASS: POST data integrity checks working correctly\n\n";
+
+// Test Case 5: Case sensitivity
+echo "Test 5: Case sensitivity of signatures\n";
+$valid_sig = $simulator->generateValidSignature($request, $server, $post);
+$uppercase_sig = strtoupper($valid_sig);
+
+$request['signature'] = $valid_sig;
+$valid_result = $simulator->validateRequest($request, $server, $post);
+
+$request['signature'] = $uppercase_sig;
+$uppercase_result = $simulator->validateRequest($request, $server, $post);
+
+if ($valid_result && !$uppercase_result) {
+    echo "✓ PASS: Signature comparison is case-sensitive\n\n";
+} else {
+    echo "❌ FAIL: Case sensitivity issue detected\n";
+    exit(1);
+}
+
+// Test Case 6: Signature with special characters (base64 padding)
+echo "Test 6: Base64 signatures with padding and special chars\n";
+$test_iterations = 10;
+$all_passed = true;
+
+for ($i = 0; $i < $test_iterations; $i++) {
+    $request['time'] = time() + $i * 10;
+    $valid_sig = $simulator->generateValidSignature($request, $server, $post);
+    $request['signature'] = rawurlencode($valid_sig);
+    
+    if (!$simulator->validateRequest($request, $server, $post)) {
+        echo "  ❌ FAIL: Valid signature rejected on iteration $i\n";
+        echo "  Signature: $valid_sig\n";
+        $all_passed = false;
+        break;
+    }
+}
+
+if ($all_passed) {
+    echo "✓ PASS: All base64 signatures handled correctly\n\n";
+} else {
+    exit(1);
+}
+
+// Test Case 7: Empty signature
+echo "Test 7: Empty signature rejection\n";
+$request['signature'] = '';
+
+if (!$simulator->validateRequest($request, $server, $post)) {
+    echo "✓ PASS: Empty signature correctly rejected\n\n";
+} else {
+    echo "❌ FAIL: Empty signature accepted\n";
+    exit(1);
+}
+
+// Test Case 8: Timing consistency for valid vs invalid signatures
+echo "Test 8: Performance consistency test\n";
+$iterations = 10000;
+
+// Time valid signature checks
+$valid_sig = $simulator->generateValidSignature($request, $server, $post);
+$request['signature'] = $valid_sig;
+
+$start = microtime(true);
+for ($i = 0; $i < $iterations; $i++) {
+    $simulator->validateRequest($request, $server, $post);
+}
+$time_valid = microtime(true) - $start;
+
+// Time invalid signature checks
+$request['signature'] = 'invalid_signature_test';
+
+$start = microtime(true);
+for ($i = 0; $i < $iterations; $i++) {
+    $simulator->validateRequest($request, $server, $post);
+}
+$time_invalid = microtime(true) - $start;
+
+echo "  Valid signature checks:   {$time_valid}s\n";
+echo "  Invalid signature checks: {$time_invalid}s\n";
+echo "  Difference: " . abs($time_valid - $time_invalid) . "s\n";
+
+if (abs($time_valid - $time_invalid) / max($time_valid, $time_invalid) < 0.1) {
+    echo "✓ PASS: Performance similar for valid/invalid signatures (< 10% difference)\n\n";
+} else {
+    echo "⚠ WARNING: Performance difference detected but may be acceptable\n\n";
+}
+
+echo "=== ALL FUNCTIONAL REGRESSION TESTS PASSED ===\n";
+echo "The security fix maintains correct API authentication behavior.\n";
+echo "No regressions detected in legitimate API request handling.\n";
+
+exit(0);

--- a/test_timing_attack_fix.php
+++ b/test_timing_attack_fix.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Test script to validate the timing attack fix
+ * 
+ * This script tests that hash_equals() provides constant-time comparison
+ * and prevents timing-based side-channel attacks on HMAC signature validation.
+ */
+
+echo "=== OpenCart API Signature Timing Attack Fix - Validation Test ===\n\n";
+
+// Test 1: Verify hash_equals() is available (required PHP 5.6+)
+echo "Test 1: Checking hash_equals() availability...\n";
+if (!function_exists('hash_equals')) {
+    echo "❌ FAIL: hash_equals() not available. PHP 5.6+ required.\n";
+    exit(1);
+}
+echo "✓ PASS: hash_equals() is available\n\n";
+
+// Test 2: Verify constant-time behavior (statistical test)
+echo "Test 2: Testing constant-time comparison behavior...\n";
+
+$key = 'test_secret_key_12345';
+$message = "test_message_for_hmac_validation";
+
+// Generate correct signature
+$correct_sig = base64_encode(hash_hmac('sha1', $message, $key, true));
+
+// Generate wrong signatures with different mismatch positions
+$wrong_sig_early = 'AAAA' . substr($correct_sig, 4);  // Mismatch at position 0
+$wrong_sig_middle = substr($correct_sig, 0, 14) . 'AAAA' . substr($correct_sig, 18);  // Mismatch at position 14
+$wrong_sig_late = substr($correct_sig, 0, 24) . 'AAAA';  // Mismatch at position 24
+
+$iterations = 100000;
+
+// Timing test for early mismatch
+$start = microtime(true);
+for ($i = 0; $i < $iterations; $i++) {
+    hash_equals($correct_sig, $wrong_sig_early);
+}
+$time_early = microtime(true) - $start;
+
+// Timing test for middle mismatch
+$start = microtime(true);
+for ($i = 0; $i < $iterations; $i++) {
+    hash_equals($correct_sig, $wrong_sig_middle);
+}
+$time_middle = microtime(true) - $start;
+
+// Timing test for late mismatch
+$start = microtime(true);
+for ($i = 0; $i < $iterations; $i++) {
+    hash_equals($correct_sig, $wrong_sig_late);
+}
+$time_late = microtime(true) - $start;
+
+echo "Early mismatch:  {$time_early}s\n";
+echo "Middle mismatch: {$time_middle}s\n";
+echo "Late mismatch:   {$time_late}s\n";
+
+// Check if timing differences are minimal (< 5% variance indicates constant-time)
+$avg_time = ($time_early + $time_middle + $time_late) / 3;
+$max_variance = max(
+    abs($time_early - $avg_time) / $avg_time,
+    abs($time_middle - $avg_time) / $avg_time,
+    abs($time_late - $avg_time) / $avg_time
+);
+
+echo "Maximum variance: " . ($max_variance * 100) . "%\n";
+
+if ($max_variance < 0.05) {
+    echo "✓ PASS: Timing variance < 5% - constant-time comparison confirmed\n\n";
+} else {
+    echo "⚠ WARNING: Timing variance >= 5% - this is expected on some systems but should be reviewed\n\n";
+}
+
+// Test 3: Verify hash_equals() correctness
+echo "Test 3: Testing hash_equals() correctness...\n";
+
+$test_cases = [
+    ['abc123', 'abc123', true, 'Identical strings'],
+    ['abc123', 'abc124', false, 'Different last char'],
+    ['abc123', 'Abc123', false, 'Case sensitive'],
+    ['abc123', 'abc12', false, 'Different length (shorter)'],
+    ['abc123', 'abc1234', false, 'Different length (longer)'],
+    ['', '', true, 'Empty strings'],
+];
+
+$all_passed = true;
+foreach ($test_cases as $test) {
+    list($str1, $str2, $expected, $description) = $test;
+    $result = hash_equals($str1, $str2);
+    
+    if ($result === $expected) {
+        echo "  ✓ PASS: {$description}\n";
+    } else {
+        echo "  ❌ FAIL: {$description} - Expected " . ($expected ? 'true' : 'false') . ", got " . ($result ? 'true' : 'false') . "\n";
+        $all_passed = false;
+    }
+}
+
+if ($all_passed) {
+    echo "✓ PASS: All correctness tests passed\n\n";
+} else {
+    echo "❌ FAIL: Some correctness tests failed\n\n";
+    exit(1);
+}
+
+// Test 4: Simulate the actual OpenCart fix behavior
+echo "Test 4: Simulating OpenCart API signature validation...\n";
+
+function simulate_old_vulnerable_check($provided, $expected) {
+    // OLD VULNERABLE CODE: return $provided != $expected;
+    return $provided != $expected;  // Non-constant-time comparison
+}
+
+function simulate_new_secure_check($provided, $expected) {
+    // NEW SECURE CODE: return !hash_equals($expected, $provided);
+    return !hash_equals($expected, $provided);  // Constant-time comparison
+}
+
+$api_key = 'opencart_api_secret_key_example';
+$request_string = "api/order\ncustomer\napi_user\nexample.com\n/\n0\nen-gb\nUSD\nd41d8cd98f00b204e9800998ecf8427e\n1736598000\n";
+$correct_signature = base64_encode(hash_hmac('sha1', $request_string, $api_key, true));
+
+// Test with correct signature
+$result_old = simulate_old_vulnerable_check($correct_signature, $correct_signature);
+$result_new = simulate_new_secure_check($correct_signature, $correct_signature);
+
+if ($result_old === false && $result_new === false) {
+    echo "  ✓ PASS: Valid signature accepted by both implementations\n";
+} else {
+    echo "  ❌ FAIL: Valid signature handling differs\n";
+    exit(1);
+}
+
+// Test with invalid signature
+$wrong_signature = 'invalid_signature_12345';
+$result_old = simulate_old_vulnerable_check($wrong_signature, $correct_signature);
+$result_new = simulate_new_secure_check($wrong_signature, $correct_signature);
+
+if ($result_old === true && $result_new === true) {
+    echo "  ✓ PASS: Invalid signature rejected by both implementations\n";
+} else {
+    echo "  ❌ FAIL: Invalid signature handling differs\n";
+    exit(1);
+}
+
+echo "✓ PASS: OpenCart simulation tests passed\n\n";
+
+// Test 5: Verify no timing leakage in fixed version
+echo "Test 5: Verifying no timing leakage in fixed implementation...\n";
+
+$iterations_leak_test = 50000;
+
+// Correct signature timing
+$start = microtime(true);
+for ($i = 0; $i < $iterations_leak_test; $i++) {
+    simulate_new_secure_check($correct_signature, $correct_signature);
+}
+$time_correct = microtime(true) - $start;
+
+// Wrong signature (early mismatch) timing
+$start = microtime(true);
+for ($i = 0; $i < $iterations_leak_test; $i++) {
+    simulate_new_secure_check($wrong_sig_early, $correct_signature);
+}
+$time_wrong_early = microtime(true) - $start;
+
+// Wrong signature (late mismatch) timing
+$start = microtime(true);
+for ($i = 0; $i < $iterations_leak_test; $i++) {
+    simulate_new_secure_check($wrong_sig_late, $correct_signature);
+}
+$time_wrong_late = microtime(true) - $start;
+
+echo "Correct signature: {$time_correct}s\n";
+echo "Wrong (early):     {$time_wrong_early}s\n";
+echo "Wrong (late):      {$time_wrong_late}s\n";
+
+$leak_variance = abs($time_wrong_early - $time_wrong_late) / (($time_wrong_early + $time_wrong_late) / 2);
+echo "Timing leakage variance: " . ($leak_variance * 100) . "%\n";
+
+if ($leak_variance < 0.05) {
+    echo "✓ PASS: No significant timing leakage detected (< 5% variance)\n\n";
+} else {
+    echo "⚠ WARNING: Some variance detected but this may be system-dependent\n\n";
+}
+
+echo "=== ALL TESTS COMPLETED SUCCESSFULLY ===\n";
+echo "The timing attack vulnerability has been successfully fixed.\n";
+echo "hash_equals() provides constant-time comparison that prevents timing-based attacks.\n";
+
+exit(0);

--- a/upload/catalog/controller/startup/api.php
+++ b/upload/catalog/controller/startup/api.php
@@ -93,7 +93,11 @@ class Api extends \Opencart\System\Engine\Controller {
 				$string .= md5(http_build_query($this->request->post)) . "\n";
 				$string .= $time . "\n";
 
-				if (rawurldecode($this->request->get['signature']) != base64_encode(hash_hmac('sha1', $string, $api_info['key'], true))) {
+				// Security: Use constant-time comparison to prevent timing attacks on HMAC signature
+				$expected_signature = base64_encode(hash_hmac('sha1', $string, $api_info['key'], true));
+				$provided_signature = rawurldecode((string)$this->request->get['signature']);
+				
+				if (!hash_equals($expected_signature, $provided_signature)) {
 					$status = false;
 				}
 			}


### PR DESCRIPTION
## Prevent timing attacks in API HMAC authentication

### Summary
This PR hardens OpenCart’s API authentication by eliminating a timing
side-channel in HMAC signature validation.

The API startup controller compared signatures using a non-constant-time
string comparison operator. This could leak information about signature
correctness via response timing, enabling statistical timing attacks
against API authentication.

---

### Root Cause
HMAC signatures were validated using a standard string inequality check,
which exits early on mismatched bytes. This behavior can reveal how many
leading bytes of a signature are correct, forming a timing oracle.

---

### Fix
The signature comparison has been replaced with PHP’s `hash_equals()`,
which performs constant-time comparison and prevents timing-based
information leakage.

**File updated:**
- `upload/catalog/controller/startup/api.php`

The authentication logic and API behavior remain unchanged.

---

### Security Impact
- Eliminates timing side-channel in API authentication
- Prevents signature forgery via statistical analysis
- Aligns with cryptographic best practices for HMAC validation

---

### Compatibility
- Fully backward compatible
- No API client changes required
- Negligible performance impact
