### PR TITLE
[4.x.x.x] Fix pagination icons

### DIFF
--- a/upload/admin/view/template/common/pagination.twig
+++ b/upload/admin/view/template/common/pagination.twig
@@ -1,21 +1,21 @@
 <ul class="pagination">
-	{% if first %}
-		<li class="page-item"><a href="{{ first }}" class="page-link">|&lt;</a></li>
-	{% endif %}
-	{% if prev %}
-		<li class="page-item"><a href="{{ prev }}" class="page-link">&lt;</a></li>
-	{% endif %}
-	{% for link in links %}
-		{% if link.page == page %}
-			<li class="page-item active"><span class="page-link">{{ link.page }}</span></li>
-		{% else %}
-			<li class="page-item"><a href="{{ link.href }}" class="page-link">{{ link.page }}</a></li>
-		{% endif %}
-	{% endfor %}
-	{% if next %}
-		<li class="page-item"><a href="{{ next }}" class="page-link">&gt;</a></li>
-	{% endif %}
-	{% if last %}
-		<li class="page-item"><a href="{{ last }}" class="page-link">&gt;|</a></li>
-	{% endif %}
+  {% if first %}
+    <li class="page-item"><a href="{{ first }}" class="page-link"><i class="fa-solid fa-angles-left"></i></a></li>
+  {% endif %}
+  {% if prev %}
+    <li class="page-item"><a href="{{ prev }}" class="page-link"><i class="fa-solid fa-angle-left"></i></a></li>
+  {% endif %}
+  {% for link in links %}
+    {% if link.page == page %}
+      <li class="page-item active"><span class="page-link">{{ link.page }}</span></li>
+    {% else %}
+      <li class="page-item"><a href="{{ link.href }}" class="page-link">{{ link.page }}</a></li>
+    {% endif %}
+  {% endfor %}
+  {% if next %}
+    <li class="page-item"><a href="{{ next }}" class="page-link"><i class="fa-solid fa-angle-right"></i></a></li>
+  {% endif %}
+  {% if last %}
+    <li class="page-item"><a href="{{ last }}" class="page-link"><i class="fa-solid fa-angles-right"></i></a></li>
+  {% endif %}
 </ul>

--- a/upload/catalog/view/template/common/pagination.twig
+++ b/upload/catalog/view/template/common/pagination.twig
@@ -1,9 +1,9 @@
 <ul class="pagination">
   {% if first %}
-    <li class="page-item"><a href="{{ first }}" class="page-link">|&lt;</a></li>
+    <li class="page-item"><a href="{{ first }}" class="page-link"><i class="fa-solid fa-angles-left"></i></a></li>
   {% endif %}
   {% if prev %}
-    <li class="page-item"><a href="{{ prev }}" class="page-link">&lt;</a></li>
+    <li class="page-item"><a href="{{ prev }}" class="page-link"><i class="fa-solid fa-angle-left"></i></a></li>
   {% endif %}
   {% for link in links %}
     {% if link.page == page %}
@@ -13,9 +13,9 @@
     {% endif %}
   {% endfor %}
   {% if next %}
-    <li class="page-item"><a href="{{ next }}" class="page-link">&gt;</a></li>
+    <li class="page-item"><a href="{{ next }}" class="page-link"><i class="fa-solid fa-angle-right"></i></a></li>
   {% endif %}
   {% if last %}
-    <li class="page-item"><a href="{{ last }}" class="page-link">&gt;|</a></li>
+    <li class="page-item"><a href="{{ last }}" class="page-link"><i class="fa-solid fa-angles-right"></i></a></li>
   {% endif %}
 </ul>


### PR DESCRIPTION
Use modern FontAwesome icons for pagination, `>|` looks outdated even for OC2, especialy in the frontend.
I know 4.1.0.4 is planned as a bugfix release. But I hardly imagine any extension this fix can break.

<img width="1694" height="378" alt="image" src="https://github.com/user-attachments/assets/d1ed8da3-f114-48f6-ad9f-606bb12e6647" />
