### PR TITLE
[4.x.x.x] Support multi-word product name search

### DIFF
--- a/upload/admin/model/catalog/product.php
+++ b/upload/admin/model/catalog/product.php
@@ -1033,7 +1033,18 @@ class Product extends \Opencart\System\Engine\Model {
 		}
 
 		if (!empty($data['filter_name'])) {
-			$sql .= " AND LCASE(`pd`.`name`) LIKE '%" . $this->db->escape(oc_strtolower($data['filter_name']) . '%') . "'";
+			$implode = [];
+
+			$words = explode(' ', trim(preg_replace('/\s+/', ' ', $data['filter_name'])));
+			$words = array_filter($words);
+
+			foreach ($words as $word) {
+				$implode[] = "LCASE(`pd`.`name`) LIKE '%" . $this->db->escape(oc_strtolower($word)) . "%'";
+			}
+
+			if ($implode) {
+				$sql .= " AND (" . implode(" AND ", $implode) . ")";
+			}
 		}
 
 		if (!empty($data['filter_model'])) {
@@ -1160,7 +1171,18 @@ class Product extends \Opencart\System\Engine\Model {
 		}
 
 		if (!empty($data['filter_name'])) {
-			$sql .= " AND LCASE(`pd`.`name`) LIKE '" . $this->db->escape(oc_strtolower($data['filter_name']) . '%') . "'";
+			$implode = [];
+
+			$words = explode(' ', trim(preg_replace('/\s+/', ' ', $data['filter_name'])));
+			$words = array_filter($words);
+
+			foreach ($words as $word) {
+				$implode[] = "LCASE(`pd`.`name`) LIKE '%" . $this->db->escape(oc_strtolower($word)) . "%'";
+			}
+
+			if ($implode) {
+				$sql .= " AND (" . implode(" AND ", $implode) . ")";
+			}
 		}
 
 		if (!empty($data['filter_model'])) {


### PR DESCRIPTION
Improve product autocomplete and name filter.
- Typing `nano ipod` will find product `ipod nano` .
- Typing `Galaxy 10` or `Samsung Tab 10` will find product `Samsung Galaxy Tab 10.1`. 

While this is impossible to find with default OC4 implementation where you need to remember the first word the product name starts with and exact words order. This is very inconvenient when you have tens or hundreds thousands of products. You cannot remember each exact product name. This is an old OC issue which lasts for decades and drives every product manager crazy :)

Also fix 'getProduct' and 'getTotalProducts' different `filter_name` SQLs.

----
Similar approach is used in frontend. But why `OR` is used there? 
Every additional word in search string must narrow the results, not expand them. 
In frontend if you search `nano ipod` you get everything with `ipod` or `nano` - you get all the ipods while you were searching for the exact model name. Imagine how this search result looks in the store with 100k products and lots of repeating words.

https://github.com/opencart/opencart/blob/f5f30e47dd3b6a45f2af7d2bc4f511109a84b486/upload/catalog/model/catalog/product.php#L163

If you make a search in frontend `ipod samsung touch canon apple macbook nikon sony` it makes no sense, but you just have selected all the store products. You can repeat the same on the store with 100k products :)