### PR TITLE
[4.x.x.x] Fix multiple issues in checkout's register component

### DIFF
--- a/upload/catalog/controller/checkout/register.php
+++ b/upload/catalog/controller/checkout/register.php
@@ -100,6 +100,10 @@ class Register extends \Opencart\System\Engine\Controller {
 
 		$data['countries'] = $this->model_localisation_country->getCountries();
 
+		// Postcode
+		$payment_country = $this->model_localisation_country->getCountry($data['payment_country_id']);
+		$data['payment_postcode_required'] = $payment_country['postcode_required'] ?? false;
+
 		// Zones
 		$this->load->model('localisation/zone');
 
@@ -150,8 +154,11 @@ class Register extends \Opencart\System\Engine\Controller {
 		$this->load->model('localisation/zone');
 
 		if ($data['payment_country_id'] == $data['shipping_country_id']) {
+			$data['shipping_postcode_required'] = $data['payment_postcode_required'];
 			$data['shipping_zones'] = $data['payment_zones'];
 		} else {
+			$shipping_country = $this->model_localisation_country->getCountry($data['shipping_country_id']);
+			$data['shipping_postcode_required'] = $shipping_country['postcode_required'] ?? false;
 			$data['shipping_zones'] = $this->model_localisation_zone->getZonesByCountryId($data['shipping_country_id']);
 		}
 

--- a/upload/catalog/controller/checkout/register.php
+++ b/upload/catalog/controller/checkout/register.php
@@ -61,6 +61,7 @@ class Register extends \Opencart\System\Engine\Controller {
 			$data['lastname'] = $this->session->data['customer']['lastname'];
 			$data['email'] = $this->session->data['customer']['email'];
 			$data['telephone'] = $this->session->data['customer']['telephone'];
+			$data['address_match'] = (int)$this->session->data['customer']['address_match'];
 			$data['account_custom_field'] = $this->session->data['customer']['custom_field'];
 		} else {
 			$data['customer_group_id'] = (int)$this->config->get('config_customer_group_id');
@@ -68,6 +69,7 @@ class Register extends \Opencart\System\Engine\Controller {
 			$data['lastname'] = '';
 			$data['email'] = '';
 			$data['telephone'] = '';
+			$data['address_match'] = 1;
 			$data['account_custom_field'] = [];
 		}
 
@@ -479,6 +481,7 @@ class Register extends \Opencart\System\Engine\Controller {
 				'lastname'          => $post_info['lastname'],
 				'email'             => $post_info['email'],
 				'telephone'         => $post_info['telephone'],
+				'address_match'     => $post_info['address_match'],
 				'custom_field'      => $post_info['custom_field']['account'] ?? [],
 				'password'          => $post_info['password'],
 				'newsletter'        => $post_info['newsletter']

--- a/upload/catalog/controller/checkout/register.php
+++ b/upload/catalog/controller/checkout/register.php
@@ -211,6 +211,7 @@ class Register extends \Opencart\System\Engine\Controller {
 			'lastname'              => '',
 			'email'                 => '',
 			'telephone'             => '',
+			'custom_field'          => [],
 			'payment_company'       => '',
 			'payment_address_1'     => '',
 			'payment_address_2'     => '',
@@ -231,7 +232,8 @@ class Register extends \Opencart\System\Engine\Controller {
 			'shipping_zone_id'      => 0,
 			'shipping_custom_field' => [],
 			'password'              => '',
-			'agree'                 => 0
+			'agree'                 => 0,
+			'newsletter'            => 0
 		];
 
 		$post_info = $this->request->post + $required;
@@ -477,18 +479,22 @@ class Register extends \Opencart\System\Engine\Controller {
 				'lastname'          => $post_info['lastname'],
 				'email'             => $post_info['email'],
 				'telephone'         => $post_info['telephone'],
-				'custom_field'      => $post_info['custom_field'] ?? []
+				'custom_field'      => $post_info['custom_field']['account'] ?? [],
+				'password'          => $post_info['password'],
+				'newsletter'        => $post_info['newsletter']
 			];
 
 			// Register
 			if ($post_info['account']) {
-				$customer_data['customer_id'] = $this->model_account_customer->addCustomer($post_info);
+				$customer_data['customer_id'] = $this->model_account_customer->addCustomer($customer_data);
 			}
 
 			// Logged in, so edit customer details
 			if ($this->customer->isLogged()) {
-				$this->model_account_customer->editCustomer($this->customer->getId(), $post_info);
+				$this->model_account_customer->editCustomer($this->customer->getId(), $customer_data);
 			}
+
+			unset($customer_data['password']);
 
 			// Check if current customer group requires approval
 			if (!$customer_group_info['approval']) {
@@ -558,7 +564,7 @@ class Register extends \Opencart\System\Engine\Controller {
 					'iso_code_2'     => $iso_code_2,
 					'iso_code_3'     => $iso_code_3,
 					'address_format' => $address_format,
-					'custom_field'   => $post_info['payment_custom_field'] ?? []
+					'custom_field'   => $post_info['payment_custom_field']['address'] ?? []
 				];
 
 				// Add
@@ -649,7 +655,7 @@ class Register extends \Opencart\System\Engine\Controller {
 						'iso_code_2'     => $iso_code_2,
 						'iso_code_3'     => $iso_code_3,
 						'address_format' => $address_format,
-						'custom_field'   => $post_info['shipping_custom_field'] ?? []
+						'custom_field'   => $post_info['shipping_custom_field']['address'] ?? []
 					];
 
 					// Add Address to account if account is being created.

--- a/upload/catalog/view/template/checkout/register.twig
+++ b/upload/catalog/view/template/checkout/register.twig
@@ -51,7 +51,7 @@
 
           {% if custom_field.type == 'select' %}
             <div class="col mb-3 custom-field custom-field-{{ custom_field.custom_field_id }}">
-              <label for="input-custom-field-{{ custom_field.custom_field_id }}" class="form-label">{{ custom_field.name }}</label> <select name="custom_field[{{ custom_field.location }}][{{ custom_field.custom_field_id }}]" id="input-customer-custom-field-{{ custom_field.custom_field_id }}" class="form-select">
+              <label for="input-custom-field-{{ custom_field.custom_field_id }}" class="form-label">{{ custom_field.name }}</label> <select name="custom_field[{{ custom_field.location }}][{{ custom_field.custom_field_id }}]" id="input-custom-field-{{ custom_field.custom_field_id }}" class="form-select">
                 <option value="">{{ text_select }}</option>
                 {% for custom_field_value in custom_field.custom_field_value %}
                   <option value="{{ custom_field_value.custom_field_value_id }}"{% if account_custom_field[custom_field.custom_field_id] and custom_field_value.custom_field_value_id == account_custom_field[custom_field.custom_field_id] %} selected{% endif %}>{{ custom_field_value.name }}</option>
@@ -108,7 +108,7 @@
 
           {% if custom_field.type == 'file' %}
             <div class="col mb-3 custom-field custom-field-{{ custom_field.custom_field_id }}">
-              <label for="input-custom-field-{{ custom_field.custom_field_id }}" class="form-label">{{ custom_field.name }}</label>
+              <label class="form-label">{{ custom_field.name }}</label>
               <div>
                 <button type="button" data-oc-toggle="upload" data-oc-url="{{ upload }}" data-oc-size-max="{{ config_file_max_size }}" data-oc-size-error="{{ error_upload_size }}" data-oc-target="#input-custom-field-{{ custom_field.custom_field_id }}" class="btn btn-light"><i class="fa-solid fa-upload"></i> {{ button_upload }}</button>
                 <input type="hidden" name="custom_field[{{ custom_field.location }}][{{ custom_field.custom_field_id }}]" value="{% if account_custom_field[custom_field.custom_field_id] %}{{ account_custom_field[custom_field.custom_field_id] }}{% endif %}" id="input-custom-field-{{ custom_field.custom_field_id }}"/>
@@ -373,7 +373,7 @@
               <div id="input-shipping-custom-field-{{ custom_field.custom_field_id }}">
                 {% for custom_field_value in custom_field.custom_field_value %}
                   <div class="form-check">
-                    <input type="radio" name="shipping_custom_field[{{ custom_field.location }}][{{ custom_field.custom_field_id }}]" value="{{ custom_field_value.custom_field_value_id }}" id="input-shipping-custom-value-{{ custom_field_value.custom_field_value_id }}" class="form-check-input"{% if shipping_custom_field[custom_field.custom_field_id] and custom_field_value.custom_field_value_id in shipping_custom_field[custom_field.custom_field_id] %} checked{% endif %}/>
+                    <input type="radio" name="shipping_custom_field[{{ custom_field.location }}][{{ custom_field.custom_field_id }}]" value="{{ custom_field_value.custom_field_value_id }}" id="input-shipping-custom-value-{{ custom_field_value.custom_field_value_id }}" class="form-check-input"{% if shipping_custom_field[custom_field.custom_field_id] and custom_field_value.custom_field_value_id == shipping_custom_field[custom_field.custom_field_id] %} checked{% endif %}/>
                     <label for="input-shipping-custom-value-{{ custom_field_value.custom_field_value_id }}" class="form-check-label">{{ custom_field_value.name }}</label>
                   </div>
                 {% endfor %}
@@ -408,7 +408,7 @@
           {% if custom_field.type == 'textarea' %}
             <div class="col mb-3{% if custom_field.required %} required{% endif %} custom-field custom-field-{{ custom_field.custom_field_id }}">
               <label for="input-shipping-custom-field-{{ custom_field.custom_field_id }}" class="form-label">{{ custom_field.name }}</label>
-              <textarea name="shipping_custom_field[{{ custom_field.location }}][{{ custom_field.custom_field_id }}]" rows="5" placeholder="{% if shipping_custom_field[custom_field.custom_field_id] %}{{ shipping_custom_field[custom_field.custom_field_id] }}{% else %}{{ custom_field.value }}{% endif %}" id="input-shipping-custom-field-{{ custom_field.custom_field_id }}" class="form-control">{{ custom_field.value }}</textarea>
+              <textarea name="shipping_custom_field[{{ custom_field.location }}][{{ custom_field.custom_field_id }}]" rows="5" placeholder="{{ custom_field.name }}" id="input-shipping-custom-field-{{ custom_field.custom_field_id }}" class="form-control">{% if shipping_custom_field[custom_field.custom_field_id] %}{{ shipping_custom_field[custom_field.custom_field_id] }}{% else %}{{ custom_field.value }}{% endif %}</textarea>
               <div id="error-shipping-custom-field-{{ custom_field.custom_field_id }}" class="invalid-feedback"></div>
             </div>
           {% endif %}
@@ -418,8 +418,8 @@
               <div>
                 <button type="button" data-oc-toggle="upload" data-oc-url="{{ upload }}" data-oc-size-max="{{ config_file_max_size }}" data-oc-size-error="{{ error_upload_size }}" data-oc-target="#input-shipping-custom-field-{{ custom_field.custom_field_id }}" class="btn btn-light"><i class="fa-solid fa-upload"></i> {{ button_upload }}</button>
                 <input type="hidden" name="shipping_custom_field[{{ custom_field.location }}][{{ custom_field.custom_field_id }}]" value="{% if shipping_custom_field[custom_field.custom_field_id] %}{{ shipping_custom_field[custom_field.custom_field_id] }}{% endif %}" id="input-shipping-custom-field-{{ custom_field.custom_field_id }}"/>
-                <div id="error-shipping-custom-field-{{ custom_field.custom_field_id }}" class="invalid-feedback"></div>
               </div>
+              <div id="error-shipping-custom-field-{{ custom_field.custom_field_id }}" class="invalid-feedback"></div>
             </div>
           {% endif %}
 

--- a/upload/catalog/view/template/checkout/register.twig
+++ b/upload/catalog/view/template/checkout/register.twig
@@ -226,7 +226,7 @@
                 <div id="input-payment-custom-field-{{ custom_field.custom_field_id }}">
                   {% for custom_field_value in custom_field.custom_field_value %}
                     <div class="form-check">
-                      <input type="checkbox" name="payment_custom_field[{{ custom_field.location }}][{{ custom_field.custom_field_id }}][]" value="{{ custom_field_value.custom_field_value_id }}" id="input-payment-custom-value-{{ custom_field_value.custom_field_value_id }}" class="form-check-input"{% if address_custom_field[custom_field.custom_field_id] and custom_field_value.custom_field_value_id in address_custom_field[custom_field.custom_field_id] %} checked{% endif %}/> <label for="input-payment-custom-value-{{ custom_field_value.custom_field_value_id }}" class="form-check-label">{{ custom_field_value.name }}</label>
+                      <input type="checkbox" name="payment_custom_field[{{ custom_field.location }}][{{ custom_field.custom_field_id }}][]" value="{{ custom_field_value.custom_field_value_id }}" id="input-payment-custom-value-{{ custom_field_value.custom_field_value_id }}" class="form-check-input"{% if payment_custom_field[custom_field.custom_field_id] and custom_field_value.custom_field_value_id in payment_custom_field[custom_field.custom_field_id] %} checked{% endif %}/> <label for="input-payment-custom-value-{{ custom_field_value.custom_field_value_id }}" class="form-check-label">{{ custom_field_value.name }}</label>
                     </div>
                   {% endfor %}
                 </div>
@@ -236,13 +236,13 @@
             {% if custom_field.type == 'text' %}
               <div class="col mb-3{% if custom_field.required %} required{% endif %} custom-field custom-field-{{ custom_field.custom_field_id }}">
                 <label for="input-payment-custom-field-{{ custom_field.custom_field_id }}" class="form-label">{{ custom_field.name }}</label>
-                <input type="text" name="payment_custom_field[{{ custom_field.location }}][{{ custom_field.custom_field_id }}]" value="{% if address_custom_field[custom_field.custom_field_id] %}{{ address_custom_field[custom_field.custom_field_id] }}{% else %}{{ custom_field.value }}{% endif %}" placeholder="{{ custom_field.name }}" id="input-payment-custom-field-{{ custom_field.custom_field_id }}" class="form-control"/>
+                <input type="text" name="payment_custom_field[{{ custom_field.location }}][{{ custom_field.custom_field_id }}]" value="{% if payment_custom_field[custom_field.custom_field_id] %}{{ payment_custom_field[custom_field.custom_field_id] }}{% else %}{{ custom_field.value }}{% endif %}" placeholder="{{ custom_field.name }}" id="input-payment-custom-field-{{ custom_field.custom_field_id }}" class="form-control"/>
                 <div id="error-payment-custom-field-{{ custom_field.custom_field_id }}" class="invalid-feedback"></div>
               </div>
             {% endif %}
             {% if custom_field.type == 'textarea' %}
               <div class="col mb-3{% if custom_field.required %} required{% endif %} custom-field custom-field-{{ custom_field.custom_field_id }}">
-                <label for="input-payment-custom-field-{{ custom_field.custom_field_id }}" class="form-label">{{ custom_field.name }}</label> <textarea name="payment_custom_field[{{ custom_field.location }}][{{ custom_field.custom_field_id }}]" rows="5" placeholder="{{ custom_field.name }}" id="input-payment-custom-field-{{ custom_field.custom_field_id }}" class="form-control">{% if address_custom_field[custom_field.custom_field_id] %}{{ address_custom_field[custom_field.custom_field_id] }}{% else %}{{ custom_field.value }}{% endif %}</textarea>
+                <label for="input-payment-custom-field-{{ custom_field.custom_field_id }}" class="form-label">{{ custom_field.name }}</label> <textarea name="payment_custom_field[{{ custom_field.location }}][{{ custom_field.custom_field_id }}]" rows="5" placeholder="{{ custom_field.name }}" id="input-payment-custom-field-{{ custom_field.custom_field_id }}" class="form-control">{% if payment_custom_field[custom_field.custom_field_id] %}{{ payment_custom_field[custom_field.custom_field_id] }}{% else %}{{ custom_field.value }}{% endif %}</textarea>
                 <div id="error-payment-custom-field-{{ custom_field.custom_field_id }}" class="invalid-feedback"></div>
               </div>
             {% endif %}

--- a/upload/catalog/view/template/checkout/register.twig
+++ b/upload/catalog/view/template/checkout/register.twig
@@ -285,7 +285,7 @@
         {% if shipping_required %}
           <div class="col mb-3">
             <div class="form-check">
-              <input type="checkbox" name="address_match" value="1" id="input-address-match" class="form-check-input" checked/> <label for="input-address-match" class="form-check-label">{{ entry_match }}</label>
+              <input type="checkbox" name="address_match" value="1" id="input-address-match" class="form-check-input" {% if address_match %} checked{% endif %}/> <label for="input-address-match" class="form-check-label">{{ entry_match }}</label>
             </div>
           </div>
         {% endif %}
@@ -293,7 +293,7 @@
       </div>
     </fieldset>
   {% endif %}
-  <fieldset id="shipping-address" style="display: {% if not config_checkout_payment_address %}block{% else %}none{% endif %};">
+  <fieldset id="shipping-address" style="display: {% if not config_checkout_payment_address or ( config_checkout_payment_address and not address_match ) %}block{% else %}none{% endif %};">
     <legend>{{ text_shipping_address }}</legend>
     <div class="row row-cols-1 row-cols-md-2">
       {% if config_checkout_payment_address %}

--- a/upload/catalog/view/template/checkout/register.twig
+++ b/upload/catalog/view/template/checkout/register.twig
@@ -167,7 +167,7 @@
           <input type="text" name="payment_city" value="{{ payment_city }}" placeholder="{{ entry_city }}" id="input-payment-city" class="form-control"/>
           <div id="error-payment-city" class="invalid-feedback"></div>
         </div>
-        <div class="col mb-3 required">
+        <div class="col mb-3 {% if payment_postcode_required %} required{% endif %}">
           <label for="input-payment-postcode" class="form-label">{{ entry_postcode }}</label>
           <input type="text" name="payment_postcode" value="{{ payment_postcode }}" placeholder="{{ entry_postcode }}" id="input-payment-postcode" class="form-control"/>
           <div id="error-payment-postcode" class="invalid-feedback"></div>
@@ -326,7 +326,7 @@
         <input type="text" name="shipping_city" value="{{ shipping_city }}" placeholder="{{ entry_city }}" id="input-shipping-city" class="form-control"/>
         <div id="error-shipping-city" class="invalid-feedback"></div>
       </div>
-      <div class="col mb-3 required">
+      <div class="col mb-3 {% if shipping_postcode_required %} required{% endif %}">
         <label for="input-shipping-postcode" class="form-label">{{ entry_postcode }}</label>
         <input type="text" name="shipping_postcode" value="{{ shipping_postcode }}" placeholder="{{ entry_postcode }}" id="input-shipping-postcode" class="form-control"/>
         <div id="error-shipping-postcode" class="invalid-feedback"></div>


### PR DESCRIPTION
### Fixed
- [#15430](https://github.com/opencart/opencart/issues/15430) - Multiple issues in checkout's register component

1.Checkout index does not check if postcode is required for given country, and only on country update does UI show correctly. Added check before showing page, for better user experience.

**Before**
<img width="971" height="222" alt="image" src="https://github.com/user-attachments/assets/1dcb6059-3820-4ad2-81b0-a6b6c62387fa" />

2.Fix custom fields not retaining data on guest checkout after save and refresh, as well as not saving custom field values in either account or address on register checkout:

In catalog/controller/checkout/register OC builds component with both custom fields for address and account, so it nests them under field type, after save in db customers' custom_field we have:
```
{"account":{"29":["48"]}}
```
instead of correct
```
{"29":["48"]}
```

3.Removed label for file custom field, since input is hidden and browser shows warnings
4. Fixed shipping radio custom field using "in" instead of "==" for single value check
5. Moved shipping button custom field's error outside of "div" like other custom fields
6. Fixed payment custom fields using incorrect "address_custom_field" instead of "payment_custom_field"