### PR TITLE
[4.x.x.x] Admin Order edit changes

### DIFF
--- a/upload/admin/view/template/sale/order_info.twig
+++ b/upload/admin/view/template/sale/order_info.twig
@@ -97,7 +97,7 @@
                 <th class="text-end">{{ column_quantity }}</th>
                 <th class="text-end">{{ column_price }}</th>
                 <th class="text-end">{{ column_total }}</th>
-                <th class="text-end" style="width: 1px;">{{ column_action }}</th>
+                {#<th class="text-end" style="width: 1px;">{{ column_action }}</th>#}
               </tr>
             </thead>
             <tbody id="order-product">
@@ -154,20 +154,21 @@
                     <td class="text-end">{{ order_product.quantity }}</td>
                     <td class="text-end">{{ order_product.price }}</td>
                     <td class="text-end">{{ order_product.total }}</td>
-                    <td class="text-end"><button type="button" data-bs-toggle="tooltip" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
+                    {#<td class="text-end"><button type="button" data-bs-toggle="tooltip" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>#}
                   </tr>
                   {% set order_product_row = order_product_row + 1 %}
                 {% endfor %}
               {% else %}
                 <tr>
-                  <td colspan="5" class="text-center">{{ text_no_results }}</td>
+                  <td colspan="4" class="text-center">{{ text_no_results }}</td>
+                  {#<td colspan="5" class="text-center">{{ text_no_results }}</td>#}
                 </tr>
               {% endif %}
             </tbody>
             <tfoot>
               <tr>
                 <td colspan="4"></td>
-                <td class="text-end"><button type="button" data-bs-toggle="modal" data-bs-target="#modal-product" class="btn btn-primary"><i class="fa-solid fa-plus-circle"></i></button></td>
+                {#<td class="text-end"><button type="button" data-bs-toggle="modal" data-bs-target="#modal-product" class="btn btn-primary"><i class="fa-solid fa-plus-circle"></i></button></td>#}
               </tr>
             </tfoot>
           </table>
@@ -613,6 +614,7 @@
       </div>
       <div class="modal-body">
         <form id="form-product-add">
+          <input type="hidden" name="order_id" value="{{ order_id }}"/>
           <div class="mb-3">
             <label for="input-product" class="form-label">{{ entry_product }}</label> <input type="text" value="" placeholder="{{ entry_product }}" id="input-product" data-oc-target="autocomplete-product" class="form-control"/>
             <ul id="autocomplete-product" class="dropdown-menu"></ul>

--- a/upload/catalog/controller/api/cart.php
+++ b/upload/catalog/controller/api/cart.php
@@ -54,6 +54,7 @@ class Cart extends \Opencart\System\Engine\Controller {
 
 			$product_info = $this->model_catalog_product->getProduct($product_id);
 
+			/* this still has issues! Stock levels were already adjusted for original order items!
 			if ($product_info) {
 				// Merge variant code with options
 				foreach ($product_info['variant'] as $option_id => $value) {
@@ -123,6 +124,11 @@ class Cart extends \Opencart\System\Engine\Controller {
 					$output['error']['product_' . (int)$key . '_subscription'] = $this->language->get('error_subscription');
 				}
 			} else {
+				$output['error']['product_' . (int)$key . '_product'] = $this->language->get('error_product');
+			}
+			*/
+
+			if (!$product_info) {
 				$output['error']['product_' . (int)$key . '_product'] = $this->language->get('error_product');
 			}
 

--- a/upload/catalog/controller/api/order.php
+++ b/upload/catalog/controller/api/order.php
@@ -384,9 +384,11 @@ class Order extends \Opencart\System\Engine\Controller {
 		}
 
 		// 3. Validate cart has products and has stock
+		/* this still has issues! Stock levels were already adjusted for original order items!
 		if ((!$this->cart->hasStock() && !$this->config->get('config_stock_checkout')) || !$this->cart->hasMinimum()) {
 			$output['error']['product'] = $this->language->get('error_stock');
 		}
+		*/
 
 		// 4. Validate payment address if required
 		if ($this->config->get('config_checkout_payment_address') && !isset($this->session->data['payment_address'])) {


### PR DESCRIPTION
The admin order edit still has some serious issues that needs to be addressed in the api/cart and api/order. For example, the stock levels are already adjusted for the purchased items, and should be excluded from cart stock level checks. Also, order options for added products which are variants of a master item are incorrectly checked, and don't show up, nor do any associated error messages for them.

This pull request simply disables product changes in the admin order edit for the time being.