### PR TITLE
[4.x.x.x] More fixes from batumibiz

### DIFF
--- a/upload/catalog/controller/checkout/register.php
+++ b/upload/catalog/controller/checkout/register.php
@@ -146,7 +146,7 @@ class Register extends \Opencart\System\Engine\Controller {
 			$data['shipping_custom_field'] = [];
 		}
 
-		// Zone
+		// Shipping Zones
 		$this->load->model('localisation/zone');
 
 		if ($data['payment_country_id'] == $data['shipping_country_id']) {
@@ -386,6 +386,7 @@ class Register extends \Opencart\System\Engine\Controller {
 				// Zones
 				$this->load->model('localisation/zone');
 
+				// Total Zones
 				$zone_total = $this->model_localisation_zone->getTotalZonesByCountryId((int)$post_info['shipping_country_id']);
 
 				if ($zone_total && !$post_info['shipping_zone_id']) {

--- a/upload/catalog/model/checkout/cart.php
+++ b/upload/catalog/model/checkout/cart.php
@@ -81,7 +81,7 @@ class Cart extends \Opencart\System\Engine\Model {
 				'subscription' => $subscription_data,
 				'option'       => $option_data,
 				'price_text'   => $this->currency->format($this->tax->calculate($product['price'], $product['tax_class_id'], $this->config->get('config_tax')), $this->session->data['currency']),
-				'total_text'   => $this->currency->format($this->tax->calculate($product['total'], $product['tax_class_id'], $this->config->get('config_tax')), $this->session->data['currency'])
+				'total_text'   => $this->currency->format($this->tax->calculate($product['price'], $product['tax_class_id'], $this->config->get('config_tax'))*$product['quantity'], $this->session->data['currency'])
 			] + $product;
 		}
 
@@ -100,7 +100,7 @@ class Cart extends \Opencart\System\Engine\Model {
 	public function getTotals(array &$totals, array &$taxes, int &$total): void {
 		$sort_order = [];
 
-		// Extension
+		// Extensions
 		$this->load->model('setting/extension');
 
 		$results = $this->model_setting_extension->getExtensionsByType('total');


### PR DESCRIPTION
Fixed: Fix autoloader: one namespace can contain classes from different folders (see https://github.com/opencart/opencart/pull/14867)

Fixed: Checkout cart page lists wrong item totals (see https://github.com/opencart/opencart/pull/14759)