### PR TITLE
[4.x.x.x] Update Lint.yml to run on PHP 8.1+

### DIFF
--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['8.1', '8.2', '8.3', '8.4', '8.5']
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
This is enough to get past the dependency installation issues since that only affected 8.0.

I'm not going to address the 200+ issues that Daniel introduced if he will still be committing more breakages to this branch. If that is not the case for this branch and I can create an issue for fixing the remaining ones then I'll look into them as well.
