### PR TITLE
[4.x.x.x] disable admin order add

### DIFF
--- a/upload/admin/view/template/sale/order.twig
+++ b/upload/admin/view/template/sale/order.twig
@@ -6,7 +6,7 @@
         <button type="button" data-bs-toggle="tooltip" title="{{ button_filter }}" onclick="$('#filter-order').toggleClass('d-none');" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
         <button type="submit" id="button-invoice" form="form-order" formaction="{{ invoice }}" formtarget="_blank" data-bs-toggle="tooltip" title="{{ button_invoice_print }}" class="btn btn-info"><i class="fa-solid fa-print"></i></button>
         <button type="submit" id="button-shipping" form="form-order" formaction="{{ shipping }}" formtarget="_blank" data-bs-toggle="tooltip" title="{{ button_shipping_print }}" class="btn btn-info"><i class="fa-solid fa-truck"></i></button>
-        <a href="{{ add }}" data-bs-toggle="tooltip" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
+        {#<a href="{{ add }}" data-bs-toggle="tooltip" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>#}
         <button type="submit" data-oc-toggle="ajax" form="form-order" formaction="{{ delete }}"  data-bs-toggle="tooltip" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>


### PR DESCRIPTION
Temporarily disable the admin order add because of outstanding issues with stock level checks and variant override options, see https://github.com/opencart/opencart/issues/15437 and https://github.com/opencart/opencart/issues/15462