### PR TITLE
[4.x.x.x] Fix option values check and error messages

### DIFF
--- a/upload/admin/controller/catalog/option.php
+++ b/upload/admin/controller/catalog/option.php
@@ -319,7 +319,7 @@ class Option extends \Opencart\System\Engine\Controller {
 			}
 		}
 
-		if (($post_info['type'] == 'select' || $post_info['type'] == 'radio' || $post_info['type'] == 'checkbox') && !isset($post_info['option_value'])) {
+		if ((in_array($post_info['type'], ['select', 'radio', 'checkbox', 'image'])) && !isset($post_info['option_value'])) {
 			$json['error']['warning'] = $this->language->get('error_type');
 		}
 
@@ -449,7 +449,7 @@ class Option extends \Opencart\System\Engine\Controller {
 			foreach ($options as $option) {
 				$option_value_data = [];
 
-				if ($option['type'] == 'select' || $option['type'] == 'radio' || $option['type'] == 'checkbox' || $option['type'] == 'image') {
+				if (in_array($option['type'], ['select', 'radio', 'checkbox', 'image'])) {
 					$option_values = $this->model_catalog_option->getValues($option['option_id']);
 
 					foreach ($option_values as $option_value) {
@@ -477,11 +477,11 @@ class Option extends \Opencart\System\Engine\Controller {
 
 				$type = '';
 
-				if ($option['type'] == 'select' || $option['type'] == 'radio' || $option['type'] == 'checkbox') {
+				if (in_array($option['type'], ['select', 'radio', 'checkbox', 'image'])) {
 					$type = $this->language->get('text_choose');
 				}
 
-				if ($option['type'] == 'text' || $option['type'] == 'textarea') {
+				if (in_array($option['type'], ['text', 'textarea'])) {
 					$type = $this->language->get('text_input');
 				}
 
@@ -489,7 +489,7 @@ class Option extends \Opencart\System\Engine\Controller {
 					$type = $this->language->get('text_file');
 				}
 
-				if ($option['type'] == 'date' || $option['type'] == 'datetime' || $option['type'] == 'time') {
+				if (in_array($option['type'], ['date', 'datetime', 'time'])) {
 					$type = $this->language->get('text_date');
 				}
 

--- a/upload/admin/controller/catalog/option.php
+++ b/upload/admin/controller/catalog/option.php
@@ -319,7 +319,7 @@ class Option extends \Opencart\System\Engine\Controller {
 			}
 		}
 
-		if ((in_array($post_info['type'], ['select', 'radio', 'checkbox', 'image'])) && !isset($post_info['option_value'])) {
+		if ((in_array($post_info['type'], ['select', 'radio', 'checkbox'])) && !isset($post_info['option_value'])) {
 			$json['error']['warning'] = $this->language->get('error_type');
 		}
 
@@ -449,7 +449,7 @@ class Option extends \Opencart\System\Engine\Controller {
 			foreach ($options as $option) {
 				$option_value_data = [];
 
-				if (in_array($option['type'], ['select', 'radio', 'checkbox', 'image'])) {
+				if (in_array($option['type'], ['select', 'radio', 'checkbox'])) {
 					$option_values = $this->model_catalog_option->getValues($option['option_id']);
 
 					foreach ($option_values as $option_value) {
@@ -477,7 +477,7 @@ class Option extends \Opencart\System\Engine\Controller {
 
 				$type = '';
 
-				if (in_array($option['type'], ['select', 'radio', 'checkbox', 'image'])) {
+				if (in_array($option['type'], ['select', 'radio', 'checkbox'])) {
 					$type = $this->language->get('text_choose');
 				}
 

--- a/upload/admin/controller/catalog/product.php
+++ b/upload/admin/controller/catalog/product.php
@@ -996,7 +996,7 @@ class Product extends \Opencart\System\Engine\Controller {
 		$data['option_values'] = [];
 
 		foreach ($data['product_options'] as $product_option) {
-			if (in_array($product_option['type'], ['select', 'radio', 'checkbox', 'image'])) {
+			if (in_array($product_option['type'], ['select', 'radio', 'checkbox'])) {
 				if (!isset($data['option_values'][$product_option['option_id']])) {
 					$data['option_values'][$product_option['option_id']] = $this->model_catalog_option->getValues($product_option['option_id']);
 				}
@@ -1246,7 +1246,7 @@ class Product extends \Opencart\System\Engine\Controller {
 		// Options
 		if (!empty($post_info['product_option'])) {
 			foreach ($post_info['product_option'] as $row_idx => $option) {
-				if ((in_array($option['type'], ['select', 'radio', 'checkbox', 'image'])) && empty($option['product_option_value'])) {
+				if ((in_array($option['type'], ['select', 'radio', 'checkbox'])) && empty($option['product_option_value'])) {
 					$json['error']['option-row-' . $row_idx] = sprintf($this->language->get('error_option_value'), $option['name']);
 				}
 			}

--- a/upload/admin/controller/catalog/product.php
+++ b/upload/admin/controller/catalog/product.php
@@ -996,7 +996,7 @@ class Product extends \Opencart\System\Engine\Controller {
 		$data['option_values'] = [];
 
 		foreach ($data['product_options'] as $product_option) {
-			if ($product_option['type'] == 'select' || $product_option['type'] == 'radio' || $product_option['type'] == 'checkbox' || $product_option['type'] == 'image') {
+			if (in_array($product_option['type'], ['select', 'radio', 'checkbox', 'image'])) {
 				if (!isset($data['option_values'][$product_option['option_id']])) {
 					$data['option_values'][$product_option['option_id']] = $this->model_catalog_option->getValues($product_option['option_id']);
 				}
@@ -1236,9 +1236,18 @@ class Product extends \Opencart\System\Engine\Controller {
 		if ($post_info['master_id']) {
 			$product_options = $this->model_catalog_product->getOptions($post_info['master_id']);
 
-			foreach ($product_options as $product_option) {
+			foreach ($product_options as $row_idx => $product_option) {
 				if (isset($post_info['override']['variant'][$product_option['product_option_id']]) && $product_option['required'] && empty($post_info['variant'][$product_option['product_option_id']])) {
-					$json['error']['option_' . $product_option['product_option_id']] = sprintf($this->language->get('error_required'), $product_option['name']);
+					$json['error']['option-row-' . $row_idx] = sprintf($this->language->get('error_required'), $product_option['name']);
+				}
+			}
+		}
+
+		// Options
+		if (!empty($post_info['product_option'])) {
+			foreach ($post_info['product_option'] as $row_idx => $option) {
+				if ((in_array($option['type'], ['select', 'radio', 'checkbox', 'image'])) && empty($option['product_option_value'])) {
+					$json['error']['option-row-' . $row_idx] = sprintf($this->language->get('error_option_value'), $option['name']);
 				}
 			}
 		}

--- a/upload/admin/language/en-gb/catalog/product.php
+++ b/upload/admin/language/en-gb/catalog/product.php
@@ -138,3 +138,4 @@ $_['error_keyword']              = 'SEO URL must be between 1 and 64 characters!
 $_['error_keyword_exists']       = 'SEO URL must be unique!';
 $_['error_keyword_character']    = 'Keyword can only use characters a-z, 0-9, - and _!';
 $_['error_required']             = '%s required!';
+$_['error_option_value']         = 'Option values required for %s!';

--- a/upload/admin/language/fr-fr/catalog/product.php
+++ b/upload/admin/language/fr-fr/catalog/product.php
@@ -138,3 +138,4 @@ $_['error_keyword']              = 'L\'URL SEO doit contenir entre 1 et 64 carac
 $_['error_keyword_exists']       = 'L\'URL SEO doit être unique!';
 $_['error_keyword_character']    = 'Le mot-clé ne peut utiliser que les caractères a-z, 0-9, - et _ !';
 $_['error_required']             = '%s requis!';
+$_['error_option_value']         = 'Les valeurs de l\'option sont requises pour %s!';

--- a/upload/admin/model/catalog/product.php
+++ b/upload/admin/model/catalog/product.php
@@ -130,6 +130,10 @@ class Product extends \Opencart\System\Engine\Model {
 		// Options
 		if (isset($data['product_option'])) {
 			foreach ($data['product_option'] as $product_option) {
+				if ((in_array($product_option['type'], ['select', 'radio', 'checkbox', 'image'])) && empty($product_option['product_option_value'])) {
+					continue;
+				}
+
 				$this->model_catalog_product->addOption($product_id, $product_option);
 			}
 		}
@@ -324,6 +328,10 @@ class Product extends \Opencart\System\Engine\Model {
 
 		if (isset($data['product_option'])) {
 			foreach ($data['product_option'] as $product_option) {
+				if (in_array($product_option['type'], ['select', 'radio', 'checkbox', 'image']) && empty($product_option['product_option_value'])) {
+					continue;
+				}
+
 				$this->model_catalog_product->addOption($product_id, $product_option);
 			}
 		}

--- a/upload/admin/model/catalog/product.php
+++ b/upload/admin/model/catalog/product.php
@@ -130,7 +130,7 @@ class Product extends \Opencart\System\Engine\Model {
 		// Options
 		if (isset($data['product_option'])) {
 			foreach ($data['product_option'] as $product_option) {
-				if ((in_array($product_option['type'], ['select', 'radio', 'checkbox', 'image'])) && empty($product_option['product_option_value'])) {
+				if ((in_array($product_option['type'], ['select', 'radio', 'checkbox'])) && empty($product_option['product_option_value'])) {
 					continue;
 				}
 
@@ -328,7 +328,7 @@ class Product extends \Opencart\System\Engine\Model {
 
 		if (isset($data['product_option'])) {
 			foreach ($data['product_option'] as $product_option) {
-				if (in_array($product_option['type'], ['select', 'radio', 'checkbox', 'image']) && empty($product_option['product_option_value'])) {
+				if (in_array($product_option['type'], ['select', 'radio', 'checkbox']) && empty($product_option['product_option_value'])) {
 					continue;
 				}
 

--- a/upload/admin/view/template/catalog/product_form.twig
+++ b/upload/admin/view/template/catalog/product_form.twig
@@ -707,6 +707,7 @@
 
                     <fieldset id="option-row-{{ option_row }}">
                       <legend>{{ product_option.name }}</legend>
+                      <div id="error-option-row-{{ option_row }}" class="invalid-feedback"></div>
                       <input type="hidden" name="product_option[{{ option_row }}][product_option_id]" value="{{ product_option.product_option_id }}"/> <input type="hidden" name="product_option[{{ option_row }}][name]" value="{{ product_option.name }}"/> <input type="hidden" name="product_option[{{ option_row }}][option_id]" value="{{ product_option.option_id }}"/> <input type="hidden" name="product_option[{{ option_row }}][type]" value="{{ product_option.type }}"/>
 
                       <div class="row align-items-center">
@@ -1586,6 +1587,7 @@ $('#input-option').autocomplete({
     'select': function(item) {
         html = '<fieldset id="option-row-' + option_row + '">';
         html += '  <legend class="float-none">' + item['label'] + '</legend>';
+        html += '  <div id="error-option-row-' + option_row + '" class="invalid-feedback"></div>';
         html += '  <input type="hidden" name="product_option[' + option_row + '][product_option_id]" value="" />';
         html += '  <input type="hidden" name="product_option[' + option_row + '][name]" value="' + decodeHTMLEntities(item['label']) + '" />';
         html += '  <input type="hidden" name="product_option[' + option_row + '][option_id]" value="' + item['value'] + '" />';


### PR DESCRIPTION
It is possible to add an option with no values now. This results with PHP or SQL error when adding/modifying a product.

Fix option values check and error messages:
1. Added option values check in controller
2. Added error div to options in product_form
3. Added error language strings
4. Added check in product model - ignore options without values (may be required for API calls without product controller checks)
5. Refactored bulk PHP `||` checks with `in_array()` for better code reading