### PR TITLE
[4.x.x.x] Fix category filter and autocomplete

### DIFF
--- a/upload/admin/model/catalog/category.php
+++ b/upload/admin/model/catalog/category.php
@@ -407,23 +407,30 @@ class Category extends \Opencart\System\Engine\Model {
 	public function getCategories(array $data = []): array {
 		$sql = "SELECT `cp`.`category_id` AS `category_id`, `c1`.`image`, GROUP_CONCAT(`cd1`.`name` ORDER BY `cp`.`level` SEPARATOR ' > ') AS `name`, `c1`.`parent_id`, `c1`.`sort_order`, `c1`.`status` FROM `" . DB_PREFIX . "category_path` `cp` LEFT JOIN `" . DB_PREFIX . "category` `c1` ON (`cp`.`category_id` = `c1`.`category_id`) LEFT JOIN `" . DB_PREFIX . "category` `c2` ON (`cp`.`path_id` = `c2`.`category_id`) LEFT JOIN `" . DB_PREFIX . "category_description` `cd1` ON (`cp`.`path_id` = `cd1`.`category_id`) LEFT JOIN `" . DB_PREFIX . "category_description` `cd2` ON (`cp`.`category_id` = `cd2`.`category_id`) WHERE `cd1`.`language_id` = '" . (int)$this->config->get('config_language_id') . "' AND `cd2`.`language_id` = '" . (int)$this->config->get('config_language_id') . "'";
 
-		$sql .= " GROUP BY `cp`.`category_id`";
-
-		$implode = [];
-		if (!empty($data['filter_name'])) {
-			$implode[] = "LCASE(`name`) LIKE '%" . $this->db->escape(oc_strtolower($data['filter_name'])) . "%'";
-		}
-
 		if (isset($data['filter_status']) && $data['filter_status'] !== '') {
-			$implode[] = "`status` = '" . (int)$data['filter_status'] . "'";
+			$sql .= " AND `c1`.`status` = '" . (int)$data['filter_status'] . "'";
 		}
 
 		if (isset($data['filter_parent_id'])) {
-			$implode[] = "`parent_id` = '" . (int)$data['filter_parent_id'] . "'";
+			$sql .= " AND `c1`.`parent_id` = '" . (int)$data['filter_parent_id'] . "'";
 		}
 
-		if ($implode) {
-			$sql .= " HAVING (" . implode(" AND ", $implode) . ")";
+		$sql .= " GROUP BY `cp`.`category_id`";
+
+		// path name filter in category list "Components > Monitors > test 1" or "Components > Monitors" or "Monitors" or "test 1"
+		if (!empty($data['filter_name'])) {
+			$implode = [];
+
+			// split category path, clear > symbols and extra spaces
+			$words = explode(' ', trim(preg_replace('/\s+/', ' ', str_ireplace([' &gt; ', ' > '], ' ', $data['filter_name']))));
+
+			foreach ($words as $word) {
+				$implode[] = "LCASE(`name`) LIKE '" . $this->db->escape('%' . oc_strtolower($word) . '%') . "'";
+			}
+
+			if ($implode) {
+				$sql .= " HAVING ((" . implode(" AND ", $implode) . ") OR LCASE(`name`) LIKE '" . $this->db->escape(oc_strtolower($data['filter_name'])) . "')";
+			}
 		}
 
 		$sort_data = [
@@ -489,24 +496,30 @@ class Category extends \Opencart\System\Engine\Model {
 
 		$sql .= "SELECT `cp`.`category_id` AS `category_id`, GROUP_CONCAT(`cd1`.`name` ORDER BY `cp`.`level` SEPARATOR ' > ') AS `name`, `c1`.`parent_id`, `c1`.`sort_order`, `c1`.`status` FROM `" . DB_PREFIX . "category_path` `cp` LEFT JOIN `" . DB_PREFIX . "category` `c1` ON (`cp`.`category_id` = `c1`.`category_id`) LEFT JOIN `" . DB_PREFIX . "category` `c2` ON (`cp`.`path_id` = `c2`.`category_id`) LEFT JOIN `" . DB_PREFIX . "category_description` `cd1` ON (`cp`.`path_id` = `cd1`.`category_id`) LEFT JOIN `" . DB_PREFIX . "category_description` `cd2` ON (`cp`.`category_id` = `cd2`.`category_id`) WHERE `cd1`.`language_id` = '" . (int)$this->config->get('config_language_id') . "' AND `cd2`.`language_id` = '" . (int)$this->config->get('config_language_id') . "'";
 
-		$sql .= " GROUP BY `cp`.`category_id`";
-
-		$implode = [];
-		if (!empty($data['filter_name'])) {
-			$filter_name = htmlspecialchars_decode($data['filter_name']);
-			$implode[] = "LCASE(`name`) LIKE '%" . $this->db->escape(oc_strtolower($filter_name)) . "%'";
-		}
-
 		if (isset($data['filter_status']) && $data['filter_status'] !== '') {
-			$implode[] = "`status` = '" . (int)$data['filter_status'] . "'";
+			$sql .= " AND `c1`.`status` = '" . (int)$data['filter_status'] . "'";
 		}
 
 		if (isset($data['filter_parent_id'])) {
-			$implode[] = "`parent_id` = '" . (int)$data['filter_parent_id'] . "'";
+			$sql .= " AND `c1`.`parent_id` = '" . (int)$data['filter_parent_id'] . "'";
 		}
 
-		if ($implode) {
-			$sql .= " HAVING (" . implode(" AND ", $implode) . ")";
+		$sql .= " GROUP BY `cp`.`category_id`";
+
+		// path name filter in category list "Components > Monitors > test 1" or "Components > Monitors" or "Monitors" or "test 1"
+		if (!empty($data['filter_name'])) {
+			$implode = [];
+
+			// split category path, clear > symbols and extra spaces
+			$words = explode(' ', trim(preg_replace('/\s+/', ' ', str_ireplace([' &gt; ', ' > '], ' ', $data['filter_name']))));
+
+			foreach ($words as $word) {
+				$implode[] = "LCASE(`name`) LIKE '" . $this->db->escape('%' . oc_strtolower($word) . '%') . "'";
+			}
+
+			if ($implode) {
+				$sql .= " HAVING ((" . implode(" AND ", $implode) . ") OR LCASE(`name`) LIKE '" . $this->db->escape(oc_strtolower($data['filter_name'])) . "')";
+			}
 		}
 
 		$sql .= ") AS result_set;";


### PR DESCRIPTION
The current category filter does not work with autocomplete category tree `Components > Monitors` when it has `>` in the filter string.

Current implementation:

Product filter
<img width="2375" height="1004" alt="image" src="https://github.com/user-attachments/assets/c09ca027-5985-4276-ad32-0c09ee0a5142" />

Category filter
<img width="2396" height="814" alt="image" src="https://github.com/user-attachments/assets/5863d0b1-c291-4407-b024-e03ba310c06b" />



After fix:
<img width="2381" height="895" alt="image" src="https://github.com/user-attachments/assets/e74ba111-c64b-4a86-8d38-507fb0680e55" />
