### PR TITLE
[4.x.x.x] Improve admin performance with order table index

### DIFF
--- a/upload/system/helper/db_schema.php
+++ b/upload/system/helper/db_schema.php
@@ -4646,6 +4646,12 @@ function oc_db_schema() {
 				'key'  => [
 					'email'
 				]
+			],
+			[
+				'name' => 'order_status_id',
+				'key'  => [
+					'order_status_id'
+				]
 			]
 		],
 		'engine'  => 'InnoDB',


### PR DESCRIPTION
The `Opencart\Admin\Model\Sale\Order::getTotalOrders()` method runs slowly since there is no indexing on `order_status_id`. Adding an index improved query speed from 1.453 seconds to 0.016 in one test case. This had a significant impact on admin page load speeds since the method is triggered on every page as part of the left column order statistics.