### PR TITLE
Regenerate Session ID on Authentication to Prevent Session Fixation

### DIFF
--- a/upload/admin/controller/common/login.php
+++ b/upload/admin/controller/common/login.php
@@ -95,6 +95,9 @@ class Login extends \Opencart\System\Engine\Controller {
 		}
 
 		if (!$json) {
+			// Regenerate session ID
+			oc_session_regenerate($this->registry);
+
 			$this->session->data['user_token'] = oc_token(32);
 
 			// Remove login token so it cannot be used again.

--- a/upload/catalog/controller/account/login.php
+++ b/upload/catalog/controller/account/login.php
@@ -150,6 +150,9 @@ class Login extends \Opencart\System\Engine\Controller {
 		}
 
 		if (!$json) {
+			// Regenerate session ID
+			oc_session_regenerate($this->registry);
+
 			// Remove form token from session
 			unset($this->session->data['login_token']);
 
@@ -252,6 +255,9 @@ class Login extends \Opencart\System\Engine\Controller {
 		$customer_info = $this->model_account_customer->getTokenByCode($code);
 
 		if ($customer_info && $customer_info['email'] == $email && $customer_info['type'] == 'login' && $this->customer->login($customer_info['email'], '', true)) {
+			// Regenerate session ID
+			oc_session_regenerate($this->registry);
+
 			// Add customer details into session
 			$this->session->data['customer'] = $customer_info;
 

--- a/upload/catalog/controller/account/register.php
+++ b/upload/catalog/controller/account/register.php
@@ -251,6 +251,9 @@ class Register extends \Opencart\System\Engine\Controller {
 		}
 
 		if (!$json) {
+			// Regenerate session ID
+			oc_session_regenerate($this->registry);
+
 			$customer_id = $this->model_account_customer->addCustomer(['customer_group_id' => $customer_group_id] + $post_info);
 
 			// Login if requires approval

--- a/upload/catalog/controller/api/customer.php
+++ b/upload/catalog/controller/api/customer.php
@@ -88,6 +88,9 @@ class Customer extends \Opencart\System\Engine\Controller {
 		}
 
 		if (!$output) {
+			// Regenerate session ID
+			oc_session_regenerate($this->registry);
+
 			// Log the customer in
 			$this->customer->login($post_info['email'], '', true);
 

--- a/upload/catalog/controller/checkout/register.php
+++ b/upload/catalog/controller/checkout/register.php
@@ -444,6 +444,9 @@ class Register extends \Opencart\System\Engine\Controller {
 		}
 
 		if (!$json) {
+			// Regenerate session ID
+			oc_session_regenerate($this->registry);
+
 			// Add customer details into session
 			$customer_data = [
 				'customer_id'       => 0,

--- a/upload/system/helper/general.php
+++ b/upload/system/helper/general.php
@@ -362,3 +362,29 @@ function oc_validate_url(string $url): bool {
 function oc_validate_path(string $keyword): bool {
 	return !preg_match('/[^\p{Latin}\p{Cyrillic}\p{Greek}0-9\/\-\_]+/u', $keyword);
 }
+
+/**
+ * Session Regenerate
+ *
+ * @param \Opencart\System\Engine\Registry $registry
+ *
+ * @return void
+ */
+function oc_session_regenerate(\Opencart\System\Engine\Registry $registry): void {
+	$session = $registry->get('session');
+	$config = $registry->get('config');
+	$request = $registry->get('request');
+
+	$session_id = $session->regenerate();
+
+	$option = [
+		'expires'  => 0,
+		'path'     => $config->get('session_path'),
+		'domain'   => $config->get('session_domain'),
+		'secure'   => $request->server['HTTPS'],
+		'httponly' => false,
+		'SameSite' => $config->get('session_samesite')
+	];
+
+	setcookie($config->get('session_name'), $session_id, $option);
+}

--- a/upload/system/library/session.php
+++ b/upload/system/library/session.php
@@ -113,4 +113,21 @@ class Session {
 	public function gc(): void {
 		$this->adaptor->gc();
 	}
+
+	/**
+	 * Regenerate
+	 *
+	 * Regenerates the session ID
+	 *
+	 * @return string
+	 */
+	public function regenerate(): string {
+		$old_session_id = $this->session_id;
+
+		$this->session_id = substr(bin2hex(openssl_random_pseudo_bytes(26)), 0, 26);
+
+		$this->adaptor->destroy($old_session_id);
+
+		return $this->session_id;
+	}
 }


### PR DESCRIPTION
This patch updates OpenCart to regenerate the session ID whenever a user moves from a guest session into an authenticated session.

At the moment, the same session identifier is preserved after login, registration auto-login, and other authentication flows. That creates a session fixation risk because a pre-existing session ID can remain valid after authentication.

To address this, I added session regeneration support to the core session library and introduced a helper to handle cookie/session rotation cleanly. The new session ID is now issued across all major authentication paths, including customer login, admin login, registration-based auto-login, checkout registration, and API customer authentication.

The goal is to ensure that every privilege transition from unauthenticated to authenticated state results in a fresh session identifier, bringing session handling more in line with standard security practices while keeping existing session data intact.