### PR TITLE
Fix missing editToken method in catalog model account customer

### DIFF
--- a/upload/catalog/model/account/customer.php
+++ b/upload/catalog/model/account/customer.php
@@ -110,6 +110,26 @@ class Customer extends \Opencart\System\Engine\Model {
 	}
 
 	/**
+	 * Edit Token
+	 *
+	 * Edit customer token record in the database.
+	 *
+	 * @param string $email
+	 * @param string $token
+	 *
+	 * @return void
+	 *
+	 * @example
+	 *
+	 * $this->load->model('account/customer');
+	 *
+	 * $this->model_account_customer->editToken($email, $token);
+	 */
+	public function editToken(string $email, string $token): void {
+		$this->db->query("UPDATE `" . DB_PREFIX . "customer` SET `token` = '" . $this->db->escape($token) . "' WHERE LCASE(`email`) = '" . $this->db->escape(oc_strtolower($email)) . "'");
+	}
+
+	/**
 	 * Edit Newsletter
 	 *
 	 * Edit customer newsletter record in the database.


### PR DESCRIPTION
## Problem
Admin -> Customers -> Action -> Login into store triggered:
`Notice: Undefined property: Proxy::editToken`
from `catalog/controller/account/login.php` (token method).

## Cause
`model_account_customer->editToken()` is called in catalog login token flow, but
`catalog/model/account/customer.php` did not define `editToken()`.

## Fix
Added `editToken(string $email, string $token): void` to
`catalog/model/account/customer.php` to update `customer.token` by email.

## Repro
1. Admin panel -> Customers
2. Action -> Login into store
3. Notice is thrown

## Result after fix
Login-into-store flow works without the Proxy::editToken notice.
