### PR TITLE
[Fix #15309 OC4 - Depected button for close]

### DIFF
--- a/upload/admin/view/javascript/cms/comment.js
+++ b/upload/admin/view/javascript/cms/comment.js
@@ -24,11 +24,11 @@ $('#list').on('click', '.btn-success, .btn-warning, .btn-danger', function() {
             $('.alert-dismissible').remove();
 
             if (json['error']) {
-                $('#alert').prepend('<div class="alert alert-danger alert-dismissible"><i class="fas fa-exclamation-circle"></i> ' + json['error'] + ' <button type="button" class="close" data-dismiss="alert">&times;</button></div>');
+                $('#alert').prepend('<div class="alert alert-danger alert-dismissible"><i class="fas fa-exclamation-circle"></i> ' + json['error'] + ' <button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>');
             }
 
             if (json['success']) {
-                $('#alert').prepend('<div class="alert alert-success alert-dismissible"><i class="fas fa-check-circle"></i> ' + json['success'] + ' <button type="button" class="close" data-dismiss="alert">&times;</button></div>');
+                $('#alert').prepend('<div class="alert alert-success alert-dismissible"><i class="fas fa-check-circle"></i> ' + json['success'] + ' <button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>');
             }
         },
         error: function(xhr, ajaxOptions, thrownError) {


### PR DESCRIPTION
Update Bootstrap 4 close button syntax to Bootstrap admin/view/javascript/cms/comment.js
Replaces class="close" with class="btn-close" and
data-dismiss with data-bs-dismiss

Fixes #15309