### PR TITLE
[4.x.x.x] Use hash_equals() for API signature validation

### DIFF
--- a/upload/catalog/controller/startup/api.php
+++ b/upload/catalog/controller/startup/api.php
@@ -93,7 +93,7 @@ class Api extends \Opencart\System\Engine\Controller {
 				$string .= md5(http_build_query($this->request->post)) . "\n";
 				$string .= $time . "\n";
 
-				if (rawurldecode($this->request->get['signature']) != base64_encode(hash_hmac('sha1', $string, $api_info['key'], true))) {
+				if (!hash_equals(base64_encode(hash_hmac('sha1', $string, $api_info['key'], true)), rawurldecode($this->request->get['signature']))) {
 					$status = false;
 				}
 			}


### PR DESCRIPTION
See https://github.com/opencart/opencart/pull/15540 for details.