### PR TITLE
[SECURITY] Add allowed_classes => false to upgrade script unserialize() calls

### DIFF
--- a/upload/install/controller/upgrade/upgrade_11.php
+++ b/upload/install/controller/upgrade/upgrade_11.php
@@ -24,7 +24,7 @@ class Upgrade11 extends \Opencart\System\Engine\Controller {
 
 			foreach ($query->rows as $result) {
 				if (preg_match('/^(a:)/', $result['custom_field'])) {
-					$this->db->query("UPDATE `" . DB_PREFIX . "customer` SET `custom_field` = '" . $this->db->escape(json_encode(unserialize($result['custom_field']))) . "' WHERE `customer_id` = '" . (int)$result['customer_id'] . "'");
+					$this->db->query("UPDATE `" . DB_PREFIX . "customer` SET `custom_field` = '" . $this->db->escape(json_encode(unserialize($result['custom_field'], ['allowed_classes' => false]))) . "' WHERE `customer_id` = '" . (int)$result['customer_id'] . "'");
 				}
 			}
 
@@ -33,7 +33,7 @@ class Upgrade11 extends \Opencart\System\Engine\Controller {
 
 			foreach ($query->rows as $result) {
 				if (preg_match('/^(a:)/', $result['data'])) {
-					$this->db->query("UPDATE `" . DB_PREFIX . "customer_activity` SET `data` = '" . $this->db->escape(json_encode(unserialize($result['data']))) . "' WHERE `customer_activity_id` = '" . (int)$result['customer_activity_id'] . "'");
+					$this->db->query("UPDATE `" . DB_PREFIX . "customer_activity` SET `data` = '" . $this->db->escape(json_encode(unserialize($result['data'], ['allowed_classes' => false]))) . "' WHERE `customer_activity_id` = '" . (int)$result['customer_activity_id'] . "'");
 				}
 			}
 
@@ -42,7 +42,7 @@ class Upgrade11 extends \Opencart\System\Engine\Controller {
 
 			foreach ($query->rows as $result) {
 				if (preg_match('/^(a:)/', $result['custom_field'])) {
-					$this->db->query("UPDATE `" . DB_PREFIX . "address` SET `custom_field` = '" . $this->db->escape(json_encode(unserialize($result['custom_field']))) . "' WHERE `address_id` = '" . (int)$result['address_id'] . "'");
+					$this->db->query("UPDATE `" . DB_PREFIX . "address` SET `custom_field` = '" . $this->db->escape(json_encode(unserialize($result['custom_field'], ['allowed_classes' => false]))) . "' WHERE `address_id` = '" . (int)$result['address_id'] . "'");
 				}
 			}
 

--- a/upload/install/controller/upgrade/upgrade_12.php
+++ b/upload/install/controller/upgrade/upgrade_12.php
@@ -22,15 +22,15 @@ class Upgrade12 extends \Opencart\System\Engine\Controller {
 
 			foreach ($query->rows as $result) {
 				if (preg_match('/^(a:)/', $result['custom_field'])) {
-					$this->db->query("UPDATE `" . DB_PREFIX . "order` SET `custom_field` = '" . $this->db->escape(json_encode(unserialize($result['custom_field']))) . "' WHERE `order_id` = '" . (int)$result['order_id'] . "'");
+					$this->db->query("UPDATE `" . DB_PREFIX . "order` SET `custom_field` = '" . $this->db->escape(json_encode(unserialize($result['custom_field'], ['allowed_classes' => false]))) . "' WHERE `order_id` = '" . (int)$result['order_id'] . "'");
 				}
 
 				if (preg_match('/^(a:)/', $result['payment_custom_field'])) {
-					$this->db->query("UPDATE `" . DB_PREFIX . "order` SET `payment_custom_field` = '" . $this->db->escape(json_encode(unserialize($result['payment_custom_field']))) . "' WHERE `order_id` = '" . (int)$result['order_id'] . "'");
+					$this->db->query("UPDATE `" . DB_PREFIX . "order` SET `payment_custom_field` = '" . $this->db->escape(json_encode(unserialize($result['payment_custom_field'], ['allowed_classes' => false]))) . "' WHERE `order_id` = '" . (int)$result['order_id'] . "'");
 				}
 
 				if (preg_match('/^(a:)/', $result['shipping_custom_field'])) {
-					$this->db->query("UPDATE `" . DB_PREFIX . "order` SET `shipping_custom_field` = '" . $this->db->escape(json_encode(unserialize($result['shipping_custom_field']))) . "' WHERE `order_id` = '" . (int)$result['order_id'] . "'");
+					$this->db->query("UPDATE `" . DB_PREFIX . "order` SET `shipping_custom_field` = '" . $this->db->escape(json_encode(unserialize($result['shipping_custom_field'], ['allowed_classes' => false]))) . "' WHERE `order_id` = '" . (int)$result['order_id'] . "'");
 				}
 			}
 

--- a/upload/install/controller/upgrade/upgrade_17.php
+++ b/upload/install/controller/upgrade/upgrade_17.php
@@ -22,7 +22,7 @@ class Upgrade17 extends \Opencart\System\Engine\Controller {
 
 			foreach ($query->rows as $result) {
 				if (preg_match('/^(a:)/', $result['permission'])) {
-					$this->db->query("UPDATE `" . DB_PREFIX . "user_group` SET `permission` = '" . $this->db->escape(json_encode(unserialize($result['permission']))) . "' WHERE `user_group_id` = '" . (int)$result['user_group_id'] . "'");
+					$this->db->query("UPDATE `" . DB_PREFIX . "user_group` SET `permission` = '" . $this->db->escape(json_encode(unserialize($result['permission'], ['allowed_classes' => false]))) . "' WHERE `user_group_id` = '" . (int)$result['user_group_id'] . "'");
 				}
 			}
 		} catch (\ErrorException $exception) {

--- a/upload/install/controller/upgrade/upgrade_5.php
+++ b/upload/install/controller/upgrade/upgrade_5.php
@@ -35,7 +35,7 @@ class Upgrade5 extends \Opencart\System\Engine\Controller {
 
 			foreach ($query->rows as $result) {
 				if (preg_match('/^(a:)/', $result['value'])) {
-					$this->db->query("UPDATE `" . DB_PREFIX . "setting` SET `value` = '" . $this->db->escape(json_encode(unserialize($result['value']))) . "' WHERE `setting_id` = '" . (int)$result['setting_id'] . "'");
+					$this->db->query("UPDATE `" . DB_PREFIX . "setting` SET `value` = '" . $this->db->escape(json_encode(unserialize($result['value'], ['allowed_classes' => false]))) . "' WHERE `setting_id` = '" . (int)$result['setting_id'] . "'");
 				}
 			}
 

--- a/upload/install/controller/upgrade/upgrade_7.php
+++ b/upload/install/controller/upgrade/upgrade_7.php
@@ -25,7 +25,7 @@ class Upgrade7 extends \Opencart\System\Engine\Controller {
 
 			foreach ($query->rows as $result) {
 				if (preg_match('/^(a:)/', $result['setting'])) {
-					$this->db->query("UPDATE `" . DB_PREFIX . "module` SET `setting` = '" . $this->db->escape(json_encode(unserialize($result['setting']))) . "' WHERE `module_id` = '" . (int)$result['module_id'] . "'");
+					$this->db->query("UPDATE `" . DB_PREFIX . "module` SET `setting` = '" . $this->db->escape(json_encode(unserialize($result['setting'], ['allowed_classes' => false]))) . "' WHERE `module_id` = '" . (int)$result['module_id'] . "'");
 				}
 			}
 		} catch (\ErrorException $exception) {


### PR DESCRIPTION
## Summary

Five database upgrade scripts read serialized data from legacy table columns before converting it to JSON format. All nine `unserialize()` calls are missing the `allowed_classes` option, leaving them vulnerable to PHP Object Injection (CWE-502).

## Problem

Bare `unserialize()` without `allowed_classes` can instantiate any PHP class loaded in memory when processing the input string. If an attacker can write a malicious serialized object to the database before the upgrade routine runs (via SQL injection, a compromised backup restore, or direct DB access), PHP magic methods (`__wakeup()`, `__destruct()`) can be triggered during deserialization, potentially leading to Remote Code Execution.

**Affected files and columns:**

| File | Column |
|------|--------|
| `upgrade_5.php` | `oc_setting.value` |
| `upgrade_7.php` | `oc_module.setting` |
| `upgrade_11.php` | `oc_customer.custom_field`, `oc_customer_activity.data`, `oc_address.custom_field` |
| `upgrade_12.php` | `oc_order.custom_field`, `oc_order.payment_custom_field`, `oc_order.shipping_custom_field` |
| `upgrade_17.php` | `oc_user_group.permission` |

## Fix

Pass `['allowed_classes' => false]` to each `unserialize()` call.

This is safe because all values in these columns were originally stored by OpenCart itself as serialized plain PHP arrays — no objects are ever stored. If a malformed row is encountered, `unserialize()` returns `false`, and `json_encode(false)` stores `'false'` in the column, which is a graceful failure.

## References

- https://www.php.net/manual/en/function.unserialize.php
- CWE-502: Deserialization of Untrusted Data
- OWASP: PHP Object Injection