### PR TITLE
[4.x.x.x] tax_rate_id instead of tax_id

### DIFF
--- a/upload/extension/opencart/catalog/model/total/coupon.php
+++ b/upload/extension/opencart/catalog/model/total/coupon.php
@@ -68,13 +68,13 @@ class Coupon extends \Opencart\System\Engine\Model {
 
 							foreach ($tax_rates as $tax_rate) {
 								if ($tax_rate['type'] == 'P') {
-									$tax_id = (int)$tax_rate['tax_rate_id'];
+									$tax_rate_id = (int)$tax_rate['tax_rate_id'];
 
-									if (!isset($taxes[$tax_id])) {
-										$taxes[$tax_id] = 0.0;
+									if (!isset($taxes[$tax_rate_id])) {
+										$taxes[$tax_rate_id] = 0.0;
 									}
 
-									$taxes[$tax_id] -= (float)$tax_rate['amount'];
+									$taxes[$tax_rate_id] -= (float)$tax_rate['amount'];
 								}
 							}
 						}
@@ -89,13 +89,13 @@ class Coupon extends \Opencart\System\Engine\Model {
 
 						foreach ($tax_rates as $tax_rate) {
 							if ($tax_rate['type'] == 'P') {
-								$tax_id = (int)$tax_rate['tax_rate_id'];
+								$tax_rate_id = (int)$tax_rate['tax_rate_id'];
 
-								if (!isset($taxes[$tax_id])) {
-									$taxes[$tax_id] = 0.0;
+								if (!isset($taxes[$tax_rate_id])) {
+									$taxes[$tax_rate_id] = 0.0;
 								}
 
-								$taxes[$tax_id] -= (float)$tax_rate['amount'];
+								$taxes[$tax_rate_id] -= (float)$tax_rate['amount'];
 							}
 						}
 					}

--- a/upload/extension/opencart/catalog/model/total/reward.php
+++ b/upload/extension/opencart/catalog/model/total/reward.php
@@ -45,13 +45,13 @@ class Reward extends \Opencart\System\Engine\Model {
 
 							foreach ($tax_rates as $tax_rate) {
 								if ($tax_rate['type'] == 'P') {
-									$tax_id = (int)$tax_rate['tax_rate_id'];
+									$tax_rate_id = (int)$tax_rate['tax_rate_id'];
 
-									if (!isset($taxes[$tax_id])) {
-										$taxes[$tax_id] = 0.0;
+									if (!isset($taxes[$tax_rate_id])) {
+										$taxes[$tax_rate_id] = 0.0;
 									}
 
-									$taxes[$tax_id] -= (float)$tax_rate['amount'];
+									$taxes[$tax_rate_id] -= (float)$tax_rate['amount'];
 								}
 							}
 						}


### PR DESCRIPTION
For better clarifications in extension/opencart/catalog/model/total/coupon.php and reward.php