### PR TITLE
[4.x.x.x] Change product rating field type to float

### DIFF
--- a/upload/admin/model/catalog/product.php
+++ b/upload/admin/model/catalog/product.php
@@ -939,7 +939,7 @@ class Product extends \Opencart\System\Engine\Model {
 	 * Edit product rating record in the database.
 	 *
 	 * @param int $product_id primary key of the product record
-	 * @param int $rating
+	 * @param float $rating
 	 *
 	 * @return void
 	 *
@@ -949,8 +949,8 @@ class Product extends \Opencart\System\Engine\Model {
 	 *
 	 * $this->model_catalog_product->editRating($result['product_id'], $this->model_catalog_review->getRating($product_id));
 	 */
-	public function editRating(int $product_id, int $rating): void {
-		$this->db->query("UPDATE `" . DB_PREFIX . "product` SET `rating` = '" . (int)$rating . "', `date_modified` = NOW() WHERE `product_id` = '" . (int)$product_id . "'");
+	public function editRating(int $product_id, float $rating): void {
+		$this->db->query("UPDATE `" . DB_PREFIX . "product` SET `rating` = '" . (float)$rating . "', `date_modified` = NOW() WHERE `product_id` = '" . (int)$product_id . "'");
 	}
 
 	/**

--- a/upload/admin/model/catalog/product.php
+++ b/upload/admin/model/catalog/product.php
@@ -938,7 +938,7 @@ class Product extends \Opencart\System\Engine\Model {
 	 *
 	 * Edit product rating record in the database.
 	 *
-	 * @param int $product_id primary key of the product record
+	 * @param int   $product_id primary key of the product record
 	 * @param float $rating
 	 *
 	 * @return void

--- a/upload/admin/model/catalog/review.php
+++ b/upload/admin/model/catalog/review.php
@@ -161,7 +161,7 @@ class Review extends \Opencart\System\Engine\Model {
 	 *
 	 * @param int $product_id primary key of the product record
 	 *
-	 * @return int total number of rating records that have product ID
+	 * @return float average rating that have product ID
 	 *
 	 * @example
 	 *

--- a/upload/admin/model/catalog/review.php
+++ b/upload/admin/model/catalog/review.php
@@ -169,11 +169,11 @@ class Review extends \Opencart\System\Engine\Model {
 	 *
 	 * $rating_info = $this->model_catalog_review->getRating($product_id);
 	 */
-	public function getRating(int $product_id): int {
+	public function getRating(int $product_id): float {
 		$query = $this->db->query("SELECT AVG(`rating`) AS `total` FROM `" . DB_PREFIX . "review` WHERE `product_id` = '" . (int)$product_id . "' AND `status` = '1'");
 
 		if ($query->num_rows) {
-			return (int)$query->row['total'];
+			return (float)$query->row['total'];
 		} else {
 			return 0;
 		}

--- a/upload/catalog/controller/product/compare.php
+++ b/upload/catalog/controller/product/compare.php
@@ -142,7 +142,7 @@ class Compare extends \Opencart\System\Engine\Controller {
 					'manufacturer' => $manufacturer,
 					'availability' => $availability,
 					'minimum'      => $product_info['minimum'] > 0 ? $product_info['minimum'] : 1,
-					'rating'       => (int)$product_info['rating'],
+					'rating'       => $product_info['rating'],
 					'reviews'      => sprintf($this->language->get('text_reviews'), (int)$product_info['reviews']),
 					'weight'       => $this->weight->format($product_info['weight'], $product_info['weight_class_id'], $this->language->get('decimal_point'), $this->language->get('thousand_point')),
 					'length'       => $this->length->format($product_info['length'], $product_info['length_class_id'], $this->language->get('decimal_point'), $this->language->get('thousand_point')),

--- a/upload/catalog/controller/product/product.php
+++ b/upload/catalog/controller/product/product.php
@@ -296,7 +296,7 @@ class Product extends \Opencart\System\Engine\Controller {
 				$data['stock'] = $product_info['quantity'];
 			}
 
-			$data['rating'] = (int)$product_info['rating'];
+			$data['rating'] = $product_info['rating'];
 			$data['review_status'] = (int)$this->config->get('config_review_status');
 			$data['review'] = $this->load->controller('product/review');
 

--- a/upload/catalog/model/catalog/product.php
+++ b/upload/catalog/model/catalog/product.php
@@ -72,7 +72,7 @@ class Product extends \Opencart\System\Engine\Model {
 			$product_data['variant'] = $query->row['variant'] ? json_decode($query->row['variant'], true) : [];
 			$product_data['override'] = $query->row['override'] ? json_decode($query->row['override'], true) : [];
 			$product_data['price'] = (float)($query->row['discount'] ?: $query->row['price']);
-			$product_data['rating'] = (int)$query->row['rating'];
+			$product_data['rating'] = (float)$query->row['rating'];
 			$product_data['reviews'] = (int)$query->row['reviews'] ? $query->row['reviews'] : 0;
 
 			return $product_data;

--- a/upload/extension/opencart/catalog/controller/module/featured.php
+++ b/upload/extension/opencart/catalog/controller/module/featured.php
@@ -71,7 +71,7 @@ class Featured extends \Opencart\System\Engine\Controller {
 					'special'     => $special,
 					'tax'         => $tax,
 					'minimum'     => $product['minimum'] > 0 ? $product['minimum'] : 1,
-					'rating'      => (int)$product['rating'],
+					'rating'      => $product['rating'],
 					'href'        => $this->url->link('product/product', 'language=' . $this->config->get('config_language') . '&product_id=' . $product['product_id'])
 				];
 


### PR DESCRIPTION
Many modern stores and themes want to show product average rating as decimal 4.4, 4.9, 5.0, etc. 
But this functionality is limited by `int` field type in `oc_product`.`rating`. 
This PR allows to calculate and store decimal(3.2) ratings allowing value `4.99`, etc. 
While you still can round it to integer in your template.