### PR TITLE
[4.x.x.x] Corrections to .htaccess.txt

### DIFF
--- a/upload/.htaccess.txt
+++ b/upload/.htaccess.txt
@@ -9,25 +9,17 @@
 # The line 'Options +FollowSymLinks' may cause problems with some server configurations.
 # It is required for the use of Apache mod_rewrite, but it may have already been set by
 # your server administrator in a way that disallows changing it in this .htaccess file.
-# If you encounter problems (e.g. site is not loading), comment out this line by adding a # in front
-# FLOC is a feature suggested by Google, if this header shall not be set, disable the line
-# having 'interest-cohort' by adding a # in front
+# If you encounter problems (e.g. site is not loading), comment out this line by adding a # in front.
 ##
 
 ## No directory listings
 <IfModule mod_autoindex.c>
-  IndexIgnore *
+ IndexIgnore *
 </IfModule>
 
-## No-Referrer-Header
+## Suppress mime type detection in browsers for unknown types
 <IfModule mod_headers.c>
-  Header set Referrer-Policy "strict-origin-when-cross-origin"
-</IfModule>
-
-## Suppress mime type detection in browsers for unknown types and prevent FLOC
-<IfModule mod_headers.c>
-  Header always set X-Content-Type-Options "nosniff"
-  Header always set Permissions-Policy "interest-cohort=()"
+ Header always set X-Content-Type-Options "nosniff"
 </IfModule>
 
 ## Can be commented out if causes errors, see notes above.
@@ -39,14 +31,14 @@ Options -Indexes
 ## Prevent Direct Access to files
 <FilesMatch "(?i)((\.tpl|\.twig|\.ini|\.log|(?<!robots)\.txt))">
  Require all denied
-## For apache 2.2 and older, replace "Require all denied" with these two lines :
+## For apache 2.2 and older, replace "Require all denied" with these two lines:
 # Order deny,allow
 # Deny from all
 </FilesMatch>
 
 ## SEO URL Settings
 RewriteEngine On
-## If your opencart installation does not run on the main web folder make sure you folder it does run in ie. / becomes /shop/
+## If your opencart installation does not run in the main web folder make sure the following is set to the folder it does run in, i.e. / becomes /shop/
 RewriteBase /
 ## Rewrite Rules
 RewriteRule ^system/storage/(.*) index.php?route=error/not_found [L]
@@ -67,23 +59,17 @@ RewriteRule ^([^?]*) index.php?_route_=$1 [L,QSA]
 ## Uncomment the commands by removing the # sign in front of it.
 ## If you get an "Internal Server Error 500" after enabling any of the following settings, restore the # as this means your host doesn't allow that.
 
-# 1. If your cart only allows you to add one item at a time, it is possible register_globals is on. This may work to disable it:
-# php_flag register_globals off
-
-# 2. If your cart has magic quotes enabled, This may work to disable it:
-# php_flag magic_quotes_gpc Off
-
-# 3. Set max upload file size. Most hosts will limit this and not allow it to be overridden but you can try
+# 1. Set max upload file size. Most hosts will limit this and not allow it to be overridden but you can try.
 # php_value upload_max_filesize 999M
 
-# 4. set max post size. uncomment this line if you have a lot of product options or are getting errors where forms are not saving all fields
+# 2. Set max post size. Uncomment this line if you have a lot of product options or are getting errors where forms are not saving all fields.
 # php_value post_max_size 999M
 
-# 5. set max time script can take. uncomment this line if you have a lot of product options or are getting errors where forms are not saving all fields
+# 3. Set max time script can take. Uncomment this line if you have a lot of product options or are getting errors where forms are not saving all fields.
 # php_value max_execution_time 200
 
-# 6. set max time for input to be received. Uncomment this line if you have a lot of product options or are getting errors where forms are not saving all fields
+# 4. Set max time for input to be received. Uncomment this line if you have a lot of product options or are getting errors where forms are not saving all fields.
 # php_value max_input_time 200
 
-# 7. disable open_basedir limitations
-# php_admin_value open_basedir none
+# 5. Disable open_basedir limitations. Most hosts will limit this and not allow it to be overridden but you can try.
+# php_value open_basedir none


### PR DESCRIPTION
FLoC ended in 2022. strict-origin-when-cross-origin in the default anyway, so no need to set. RewriteBase comment didn't make sense. register_globals and magic_quotes_gpc were removed in PHP 5.4. php_admin_value does not work in .htaccess.