### PR TITLE
Harden lint workflow actions

### DIFF
--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -10,6 +10,9 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -18,10 +21,10 @@ jobs:
         php: ['8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ matrix.php }}
           tools: composer:v2, cs2pr
@@ -36,7 +39,7 @@ jobs:
           fi
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cache/composer/files


### PR DESCRIPTION
## Summary

- restrict the Lint workflow `GITHUB_TOKEN` to read-only repository contents
- pin `actions/checkout`, `shivammathur/setup-php`, and `actions/cache` to immutable commit SHAs
- update the cache action from the old v3 tag to the current pinned v5.0.5 commit

## Rationale

The Lint workflow runs on pull requests and previously loaded all external actions through mutable tags. Pinning actions to full commit SHAs reduces supply-chain risk from tag movement or compromised action releases. The workflow only needs repository read access, so the patch also makes that token scope explicit with `contents: read`.

Before this change, zizmor reported high-confidence `unpinned-uses` findings for all three action steps. After this change, the workflow has no medium-or-higher findings under the same scan settings.

## Testing

- `uvx --from zizmor zizmor --min-severity medium --min-confidence medium .github/workflows/Lint.yml`
- `python3 -c "import yaml; yaml.safe_load(open(".github/workflows/Lint.yml"))"`
- `git diff --check`

Not run locally: PHP/composer lint job, because this container does not have PHP or Composer installed.
