### PR TITLE
Fix SEO URL fallback when path or product_id has no keyword

### DIFF
--- a/upload/catalog/controller/startup/seo_url.php
+++ b/upload/catalog/controller/startup/seo_url.php
@@ -136,6 +136,10 @@ class SeoUrl extends \Opencart\System\Engine\Controller {
 				continue;
 			}
 
+			if ($key == 'path' || $key == 'product_id') {
+				return $link;
+			}
+			
 			// Run through the regexes to match and replace queries to a path
 			if (isset($this->regex[$key])) {
 				foreach ((array)$this->regex[$key] as $result) {


### PR DESCRIPTION
Fixes #15286

When a category or product has no SEO keyword, the rewrite() function 
generated an incorrect URL. Added a fallback to return the original 
link when path or product_id has no matching SEO keyword.