### PR TITLE
[4.x.x.x] Remove HTTP_CLIENT_IP override in startup

### DIFF
--- a/upload/system/startup.php
+++ b/upload/system/startup.php
@@ -45,11 +45,6 @@ if ((isset($_SERVER['HTTPS']) && (($_SERVER['HTTPS'] == 'on') || ($_SERVER['HTTP
 	$_SERVER['HTTPS'] = false;
 }
 
-// Check IP
-if (!empty($_SERVER['HTTP_CLIENT_IP'])) {
-	$_SERVER['REMOTE_ADDR'] = $_SERVER['HTTP_CLIENT_IP'];
-}
-
 // OpenCart Autoloader
 require_once(DIR_SYSTEM . 'engine/autoloader.php');
 


### PR DESCRIPTION
Correctly done and filtered in oc_get_ip() now.