### PR TITLE
[4.x.x.x]  Fix admin order methods validation

### DIFF
--- a/upload/admin/view/template/sale/order_info.twig
+++ b/upload/admin/view/template/sale/order_info.twig
@@ -260,12 +260,12 @@
         <div class="row">
           <div id="shipping-method" class="col-md mb-3{% if not shipping_method_code %} d-none{% endif %}" style="min-height: 64px;">
             <div class="input-group">
-              <section id="section-shipping-method" class="form-control rounded-start" style="min-height: 64px;">
+              <div id="input-shipping-method-info" class="form-control rounded-start" style="min-height: 64px;">
                 <div class="lead"><strong>{{ text_shipping_method }}</strong>
                   <br/>
                   <div id="output-shipping-method">{{ shipping_method_name }}</div>
                 </div>
-              </section>
+              </div>
               <button type="button" id="button-shipping-methods" class="btn btn-outline-primary"><i class="fa-solid fa-cog"></i></button>
             </div>
           </div>
@@ -2248,6 +2248,22 @@ $('#button-confirm').on('click', function() {
             }
 
             if (typeof json['error'] == 'object') {
+                if (json['error']['shipping_method']) {
+                    $('#alert').prepend('<div class="alert alert-danger alert-dismissible"><i class="fa-solid fa-circle-exclamation"></i> ' + json['error']['shipping_method'] + ' <button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>');
+
+                    $('#input-shipping-method-info').addClass('is-invalid');
+
+                    delete json['error']['shipping_method'];
+                }
+
+                if (json['error']['payment_method']) {
+                    $('#alert').prepend('<div class="alert alert-danger alert-dismissible"><i class="fa-solid fa-circle-exclamation"></i> ' + json['error']['payment_method'] + ' <button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>');
+
+                    $('#input-payment-method-info').addClass('is-invalid');
+
+                    delete json['error']['payment_method'];
+                }
+
                 for (key in json['error']) {
                     $('#input-' + key.replaceAll('_', '-')).addClass('is-invalid').find('.form-control, .form-select, .form-check-input, .form-check-label').addClass('is-invalid');
                     $('#error-' + key.replaceAll('_', '-')).html(json['error'][key]).addClass('d-block');

--- a/upload/catalog/controller/api/payment_method.php
+++ b/upload/catalog/controller/api/payment_method.php
@@ -18,20 +18,7 @@ class PaymentMethod extends \Opencart\System\Engine\Controller {
 
 		$output = [];
 
-		$required = [
-			'payment_method' => [
-				'name' => '',
-				'code' => ''
-			]
-		];
-
-		$post_info = $this->request->post + $required;
-
-		if (!is_array($post_info['payment_method'])) {
-			$post_info['payment_method'] = $required['payment_method'];
-		} else {
-			$post_info['payment_method'] += $required['payment_method'];
-		}
+		$post_info = $this->request->post;
 
 		// 1. Validate customer data exists
 		if (!isset($this->session->data['customer'])) {
@@ -57,6 +44,20 @@ class PaymentMethod extends \Opencart\System\Engine\Controller {
 		// 4. Validate payment address if required
 		if ($this->config->get('config_checkout_payment_address') && !isset($this->session->data['payment_address'])) {
 			$output['error'] = $this->language->get('error_payment_address');
+		}
+
+		// 5. Validate payment method
+		$keys = [
+			'name',
+			'code'
+		];
+
+		foreach ($keys as $key) {
+			if (empty($post_info['payment_method'][$key])) {
+				$output['error'] = $this->language->get('error_payment_method');
+
+				break;
+			}
 		}
 
 		if (!$output) {

--- a/upload/catalog/controller/api/shipping_method.php
+++ b/upload/catalog/controller/api/shipping_method.php
@@ -40,7 +40,7 @@ class ShippingMethod extends \Opencart\System\Engine\Controller {
 			];
 
 			foreach ($keys as $key) {
-				if (!isset($post_info['shipping_method'][$key])) {
+				if (empty($post_info['shipping_method'][$key])) {
 					$output['error'] = $this->language->get('error_shipping_method');
 
 					break;


### PR DESCRIPTION
### Fixed
- [#15477](https://github.com/opencart/opencart/issues/15477) - [4.x.x.x] Admin edit order - methods validation issues

**Before**
<img width="1086" height="758" alt="Image" src="https://github.com/user-attachments/assets/4ccf4fb9-bc1a-4f4e-b9c1-21741f3d2c80" />

**After**
<img width="1002" height="860" alt="image" src="https://github.com/user-attachments/assets/b1359dde-525e-4df0-90ee-68c74a109dbb" />


- Show alert on missing shipping and/or payment methods (same as in **index.php?route=sale/subscription.info**)
- Same validation for payment_method as in shipping_method