### PR TITLE
[4.x.x.x] Bug: admin/model/cms/article.php getComments()

### DIFF
--- a/upload/admin/model/cms/article.php
+++ b/upload/admin/model/cms/article.php
@@ -770,7 +770,7 @@ class Article extends \Opencart\System\Engine\Model {
 	 * $results = $this->model_cms_article->getComments($filter_data);
 	 */
 	public function getComments(array $data = []): array {
-		$sql = "SELECT *, `ac`.`rating`, `ac`.`status`, `ac`.`date_added` FROM `" . DB_PREFIX . "article_comment` `ac` LEFT JOIN `" . DB_PREFIX . "article` `a` ON (`ac`.`article_id` = `a`.`article_id`) LEFT JOIN `" . DB_PREFIX . "article_description` `ad` ON (`ac`.`article_id` = `ad`.`article_id`) WHERE `ad`.`language_id` = '" . (int)$this->config->get('config_language_id') . "'";
+		$sql = "SELECT *, `ac`.`author`, `ac`.`rating`, `ac`.`status`, `ac`.`date_added` FROM `" . DB_PREFIX . "article_comment` `ac` LEFT JOIN `" . DB_PREFIX . "article` `a` ON (`ac`.`article_id` = `a`.`article_id`) LEFT JOIN `" . DB_PREFIX . "article_description` `ad` ON (`ac`.`article_id` = `ad`.`article_id`) WHERE `ad`.`language_id` = '" . (int)$this->config->get('config_language_id') . "'";
 
 		$implode = [];
 


### PR DESCRIPTION
admin/model/cms/article.php getComments() — ac.author overwritten by a.author due to SELECT * with JOIN