### PR TITLE
[4.x.x.x] Add manufacturer.info route to SQL installation file

### DIFF
--- a/upload/install/opencart-en-gb.sql
+++ b/upload/install/opencart-en-gb.sql
@@ -2560,7 +2560,8 @@ VALUES (0, 1, 'product_id', '47', 'hp-lp3065', 1),
        (0, 1, 'route', 'information/information', 'information', -1),
        (0, 1, 'route', 'product/product', 'product', -1),
        (0, 1, 'route', 'product/category', 'catalog', -1),
-       (0, 1, 'route', 'product/manufacturer', 'brands', -1);
+       (0, 1, 'route', 'product/manufacturer', 'brands', -1),
+	   (0, 1, 'route', 'product/manufacturer.info', 'brand', -2);
 
 -----------------------------------------------------------
 


### PR DESCRIPTION
This adds the missing SEO URL route entries for product/manufacturer.info.

Individual manufacturer pages currently generate URLs such as:

/apple?route=product/manufacturer.info

because the installer includes an SEO URL route for product/manufacturer, but not for product/manufacturer.info.

Adding the missing route allows the existing SEO rewrite logic to generate clean manufacturer URLs such as:

/brand/apple

Fixes #15461