### PR TITLE
[4.x.x.x]  More fixes from batumibiz

### DIFF
--- a/upload/catalog/controller/account/forgotten.php
+++ b/upload/catalog/controller/account/forgotten.php
@@ -78,7 +78,7 @@ class Forgotten extends \Opencart\System\Engine\Controller {
 		}
 
 		if (!$json) {
-			$this->session->data['success'] = $this->language->get('text_success');
+			$this->session->data['success'] = $this->language->get('text_sent');
 
 			$this->model_account_customer->addToken($customer_info['customer_id'], 'password', oc_token(40));
 

--- a/upload/catalog/controller/product/product.php
+++ b/upload/catalog/controller/product/product.php
@@ -366,13 +366,13 @@ class Product extends \Opencart\System\Engine\Controller {
 			if ($product_info['master_id']) {
 				$master_id = (int)$product_info['master_id'];
 			} else {
-				$master_id = (int)$this->request->get['product_id'];
+				$master_id = (int)$product_id;
 			}
 
 			$product_options = $this->model_catalog_product->getOptions($master_id);
 
 			foreach ($product_options as $option) {
-				if ((int)$this->request->get['product_id'] && !isset($product_info['override']['variant'][$option['product_option_id']])) {
+				if ($product_id && !isset($product_info['override']['variant'][$option['product_option_id']])) {
 					$product_option_value_data = [];
 
 					foreach ($option['product_option_value'] as $option_value) {
@@ -436,7 +436,7 @@ class Product extends \Opencart\System\Engine\Controller {
 				$data['minimum'] = 1;
 			}
 
-			$data['share'] = $this->url->link('product/product', 'language=' . $this->config->get('config_language') . '&product_id=' . (int)$this->request->get['product_id']);
+			$data['share'] = $this->url->link('product/product', 'language=' . $this->config->get('config_language') . '&product_id=' . $product_id);
 
 			$data['attribute_groups'] = $this->model_catalog_product->getAttributes($product_id);
 
@@ -456,7 +456,7 @@ class Product extends \Opencart\System\Engine\Controller {
 			}
 
 			if ($this->config->get('config_product_report_status')) {
-				$this->model_catalog_product->addReport($this->request->get['product_id'], oc_get_ip());
+				$this->model_catalog_product->addReport($product_id, oc_get_ip());
 			}
 
 			$data['language'] = $this->config->get('config_language');

--- a/upload/catalog/model/checkout/cart.php
+++ b/upload/catalog/model/checkout/cart.php
@@ -93,11 +93,11 @@ class Cart extends \Opencart\System\Engine\Model {
 	 *
 	 * @param array<int, array<string, mixed>> $totals
 	 * @param array<int, float>                $taxes
-	 * @param int                              $total
+	 * @param float                            $total
 	 *
 	 * @return void
 	 */
-	public function getTotals(array &$totals, array &$taxes, int &$total): void {
+	public function getTotals(array &$totals, array &$taxes, float &$total): void {
 		$sort_order = [];
 
 		// Extensions

--- a/upload/system/library/cart/cart.php
+++ b/upload/system/library/cart/cart.php
@@ -474,10 +474,15 @@ class Cart {
 				$tax_rates = $this->tax->getRates($product['price'], $product['tax_class_id']);
 
 				foreach ($tax_rates as $tax_rate) {
-					if (!isset($tax_data[$tax_rate['tax_rate_id']])) {
-						$tax_data[$tax_rate['tax_rate_id']] = ($tax_rate['amount'] * $product['quantity']);
+					if ($tax_rate['type'] == 'P') {
+						$quantity = $product['quantity'];
 					} else {
-						$tax_data[$tax_rate['tax_rate_id']] += ($tax_rate['amount'] * $product['quantity']);
+						$quantity = 1;
+					}
+					if (!isset($tax_data[$tax_rate['tax_rate_id']])) {
+						$tax_data[$tax_rate['tax_rate_id']] = ($tax_rate['amount'] * $quantity);
+					} else {
+						$tax_data[$tax_rate['tax_rate_id']] += ($tax_rate['amount'] * $quantity);
 					}
 				}
 			}


### PR DESCRIPTION
Fixed: Missing language definition in account/forgotten.php (see https://github.com/opencart/opencart/issues/14845)

Fixed: Product::addReport(): Argument 1 must be of type int, string given (see https://github.com/opencart/opencart/issues/14887)

Fixed: Wrong total on cart page (see https://github.com/opencart/opencart/issues/14755)

Fixed: getTotals() (see https://github.com/opencart/opencart/pull/14903)