### PR TITLE
Document MariaDB support in install and Docker docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ OpenCart 4.1 requires PHP 8.0+.
 Use the supplied `Makefile` wrappers around `docker compose`:
 ```bash
 make init        # first run only – copies docker/.env.docker.example
-make build       # build PHP/Apache/MySQL images
+make build       # build PHP/Apache/MariaDB images
 make up          # start the stack (add `profiles="redis"` etc. to include extras)
 make php         # open a shell in the PHP container as www-data
 make logs        # tail all service logs
@@ -25,7 +25,7 @@ Once the stack is running, visit `http://localhost`, complete the installer (cre
 ### Native / custom setups
 If you run OpenCart without Docker you must still provide:
 - PHP 8.0+ with extensions: `curl`, `gd`, `zip` (see `INSTALL.md` for OS-specific notes).
-- MySQL (or compatible) database.
+- MySQL or MariaDB database.
 - Web server pointing to `upload/` as the document root.
 
 Install PHP dependencies locally by running:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,7 +17,7 @@ If you are __upgrading your existing cart__, be sure to read the [upgrade instru
 		chmod 0777 config.php
 		chmod 0777 admin/config.php
 
-5. Make sure you have installed a MySQL Database which has a user assigned to it
+5. Make sure you have installed a MySQL or MariaDB database which has a user assigned to it
 	* do not use your ```root``` username and ```root``` password
 6. Visit the store homepage e.g. http://www.example.com or http://www.example.com/store/
 7. You should be taken to the installer page. Follow the on screen instructions.
@@ -33,7 +33,7 @@ If you are __upgrading your existing cart__, be sure to read the [upgrade instru
 		config.php
 		admin/config.php
 
-4. Make sure you have installed a MySQL Database which has a user assigned to it
+4. Make sure you have installed a MySQL or MariaDB database which has a user assigned to it
 	* do not use your ```root``` username and ```root``` password
 5. You should be taken to the installer page. Follow the on screen instructions.
 6. After successful install, delete the ```/install/``` directory.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ make build
 
 ### Using Docker Compose Profiles for Optional Services
 
-By default, only the core services (`apache`, `php`, `mysql`) are started.
+By default, only the core services (`apache`, `php`, `mysql`) are started. The `mysql` service runs MariaDB.
 Optional services such as **Adminer**, **Redis**, **Memcached**, and **PostgreSQL** can be enabled using [Docker Compose profiles](https://docs.docker.com/compose/profiles/).
 
 To enable one or more optional services, use the `--profile` flag and specify your env file:

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -103,7 +103,7 @@ Go to the “Upload” folder and select all the files inside and zip it to a ne
 
 ### Creating a database for the shop
 
-The next step is to create a database on the MySQL server for OpenCart to store a shop's data on. You should log into the site’s control panel and locate MySQL Databases. Using MySQL Databases, you can create a new database by entering a database name and a username/password to access this database. The user that was just created needs to be added to the database, along with enabling all of the necessary permissions. We will use this database information later when we are configuring OpenCart using the auto-installer.
+The next step is to create a database on your MySQL or MariaDB server for OpenCart to store a shop's data on. You should log into the site’s control panel and locate MySQL Databases. Using MySQL Databases, you can create a new database by entering a database name and a username/password to access this database. The user that was just created needs to be added to the database, along with enabling all of the necessary permissions. We will use this database information later when we are configuring OpenCart using the auto-installer.
 
 ### Launch the auto-installer
 

--- a/docs/getting-started/system-requirements.md
+++ b/docs/getting-started/system-requirements.md
@@ -2,7 +2,7 @@
 
 OpenCart has certain technical requirements for the software to operate properly. The software must be uploaded to a web server, which will make the store publicly available on the web. If you do not already have a domain or web hosting account, those can easily be purchased for an affordable price at various places online.
 
-When selecting a hosting service, an Apache server is recommended. You will also need a database server that supports MySQLi, PDO, or PostgreSQL. (MySQLi is recommended if possible.) Finally, you will need to have the following PHP libraries installed in your PHP configuration:
+When selecting a hosting service, an Apache server is recommended. You will also need a database server that supports MySQLi, PDO, or PostgreSQL. MySQL or MariaDB are supported when using MySQLi or PDO with a MySQL driver. (MySQLi is recommended if possible.) Finally, you will need to have the following PHP libraries installed in your PHP configuration:
 
 * PHP 8.0 or later
 * Curl


### PR DESCRIPTION
The Docker dev stack uses the official MariaDB image; list MariaDB alongside MySQL in install and contributor documentation.