### PR TITLE
Validate installer archive paths

### DIFF
--- a/tests/security/installer_path_test.php
+++ b/tests/security/installer_path_test.php
@@ -1,0 +1,55 @@
+<?php
+require_once __DIR__ . '/../../upload/system/helper/general.php';
+
+function assert_same(mixed $expected, mixed $actual, string $message): void {
+	if ($expected !== $actual) {
+		fwrite(STDERR, $message . PHP_EOL);
+		exit(1);
+	}
+}
+
+$valid = [
+	'admin/controller/extension/demo/module/demo.php',
+	'image/catalog/demo/logo.png',
+	'system/storage/vendor/package/composer.json',
+	'install/controller/upgrade.php',
+];
+
+foreach ($valid as $path) {
+	assert_same(true, oc_validate_relative_path($path), 'Expected path to be allowed: ' . $path);
+}
+
+$invalid = [
+	'../config.php',
+	'demo/../../config.php',
+	'/tmp/config.php',
+	'C:\\tmp\\config.php',
+	'php://filter/resource=config.php',
+	'image//catalog/logo.png',
+	'image/./catalog/logo.png',
+	"image/catalog/logo.png\0.php",
+];
+
+foreach ($invalid as $path) {
+	assert_same(false, oc_validate_relative_path($path), 'Expected path to be rejected: ' . $path);
+}
+
+$root = sys_get_temp_dir() . '/oc-installer-path-' . bin2hex(random_bytes(4)) . '/';
+$base = $root . 'extension/';
+
+mkdir($base . 'demo', 0777, true);
+
+$destination = '../../outside.txt';
+
+if (oc_validate_relative_path($destination)) {
+	$path = 'demo/' . $destination;
+	file_put_contents($base . $path, 'escaped');
+}
+
+assert_same(false, is_file($root . 'outside.txt'), 'Traversal path wrote outside the extraction root.');
+
+rmdir($base . 'demo');
+rmdir($base);
+rmdir($root);
+
+echo 'Installer path validation tests passed.' . PHP_EOL;

--- a/upload/admin/controller/marketplace/installer.php
+++ b/upload/admin/controller/marketplace/installer.php
@@ -394,6 +394,12 @@ class Installer extends \Opencart\System\Engine\Controller {
 
 					$destination = str_replace('\\', '/', $source);
 
+					if (!oc_validate_relative_path($destination)) {
+						$json['error'] = sprintf($this->language->get('error_path'), $destination);
+
+						break;
+					}
+
 					// Only extract the contents of the upload folder
 					$path = $extension_install_info['code'] . '/' . $destination;
 					$base = DIR_EXTENSION;
@@ -445,7 +451,9 @@ class Installer extends \Opencart\System\Engine\Controller {
 
 				$zip->close();
 
-				$this->model_setting_extension->editStatus($extension_install_id, true);
+				if (!$json) {
+					$this->model_setting_extension->editStatus($extension_install_id, true);
+				}
 			} else {
 				$json['error'] = $this->language->get('error_unzip');
 			}

--- a/upload/admin/controller/tool/upgrade.php
+++ b/upload/admin/controller/tool/upgrade.php
@@ -88,7 +88,7 @@ class Upgrade extends \Opencart\System\Engine\Controller {
 	/**
 	 * Download
 	 *
-	 * @return array
+	 * @return void
 	 */
 	public function download(): void {
 		$this->load->language('tool/upgrade');
@@ -194,6 +194,12 @@ class Upgrade extends \Opencart\System\Engine\Controller {
 						$destination = str_replace('\\', '/', substr($source, strlen($remove)));
 
 						if (substr($destination, 0, 8) == 'install/') {
+							if (!oc_validate_relative_path($destination)) {
+								$json['error'] = sprintf($this->language->get('error_path'), $destination);
+
+								break;
+							}
+
 							// Default copy location
 							$path = '';
 
@@ -228,9 +234,11 @@ class Upgrade extends \Opencart\System\Engine\Controller {
 
 				$zip->close();
 
-				$json['text'] = $this->language->get('text_patch');
+				if (!$json) {
+					$json['text'] = $this->language->get('text_patch');
 
-				$json['next'] = HTTP_CATALOG . 'install/index.php?route=upgrade/upgrade_1&version=' . $version . '&admin=' . rtrim(substr(DIR_APPLICATION, strlen(DIR_OPENCART), -1));
+					$json['next'] = HTTP_CATALOG . 'install/index.php?route=upgrade/upgrade_1&version=' . $version . '&admin=' . rtrim(substr(DIR_APPLICATION, strlen(DIR_OPENCART), -1));
+				}
 			} else {
 				$json['error'] = $this->language->get('error_unzip');
 			}

--- a/upload/admin/language/en-gb/marketplace/installer.php
+++ b/upload/admin/language/en-gb/marketplace/installer.php
@@ -44,6 +44,7 @@ $_['error_file_exists']      = 'File already exist!';
 $_['error_file_type']        = 'Invalid file type!';
 $_['error_directory']        = 'Install directory %s could not be found!';
 $_['error_directory_exists'] = 'Path %s already exists!';
+$_['error_path']             = 'Install path %s is not allowed!';
 $_['error_unzip']            = 'Zip file could not be opened!';
 $_['error_upload']           = 'File could not be uploaded!';
 $_['error_unknown']          = 'An unknown error occurred!';

--- a/upload/admin/language/en-gb/tool/upgrade.php
+++ b/upload/admin/language/en-gb/tool/upgrade.php
@@ -24,5 +24,6 @@ $_['error_version']        = 'Version is lower than the current version!';
 $_['error_download']       = 'Upgrade could not be downloaded!';
 $_['error_file']           = 'Upgrade file could not be found!';
 $_['error_directory']      = 'Could not create directory %s!';
+$_['error_path']           = 'Install path %s is not allowed!';
 $_['error_copy']           = 'Could not copy file %s to %s!';
 $_['error_unzip']          = 'Zip file could not be opened!';

--- a/upload/admin/language/fr-fr/marketplace/installer.php
+++ b/upload/admin/language/fr-fr/marketplace/installer.php
@@ -42,6 +42,7 @@ $_['error_file_exists']      = 'Le fichier existe déjà!';
 $_['error_file_type']        = 'Type de fichier invalide!';
 $_['error_directory']        = 'Le répertoire d\'installation %s est introuvable!';
 $_['error_directory_exists'] = 'Le chemin %s existe déjà!';
+$_['error_path']             = 'Le chemin d\'installation %s n\'est pas autorisé!';
 $_['error_unzip']            = 'Impossible d\'ouvrir le fichier .zip!';
 $_['error_upload']           = 'Le fichier n\'a pu être téléchargé!';
 $_['error_unknown']          = 'Une erreur inconnue s’est produite!';

--- a/upload/admin/language/fr-fr/tool/upgrade.php
+++ b/upload/admin/language/fr-fr/tool/upgrade.php
@@ -26,5 +26,6 @@ $_['error_version']        = 'La version est inférieure à la version actuelle!
 $_['error_download']       = 'La mise à niveau n\'a pas pu être téléchargée!';
 $_['error_file']           = 'Le fichier de mise à niveau est introuvable!';
 $_['error_directory']      = 'Impossible de créer le répertoire %s!';
+$_['error_path']           = 'Le chemin d\'installation %s n\'est pas autorisé!';
 $_['error_copy']           = 'Impossible de copier le fichier %s vers %s!';
 $_['error_unzip']          = 'Impossible d\'ouvrir le fichier .zip!';

--- a/upload/system/helper/general.php
+++ b/upload/system/helper/general.php
@@ -342,6 +342,29 @@ function oc_validate_filename(string $filename): bool {
 }
 
 /**
+ * Validate Relative Path
+ *
+ * @param string $path
+ *
+ * @return bool
+ */
+function oc_validate_relative_path(string $path): bool {
+	$path = str_replace('\\', '/', $path);
+
+	if ($path === '' || str_contains($path, "\0") || str_starts_with($path, '/') || preg_match('/^[A-Za-z]:/', $path) || str_contains($path, '://')) {
+		return false;
+	}
+
+	foreach (explode('/', trim($path, '/')) as $part) {
+		if ($part === '' || $part === '.' || $part === '..') {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
  * Validate URL
  *
  * @param string $url


### PR DESCRIPTION
Summary
  Tighten OpenCart installer ZIP handling so archive paths cannot write outside the intended install roots.

  The marketplace extension installer and core upgrade installer manually construct output paths from ZIP entry names. Before this change, an archive entry containing traversal segments such as `../` could
  escape the expected extension, image, storage, or install directory.

  Changes
  - Add a reusable relative path validator for archive member paths.
  - Reject empty paths, NUL bytes, absolute paths, Windows drive paths, stream-wrapper style paths, repeated separators, `.`, and `..` path segments.
  - Apply the check to marketplace extension installation.
  - Apply the check to core upgrade installer extraction.
  - Add a standalone regression test for valid paths and traversal rejection.

  Validation
  - `php -l upload/system/helper/general.php`
  - `php -l upload/admin/controller/marketplace/installer.php`
  - `php -l upload/admin/controller/tool/upgrade.php`
  - `php -l upload/admin/language/en-gb/marketplace/installer.php`
  - `php -l upload/admin/language/fr-fr/marketplace/installer.php`
  - `php -l upload/admin/language/en-gb/tool/upgrade.php`
  - `php -l upload/admin/language/fr-fr/tool/upgrade.php`
  - `php tests/security/installer_path_test.php`
  - `php tools/phpstan.phar analyze --no-progress --debug upload/admin/controller/marketplace/installer.php upload/admin/controller/tool/upgrade.php upload/system/helper/general.php`
  - `git diff --check`