### PR TITLE
[4.x.x.x] More fixes from batumibiz

### DIFF
--- a/upload/admin/controller/sale/order.php
+++ b/upload/admin/controller/sale/order.php
@@ -1262,7 +1262,7 @@ class Order extends \Opencart\System\Engine\Controller {
 			// 3. Add the request GET vars.
 			$store->request->get = $request_data;
 
-			print_r($store->request->get);
+			// print_r($store->request->get);
 
 			$store->request->get['route'] = 'api/order';
 

--- a/upload/admin/view/javascript/ckeditor/config.js
+++ b/upload/admin/view/javascript/ckeditor/config.js
@@ -28,6 +28,7 @@ CKEDITOR.editorConfig = function( config ) {
 	config.resize_enabled = true;
 	config.resize_dir = 'vertical';
 	config.versionCheck = false;
+	config.removePlugins = 'iframe';
 
 	config.toolbar_Custom = [
 		['Source'],

--- a/upload/system/library/cart/cart.php
+++ b/upload/system/library/cart/cart.php
@@ -90,10 +90,10 @@ class Cart {
 
 					$option_data = [];
 
-					$product_options = (array)json_decode($cart['option'], true);
+					$product_options = (array) json_decode(!empty($cart['option']) ? $cart['option'] : '{}', true);
 
-					// Merge variant code with options
-					$variant = json_decode($product_query->row['variant'], true);
+					$variant = json_decode(!empty($product_query->row['variant']) ? $product_query->row['variant'] : '{}', true);
+
 
 					if ($variant) {
 						foreach ($variant as $key => $value) {


### PR DESCRIPTION
Fixed: In Admin, while creating new order, Product is not being added (see https://github.com/opencart/opencart/pull/14822)

Changed: Safest one just in case the product options are empty (see https://github.com/opencart/opencart/pull/14818)

Fixed: WYSIWYG misconfiguration in ADMIN page for product edit (see WYSIWYG misconfiguration in ADMIN page for product edit)