### PR TITLE
[4.x.x.x] Coupon category restriction not enforced

### DIFF
--- a/upload/catalog/model/catalog/product.php
+++ b/upload/catalog/model/catalog/product.php
@@ -462,7 +462,7 @@ class Product extends \Opencart\System\Engine\Model {
 	 * $category_total = $this->model_catalog_product->getTotalCategoriesByCategoryId($product_id, $category_id);
 	 */
 	public function getTotalCategoriesByCategoryId(int $product_id, int $category_id): int {
-		$query = $this->db->query("SELECT COUNT(*) AS `total` FROM `" . DB_PREFIX . "product_to_category` WHERE `category_id` = '" . (int)$category_id . "'");
+		$query = $this->db->query("SELECT COUNT(*) AS `total` FROM `" . DB_PREFIX . "product_to_category` WHERE `product_id` = '" . (int)$product_id . "' AND `category_id` = '" . (int)$category_id . "'");
 
 		return (int)$query->row['total'];
 	}


### PR DESCRIPTION
It ignores the product_id, see https://github.com/opencart/opencart/issues/15523