### PR TITLE
[4.x.x.x] Removal of deprecated function calls

### DIFF
--- a/upload/admin/controller/marketplace/marketplace.php
+++ b/upload/admin/controller/marketplace/marketplace.php
@@ -171,7 +171,7 @@ class Marketplace extends \Opencart\System\Engine\Controller {
 
 		$status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
-		curl_close($curl);
+		unset($curl);
 
 		if ($status == 200) {
 			$response_info = json_decode($response, true);
@@ -560,7 +560,7 @@ class Marketplace extends \Opencart\System\Engine\Controller {
 
 		$status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
-		curl_close($curl);
+		unset($curl);
 
 		if ($status == 200) {
 			$response_info = json_decode($response, true);
@@ -823,7 +823,7 @@ class Marketplace extends \Opencart\System\Engine\Controller {
 
 			$status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
-			curl_close($curl);
+			unset($curl);
 
 			if ($status == 200) {
 				$response_info = json_decode($response, true);
@@ -912,7 +912,7 @@ class Marketplace extends \Opencart\System\Engine\Controller {
 
 			$status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
-			curl_close($curl);
+			unset($curl);
 
 			if ($status == 200) {
 				$response_info = json_decode($response, true);
@@ -1027,7 +1027,7 @@ class Marketplace extends \Opencart\System\Engine\Controller {
 
 			$status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
-			curl_close($curl);
+			unset($curl);
 
 			if ($status == 200) {
 				$response_info = json_decode($response, true);
@@ -1082,7 +1082,7 @@ class Marketplace extends \Opencart\System\Engine\Controller {
 
 		$status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
-		curl_close($curl);
+		unset($curl);
 
 		if ($status == 200) {
 			$json = json_decode($response, true);
@@ -1167,7 +1167,7 @@ class Marketplace extends \Opencart\System\Engine\Controller {
 
 		$status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
-		curl_close($curl);
+		unset($curl);
 
 		if ($status == 200) {
 			$json = json_decode($response, true);

--- a/upload/admin/controller/marketplace/promotion.php
+++ b/upload/admin/controller/marketplace/promotion.php
@@ -47,7 +47,7 @@ class Promotion extends \Opencart\System\Engine\Controller {
 
 			$status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
-			curl_close($curl);
+			unset($curl);
 
 			if ($status == 200) {
 				$promotion = json_decode($response, true);

--- a/upload/admin/controller/sale/order.php
+++ b/upload/admin/controller/sale/order.php
@@ -1196,7 +1196,7 @@ class Order extends \Opencart\System\Engine\Controller {
 	 *
 	 * $status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 	 *
-	 * curl_close($curl);
+	 * unset($curl);
 	 *
 	 * if ($status == 200) {
 	 *      $response_info = json_decode($response, true);

--- a/upload/admin/controller/sale/subscription.php
+++ b/upload/admin/controller/sale/subscription.php
@@ -829,7 +829,7 @@ class Subscription extends \Opencart\System\Engine\Controller {
 	 *
 	 * $status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 	 *
-	 * curl_close($curl);
+	 * unset($curl);
 	 *
 	 * if ($status == 200) {
 	 *      $response_info = json_decode($response, true);

--- a/upload/admin/controller/startup/notification.php
+++ b/upload/admin/controller/startup/notification.php
@@ -27,7 +27,7 @@ class Notification extends \Opencart\System\Engine\Controller {
 
 			$status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
-			curl_close($curl);
+			unset($curl);
 
 			if ($status == 200) {
 				$notification = json_decode($response, true);

--- a/upload/admin/controller/tool/upgrade.php
+++ b/upload/admin/controller/tool/upgrade.php
@@ -53,7 +53,7 @@ class Upgrade extends \Opencart\System\Engine\Controller {
 
 		$status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
-		curl_close($curl);
+		unset($curl);
 
 		if ($status == 200) {
 			$response_info = json_decode($response, true);
@@ -137,7 +137,7 @@ class Upgrade extends \Opencart\System\Engine\Controller {
 				$json['error'] = $this->language->get('error_download');
 			}
 
-			curl_close($curl);
+			unset($curl);
 		}
 
 		if (!$json) {

--- a/upload/extension/opencart/admin/controller/currency/ecb.php
+++ b/upload/extension/opencart/admin/controller/currency/ecb.php
@@ -94,7 +94,7 @@ class ECB extends \Opencart\System\Engine\Controller {
 
 			$status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
-			curl_close($curl);
+			unset($curl);
 
 			if ($status == 200) {
 				$dom = new \DOMDocument('1.0', 'UTF-8');

--- a/upload/extension/opencart/admin/controller/currency/fixer.php
+++ b/upload/extension/opencart/admin/controller/currency/fixer.php
@@ -99,7 +99,7 @@ class Fixer extends \Opencart\System\Engine\Controller {
 
 			$status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
-			curl_close($curl);
+			unset($curl);
 
 			if ($status == 200) {
 				$response_info = json_decode($response, true);

--- a/upload/extension/opencart/catalog/controller/captcha/basic.php
+++ b/upload/extension/opencart/catalog/controller/captcha/basic.php
@@ -70,7 +70,7 @@ class Basic extends \Opencart\System\Engine\Controller {
 
 		imagejpeg($image);
 
-		imagedestroy($image);
+		unset($image);
 		exit();
 	}
 }

--- a/upload/extension/opencart/catalog/controller/currency/ecb.php
+++ b/upload/extension/opencart/catalog/controller/currency/ecb.php
@@ -28,7 +28,7 @@ class ECB extends \Opencart\System\Engine\Controller {
 
 			$status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
-			curl_close($curl);
+			unset($curl);
 
 			if ($status == 200) {
 				$dom = new \DOMDocument('1.0', 'UTF-8');

--- a/upload/extension/opencart/catalog/controller/currency/fixer.php
+++ b/upload/extension/opencart/catalog/controller/currency/fixer.php
@@ -28,7 +28,7 @@ class Fixer extends \Opencart\System\Engine\Controller {
 
 			$status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
-			curl_close($curl);
+			unset($curl);
 
 			if ($status == 200) {
 				$response_info = json_decode($response, true);

--- a/upload/install/controller/install/promotion.php
+++ b/upload/install/controller/install/promotion.php
@@ -33,7 +33,7 @@ class Promotion extends \Opencart\System\Engine\Controller {
 			$response = '';
 		}
 
-		curl_close($curl);
+		unset($curl);
 
 		return $response;
 	}

--- a/upload/system/library/cart/api.php
+++ b/upload/system/library/cart/api.php
@@ -73,7 +73,7 @@ class Api {
 
 		$status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
-		curl_close($curl);
+		unset($curl);
 
 		if ($status == 200) {
 			$response_info = json_decode($response, true);

--- a/upload/system/library/curl.php
+++ b/upload/system/library/curl.php
@@ -55,7 +55,7 @@ class Curl {
 
 		$status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
-		curl_close($curl);
+		unset($curl);
 
 		if ($status == 200) {
 			$response_info = json_decode($response, true);

--- a/upload/system/library/image.php
+++ b/upload/system/library/image.php
@@ -152,7 +152,7 @@ class Image {
 				imagewebp($this->image, $file);
 			}
 
-			imagedestroy($this->image);
+			unset($this->image);
 		}
 	}
 
@@ -218,7 +218,7 @@ class Image {
 		imagefilledrectangle($this->image, 0, 0, $width, $height, $background);
 
 		imagecopyresampled($this->image, $image_old, $xpos, $ypos, 0, 0, $new_width, $new_height, $this->width, $this->height);
-		imagedestroy($image_old);
+		unset($image_old);
 
 		$this->width = $width;
 		$this->height = $height;
@@ -280,7 +280,7 @@ class Image {
 		imagesavealpha($this->image, true);
 		imagecopy($this->image, $watermark->getImage(), $watermark_pos_x, $watermark_pos_y, 0, 0, $watermark->getWidth(), $watermark->getHeight());
 
-		imagedestroy($watermark->getImage());
+//		imagedestroy($watermark->getImage());
 	}
 
 	/**
@@ -298,7 +298,7 @@ class Image {
 		$this->image = imagecreatetruecolor($bottom_x - $top_x, $bottom_y - $top_y);
 
 		imagecopy($this->image, $image_old, 0, 0, $top_x, $top_y, $this->width, $this->height);
-		imagedestroy($image_old);
+		unset($image_old);
 
 		$this->width = $bottom_x - $top_x;
 		$this->height = $bottom_y - $top_y;


### PR DESCRIPTION
Since PHP 8.0 the imagedestroy and curl_close aren't needed anymore.