### PR TITLE
[3.0.x.x] Don't remove leading slash from PHP_SELF

### DIFF
--- a/upload/system/startup.php
+++ b/upload/system/startup.php
@@ -25,7 +25,7 @@ if (!isset($_SERVER['DOCUMENT_ROOT'])) {
 }
 
 if (!isset($_SERVER['REQUEST_URI'])) {
-	$_SERVER['REQUEST_URI'] = substr($_SERVER['PHP_SELF'], 1);
+	$_SERVER['REQUEST_URI'] = $_SERVER['PHP_SELF'];
 
 	if (isset($_SERVER['QUERY_STRING'])) {
 		$_SERVER['REQUEST_URI'] .= '?' . $_SERVER['QUERY_STRING'];


### PR DESCRIPTION
REQUEST_URI has leading slash, so don't remove it when using PHP_SELF.