### PR TITLE
[4.x.x.x] Change 'link' type from varchar to text

### DIFF
--- a/upload/system/helper/db_schema.php
+++ b/upload/system/helper/db_schema.php
@@ -474,7 +474,7 @@ function oc_db_schema() {
 			],
 			[
 				'name' => 'link',
-				'type' => 'varchar(255)'
+				'type' => 'text'
 			],
 			[
 				'name' => 'image',


### PR DESCRIPTION
Often banner links require additional link parameters like filters or tracking tokens which are more than 255 chars. 
I propose to change link field type to text.