### PR TITLE
[Master] reject api requests outside the signature time window

### DIFF
--- a/upload/catalog/controller/startup/api.php
+++ b/upload/catalog/controller/startup/api.php
@@ -76,7 +76,7 @@ class Api extends \Opencart\System\Engine\Controller {
 				$time_start = time() - 450;
 				$time_end = time() + 450;
 
-				if ($time < $time_start && $time > $time_end) {
+				if ($time < $time_start || $time > $time_end) {
 					$status = false;
 				}
 			}


### PR DESCRIPTION
startup/api validates the request `time` against a +/-450 second window, but the two bounds are joined with && , so `$time < $time_start && $time > $time_end` can never be true and the check never rejects anything. Since `time` is folded into the HMAC-signed string only to bound replay, a captured signed api/order or api/subscription request stays valid forever instead of expiring. Switching to || rejects timestamps that fall outside the window.