### PR TITLE
[4.x.x.x] Keep variant's code override on master update

### DIFF
--- a/upload/admin/model/catalog/product.php
+++ b/upload/admin/model/catalog/product.php
@@ -839,6 +839,11 @@ class Product extends \Opencart\System\Engine\Model {
 				}
 			}
 
+			// Codes
+			if (isset($override['product_code'])) {
+				$product_data['product_code'] = $this->model_catalog_product->getCodes($product['product_id']);
+			}
+
 			// Attributes
 			if (isset($override['product_attribute'])) {
 				$product_data['product_attribute'] = $this->model_catalog_product->getAttributes($product['product_id']);


### PR DESCRIPTION
When updating master it replaces variants' codes even if override is selected.

The issue is fixed in master branch - [#15108](https://github.com/opencart/opencart/pull/15108) fix: Master replacing variant codes
