### PR TITLE
[4.x.x.x] Customer-facing 2FA email contains admin-oriented text

### DIFF
--- a/upload/catalog/language/en-gb/mail/authorize.php
+++ b/upload/catalog/language/en-gb/mail/authorize.php
@@ -1,6 +1,6 @@
 <?php
 // Text
 $_['text_subject'] = 'Security';
-$_['text_code']    = 'You must enter the security code in the admin security check.';
+$_['text_code']    = 'Please enter the following security code to sign in to your account:';
 $_['text_ip']      = 'IP:';
 $_['text_regards'] = 'Best Regards';


### PR DESCRIPTION
2FA email text now changed to refer to customer account, see https://github.com/opencart/opencart/issues/15531