### PR TITLE
[4.x.x.x] Fix admin product list wrong discount value

### DIFF
--- a/upload/admin/controller/catalog/product.php
+++ b/upload/admin/controller/catalog/product.php
@@ -349,8 +349,22 @@ class Product extends \Opencart\System\Engine\Controller {
 
 			foreach ($product_discounts as $product_discount) {
 				if (($product_discount['date_start'] == '0000-00-00' || strtotime($product_discount['date_start']) < time()) && ($product_discount['date_end'] == '0000-00-00' || strtotime($product_discount['date_end']) > time())) {
-					$special = $this->currency->format($product_discount['price'], $this->config->get('config_currency'));
+					switch ($product_discount['type']) {
+    				    case 'P':
+    				        $price = $result['price'] - ($result['price'] * ($product_discount['price'] / 100));
+							break;
 
+    				    case 'S':
+    				        $price = $result['price'] - $product_discount['price'];
+							break;
+
+    				    case 'F':
+    				    default:
+    				        $price = $product_discount['price'];
+							break;
+    				}
+
+					$special = $this->currency->format($price, $this->config->get('config_currency'));
 					break;
 				}
 			}


### PR DESCRIPTION
### Fixed
- [#15419](https://github.com/opencart/opencart/issues/15419) - [4.x.x.x] Admin product list has wrong discount value

Check discount type and calculate final price
