### PR TITLE
[3.0.x.x] Fix Google sitemap XML when product names contain HTML entities

### DIFF
--- a/upload/catalog/controller/extension/feed/google_sitemap.php
+++ b/upload/catalog/controller/extension/feed/google_sitemap.php
@@ -20,8 +20,9 @@ class ControllerExtensionFeedGoogleSitemap extends Controller {
 				if ($product['image']) {
 					$output .= '<image:image>' . PHP_EOL;
 					$output .= '  <image:loc>' . $this->model_tool_image->resize($product['image'], $this->config->get('theme_' . $this->config->get('config_theme') . '_image_popup_width'), $this->config->get('theme_' . $this->config->get('config_theme') . '_image_popup_height')) . '</image:loc>' . PHP_EOL;
-					$output .= '  <image:caption>' . $product['name'] . '</image:caption>' . PHP_EOL;
-					$output .= '  <image:title>' . $product['name'] . '</image:title>' . PHP_EOL;
+					$name = html_entity_decode($product['name'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+					$output .= '  <image:caption>' . htmlspecialchars($name, ENT_XML1 | ENT_QUOTES, 'UTF-8') . '</image:caption>' . PHP_EOL;
+					$output .= '  <image:title>' . htmlspecialchars($name, ENT_XML1 | ENT_QUOTES, 'UTF-8') . '</image:title>' . PHP_EOL;
 					$output .= '</image:image>' . PHP_EOL;
 				}
 


### PR DESCRIPTION
When product names contain HTML entities such as:
- `&ndash;`
- `&nbsp;`
- `&amp;`

the Google sitemap feed outputs invalid XML because these entities are not defined in XML.

Example of broken output:
```xml
<image:title>LED Garage Mat &ndash; 8' x 16'</image:title>
```

This results in XML parser errors such as:
`Entity 'ndash' not defined`

This patch:
- Decodes HTML entities using `html_entity_decode()`
- Escapes output using `ENT_XML1` for valid XML

Example of corrected output:
```xml
<image:title>LED Garage Mat – 8' x 16'</image:title>
```

This ensures the sitemap remains valid XML while preserving correct UTF-8 characters.