### PR TITLE
fix inverted .sql extension check in backup upload

### DIFF
--- a/upload/admin/controller/tool/backup.php
+++ b/upload/admin/controller/tool/backup.php
@@ -262,7 +262,7 @@ class Backup extends \Opencart\System\Engine\Controller {
 			}
 
 			// Allowed file extension types
-			if (str_ends_with(strtolower($filename), '.sql')) {
+			if (!str_ends_with(strtolower($filename), '.sql')) {
 				$json['error'] = $this->language->get('error_file_type');
 			}
 		}


### PR DESCRIPTION
The backup upload handler is supposed to accept only .sql files, but the extension test in upload() is reversed: it sets the "Invalid file type" error when the filename ends with .sql and lets every other extension through, so a .php or .phar name passes validation and gets written into the storage backup directory. Negating the condition restores the intended allowlist so only .sql backups are accepted.