### PR TITLE
[Master] Use hash_equals() for API signature validation

### DIFF
--- a/upload/catalog/controller/startup/api.php
+++ b/upload/catalog/controller/startup/api.php
@@ -93,7 +93,7 @@ class Api extends \Opencart\System\Engine\Controller {
 				$string .= md5(http_build_query($this->request->post)) . "\n";
 				$string .= $time . "\n";
 
-				if (rawurldecode($this->request->get['signature']) != base64_encode(hash_hmac('sha1', $string, $api_info['key'], true))) {
+				if (!hash_equals(base64_encode(hash_hmac('sha1', $string, $api_info['key'], true)), rawurldecode($this->request->get['signature']))) {
 					$status = false;
 				}
 			}


### PR DESCRIPTION
## Summary

`catalog/controller/startup/api.php` compares the request signature against the server-computed HMAC with a plain `!=`:

```php
if (rawurldecode($this->request->get['signature']) != base64_encode(hash_hmac('sha1', $string, $api_info['key'], true))) {
```

This switches that comparison to `hash_equals()`, PHP's built-in function for comparing HMAC / signature values. Both operands are strings, so it is a direct drop-in:

```php
if (!hash_equals(base64_encode(hash_hmac('sha1', $string, $api_info['key'], true)), rawurldecode($this->request->get['signature']))) {
```

Behavior is unchanged for valid and invalid signatures. This keeps the API signature check consistent with how the project already compares HMAC values elsewhere (the Cardinity extension, #4020).
