### PR TITLE
[4.x.x.x] Emulation of `GLOB_BRACE` for Alpine/musl environments.

### DIFF
--- a/upload/admin/controller/common/developer.php
+++ b/upload/admin/controller/common/developer.php
@@ -244,7 +244,7 @@ class Developer extends \Opencart\System\Engine\Controller {
 								$next = array_shift($directories);
 
 								if (is_dir($next)) {
-									foreach (glob(trim($next, '/') . '/{*,.[!.]*,..?*}', GLOB_BRACE) as $file) {
+									foreach (oc_glob(trim($next, '/') . '/{*,.[!.]*,..?*}') as $file) {
 										if (is_dir($file)) {
 											$directories[] = $file . '/';
 										}

--- a/upload/admin/controller/common/security.php
+++ b/upload/admin/controller/common/security.php
@@ -143,7 +143,7 @@ class Security extends \Opencart\System\Engine\Controller {
 				$next = array_shift($directory);
 
 				if (is_dir($next)) {
-					foreach (glob(rtrim($next, '/') . '/{*,.[!.]*,..?*}', GLOB_BRACE) as $file) {
+					foreach (oc_glob(rtrim($next, '/') . '/{*,.[!.]*,..?*}') as $file) {
 						// If directory add to path array
 						if (is_dir($file)) {
 							$directory[] = $file;
@@ -241,7 +241,7 @@ class Security extends \Opencart\System\Engine\Controller {
 			while (count($directory) != 0) {
 				$next = array_shift($directory);
 
-				foreach (glob(rtrim($next, '/') . '/{*,.[!.]*,..?*}', GLOB_BRACE) as $file) {
+				foreach (oc_glob(rtrim($next, '/') . '/{*,.[!.]*,..?*}') as $file) {
 					// If directory add to path array
 					if (is_dir($file)) {
 						$directory[] = $file;
@@ -408,7 +408,7 @@ class Security extends \Opencart\System\Engine\Controller {
 			while (count($directory) != 0) {
 				$next = array_shift($directory);
 
-				foreach (glob(rtrim($next, '/') . '/{*,.[!.]*,..?*}', GLOB_BRACE) as $file) {
+				foreach (oc_glob(rtrim($next, '/') . '/{*,.[!.]*,..?*}') as $file) {
 					// If directory, add to path array
 					if (is_dir($file)) {
 						$directory[] = $file;
@@ -565,7 +565,7 @@ class Security extends \Opencart\System\Engine\Controller {
 					$next = array_shift($directory);
 
 					if (is_dir($next)) {
-						foreach (glob(rtrim($next, '/') . '/{*,.[!.]*,..?*}', GLOB_BRACE) as $file) {
+						foreach (oc_glob(rtrim($next, '/') . '/{*,.[!.]*,..?*}') as $file) {
 							// If directory add to path array
 							if (is_dir($file)) {
 								$directory[] = $file;

--- a/upload/admin/controller/design/theme.php
+++ b/upload/admin/controller/design/theme.php
@@ -191,7 +191,7 @@ class Theme extends \Opencart\System\Engine\Controller {
 			$next = array_shift($directory);
 
 			if (is_dir($next)) {
-				foreach (glob(rtrim($next, '/') . '/{*,.[!.]*,..?*}', GLOB_BRACE) as $file) {
+				foreach (oc_glob(rtrim($next, '/') . '/{*,.[!.]*,..?*}') as $file) {
 					$directory[] = $file;
 				}
 			}
@@ -228,7 +228,7 @@ class Theme extends \Opencart\System\Engine\Controller {
 				$next = array_shift($directory);
 
 				if (is_dir($next)) {
-					foreach (glob(rtrim($next, '/') . '/{*,.[!.]*,..?*}', GLOB_BRACE) as $file) {
+					foreach (oc_glob(rtrim($next, '/') . '/{*,.[!.]*,..?*}') as $file) {
 						$directory[] = $file;
 					}
 				}

--- a/upload/admin/controller/marketplace/installer.php
+++ b/upload/admin/controller/marketplace/installer.php
@@ -715,7 +715,7 @@ class Installer extends \Opencart\System\Engine\Controller {
 				$next = array_shift($directory);
 
 				if (is_dir($next)) {
-					foreach (glob(rtrim($next, '/') . '/{*,.[!.]*,..?*}', GLOB_BRACE) as $file) {
+					foreach (oc_glob(rtrim($next, '/') . '/{*,.[!.]*,..?*}') as $file) {
 						// If directory add to path array
 						$directory[] = $file;
 					}

--- a/upload/admin/controller/marketplace/modification.php
+++ b/upload/admin/controller/marketplace/modification.php
@@ -307,7 +307,7 @@ class Modification extends \Opencart\System\Engine\Controller {
 						}
 
 						if ($path) {
-							$files = glob($path, GLOB_BRACE);
+							$files = oc_glob($path);
 
 							if ($files) {
 								foreach ($files as $file) {

--- a/upload/install/controller/upgrade/upgrade_1.php
+++ b/upload/install/controller/upgrade/upgrade_1.php
@@ -234,7 +234,7 @@ class Upgrade1 extends \Opencart\System\Engine\Controller {
 					$next = array_shift($directory);
 
 					if (is_dir($next)) {
-						foreach (glob(trim($next, '/') . '/{*,.[!.]*,..?*}', GLOB_BRACE) as $delete) {
+						foreach (oc_glob(trim($next, '/') . '/{*,.[!.]*,..?*}') as $delete) {
 							// If directory add to path array
 							$directory[] = $delete;
 						}
@@ -387,7 +387,7 @@ class Upgrade1 extends \Opencart\System\Engine\Controller {
 			while (count($directory) != 0) {
 				$next = array_shift($directory);
 
-				foreach (glob(rtrim($next, '/') . '/{*,.[!.]*,..?*}', GLOB_BRACE) as $file) {
+				foreach (oc_glob(rtrim($next, '/') . '/{*,.[!.]*,..?*}') as $file) {
 					// If directory add to path array
 					if (is_dir($file)) {
 						$directory[] = $file;

--- a/upload/system/helper/general.php
+++ b/upload/system/helper/general.php
@@ -97,6 +97,39 @@ function oc_strtolower(string $string): string {
 	return mb_strtolower($string);
 }
 
+/**
+ * Emulation of GLOB_BRACE for Alpine/musl environments
+ *
+ * @param string $pattern Pattern with curly braces
+ * @param int $flags Flags for glob()
+ * @return array Array of matches
+ */
+function oc_glob($pattern, $flags = 0) {
+    // If there are no curly braces — just call glob()
+    if (strpos($pattern, '{') === false) {
+        return glob($pattern, $flags);
+    }
+
+    // Find the first pair of {}
+    $matches = [];
+    if (preg_match('/\{([^}]+)\}/', $pattern, $m)) {
+        // Split the content inside braces by comma
+        $options = explode(',', $m[1]);
+        foreach ($options as $opt) {
+            // Replace the whole {a,b,c} with one option
+            $newPattern = str_replace($m[0], $opt, $pattern);
+            // Recursively call oc_glob in case of nested braces
+            $matches = array_merge($matches, oc_glob($newPattern, $flags));
+        }
+    }
+
+    // Remove duplicates and sort results
+    $matches = array_unique($matches);
+    sort($matches);
+
+    return $matches;
+}
+
 // Pre PHP8 compatibility
 /*
  * @param string $string

--- a/upload/system/helper/vendor.php
+++ b/upload/system/helper/vendor.php
@@ -56,7 +56,7 @@ function oc_generate_vendor(): void {
 						$next = array_shift($directories);
 
 						if (is_dir($next)) {
-							foreach (glob(trim($next, '/') . '/{*,.[!.]*,..?*}', GLOB_BRACE) as $file) {
+							foreach (oc_glob(trim($next, '/') . '/{*,.[!.]*,..?*}') as $file) {
 								if (is_dir($file)) {
 									$directories[] = $file . '/';
 								}


### PR DESCRIPTION
Refactored the codebase to replace all `glob()` calls using the `GLOB_BRACE` flag with `oc_glob()` emulator to ensure compatibility with Alpine Linux and other musl-based environments where `GLOB_BRACE` is unavailable.