### PR TITLE
[Master] reject traversal zip entries in marketplace installer

### DIFF
--- a/upload/admin/controller/marketplace/installer.php
+++ b/upload/admin/controller/marketplace/installer.php
@@ -394,6 +394,11 @@ class Installer extends \Opencart\System\Engine\Controller {
 
 					$destination = str_replace('\\', '/', $source);
 
+					// Reject any entry that traverses outside the install directory
+					if (in_array('..', explode('/', $destination))) {
+						continue;
+					}
+
 					// Only extract the contents of the upload folder
 					$path = $extension_install_info['code'] . '/' . $destination;
 					$base = DIR_EXTENSION;


### PR DESCRIPTION
**Zip-slip in the ocmod extension installer**

Entry names from an uploaded `.ocmod.zip` get mapped onto a fixed base but are never checked for `..`, so a crafted archive can drop files outside the extension folder the extractor is meant to confine them to. Skipping entries that contain a traversal segment keeps the write within bounds and matches the containment the surrounding `image/` and `system/storage/` handling already assumes.
