### PR TITLE
[4.x.x.x] Missing user's name in activity on checkout register

### DIFF
--- a/upload/catalog/controller/event/activity.php
+++ b/upload/catalog/controller/event/activity.php
@@ -246,8 +246,8 @@ class Activity extends \Opencart\System\Engine\Controller {
 			$this->load->model('account/activity');
 
 			$activity_data = [
-				'customer_id' => $this->customer->getId(),
-				'name'        => $this->customer->getFirstName() . ' ' . $this->customer->getLastName()
+				'customer_id' => $args[0],
+				'name'        => $args[1]['firstname'] . ' ' . $args[1]['lastname']
 			];
 
 			$this->model_account_activity->addActivity('address_add', $activity_data);


### PR DESCRIPTION
### Fixed
- [#15411](https://github.com/opencart/opencart/issues/15411) - [4.x.x.x] Missing user's name in activity on checkout register

When OC calls $this->model_account_address->addAddress it either uses:
```
$this->model_account_address->addAddress($this->customer->getId(), ...
```

```
$this->model_account_address->addAddress($customer_data['customer_id'], ...
```

Using the $args for addAddress we can read customer_id and names, but if different name is provided for shipping it is shown, still redirects to same customer.

**Before**
<img width="521" height="211" alt="Image" src="https://github.com/user-attachments/assets/93ec861c-6262-4445-8fe4-ea4a3f6a88a1" />

**After**
<img width="512" height="270" alt="Screenshot from 2026-05-03 17-13-53" src="https://github.com/user-attachments/assets/9e64b513-7c4a-4d9c-8dc0-588ac94f76ab" />
