### PR TITLE
[4.x.x.x] Fix dashboard activities sort

### DIFF
--- a/upload/extension/opencart/admin/model/report/activity.php
+++ b/upload/extension/opencart/admin/model/report/activity.php
@@ -18,7 +18,7 @@ class Activity extends \Opencart\System\Engine\Model {
 	 * $results = $this->model_extension_opencart_report_activity->getActivities();
 	 */
 	public function getActivities(): array {
-		$query = $this->db->query("SELECT `key`, `data`, `date_added` FROM `" . DB_PREFIX . "customer_activity` ORDER BY `date_added` DESC LIMIT 0,5");
+		$query = $this->db->query("SELECT `key`, `data`, `date_added` FROM `" . DB_PREFIX . "customer_activity` ORDER BY `customer_activity_id` DESC LIMIT 0,5");
 
 		return $query->rows;
 	}


### PR DESCRIPTION
By default OC sorts activities by date_added, but since multiple activities can be added in the same second they are not sorted correctly.

**Before**
<img width="522" height="276" alt="Screenshot from 2026-05-06 10-36-51" src="https://github.com/user-attachments/assets/17f9a9d1-f479-4019-a166-b40336dcd15f" />

**After**
<img width="522" height="276" alt="image" src="https://github.com/user-attachments/assets/6743051c-f1b5-4a11-a331-78cbde49328f" />
