### PR TITLE
Increase module table field size for html extension

### DIFF
--- a/upload/system/helper/db_schema.php
+++ b/upload/system/helper/db_schema.php
@@ -4240,7 +4240,7 @@ function oc_db_schema() {
 			],
 			[
 				'name' => 'setting',
-				'type' => 'text'
+				'type' => 'longtext'
 			]
 		],
 		'primary' => [


### PR DESCRIPTION
Due to the setting column being used for storing html for the html module/extension it would be a good idea to increase the limit on this that ive hit.