### PR TITLE
[4.x.x.x] Help prevent long-running cron jobs from causing misses.

### DIFF
--- a/upload/catalog/controller/cron/cron.php
+++ b/upload/catalog/controller/cron/cron.php
@@ -22,9 +22,9 @@ class Cron extends \Opencart\System\Engine\Controller {
 
 		foreach ($results as $result) {
 			if ($result['status'] && (strtotime('+1 ' . $result['cycle'], strtotime($result['date_modified'])) < ($time + 10))) {
-				$this->load->controller($result['action'], $result['cron_id'], $result['code'], $result['cycle'], $result['date_added'], $result['date_modified']);
-
 				$this->model_setting_cron->editCron($result['cron_id']);
+
+				$this->load->controller($result['action'], $result['cron_id'], $result['code'], $result['cycle'], $result['date_added'], $result['date_modified']);
 			}
 		}
 	}

--- a/upload/catalog/controller/cron/cron.php
+++ b/upload/catalog/controller/cron/cron.php
@@ -12,8 +12,6 @@ class Cron extends \Opencart\System\Engine\Controller {
 	 * @return void
 	 */
 	public function index(): void {
-		$time = time();
-
 		$this->load->model('setting/cron');
 
 		$results = $this->model_setting_cron->getCrons();
@@ -21,7 +19,7 @@ class Cron extends \Opencart\System\Engine\Controller {
 		$this->load->controller('cron/subscription', 3, 'subscription', 1, '', '');
 
 		foreach ($results as $result) {
-			if ($result['status'] && (strtotime('+1 ' . $result['cycle'], strtotime($result['date_modified'])) < ($time + 10))) {
+			if ($result['status'] && (strtotime('+1 ' . $result['cycle'], strtotime($result['date_modified'])) < (time() + 10))) {
 				$this->model_setting_cron->editCron($result['cron_id']);
 
 				$this->load->controller($result['action'], $result['cron_id'], $result['code'], $result['cycle'], $result['date_added'], $result['date_modified']);


### PR DESCRIPTION
Crons that took longer than 10 seconds could miss the next execution.