### PR TITLE
[SECURITY] Add allowed_classes => false to upgrade_7.php unserialize() call

### DIFF
--- a/upload/install/controller/upgrade/upgrade_7.php
+++ b/upload/install/controller/upgrade/upgrade_7.php
@@ -25,7 +25,7 @@ class Upgrade7 extends \Opencart\System\Engine\Controller {
 
 			foreach ($query->rows as $result) {
 				if (preg_match('/^(a:)/', $result['setting'])) {
-					$this->db->query("UPDATE `" . DB_PREFIX . "module` SET `setting` = '" . $this->db->escape(json_encode(unserialize($result['setting']))) . "' WHERE `module_id` = '" . (int)$result['module_id'] . "'");
+					$this->db->query("UPDATE `" . DB_PREFIX . "module` SET `setting` = '" . $this->db->escape(json_encode(unserialize($result['setting'], ['allowed_classes' => false]))) . "' WHERE `module_id` = '" . (int)$result['module_id'] . "'");
 				}
 			}
 		} catch (\ErrorException $exception) {


### PR DESCRIPTION
## Summary

`upgrade_7.php` calls `unserialize()` on database-stored module settings without an `allowed_classes` restriction. This PR adds `['allowed_classes' => false]` to the call, consistent with the fix applied in PR #15498 for `upgrade_5`, `upgrade_11`, `upgrade_12`, and `upgrade_17`.

## Vulnerability

The upgrade script reads `module.setting` from the database and passes it directly to `unserialize()` before re-encoding it as JSON. If the stored value was previously poisoned with a PHP gadget chain (e.g. by a prior SQL-injection attack or a compromised database), the instantiation of the gadget class during the OpenCart upgrade could lead to Remote Code Execution.

## Fix

```php
// Before
unserialize($result['setting'])

// After
unserialize($result['setting'], ['allowed_classes' => false])
```

Module settings at this point in the upgrade path are always plain arrays of scalar values. `allowed_classes => false` prevents any object instantiation while keeping the migration logic intact for legitimate data.

## Related

- PR #15498 — same fix applied to `upgrade_5`, `upgrade_11`, `upgrade_12`, `upgrade_17`
