### PR TITLE
[Master] reject traversal entries in upgrade archive extraction

### DIFF
--- a/upload/admin/controller/tool/upgrade.php
+++ b/upload/admin/controller/tool/upgrade.php
@@ -193,6 +193,11 @@ class Upgrade extends \Opencart\System\Engine\Controller {
 						// Only extract the contents of the upload folder
 						$destination = str_replace('\\', '/', substr($source, strlen($remove)));
 
+						// Reject any entry that traverses outside the target directory
+						if (in_array('..', explode('/', $destination))) {
+							continue;
+						}
+
 						if (substr($destination, 0, 8) == 'install/') {
 							// Default copy location
 							$path = '';

--- a/upload/install/controller/upgrade/upgrade_3.php
+++ b/upload/install/controller/upgrade/upgrade_3.php
@@ -77,6 +77,11 @@ class Upgrade3 extends \Opencart\System\Engine\Controller {
 						// Only extract the contents of the upload folder
 						$destination = str_replace('\\', '/', substr($source, strlen($remove)));
 
+						// Reject any entry that traverses outside the target directory
+						if (in_array('..', explode('/', $destination))) {
+							continue;
+						}
+
 						if (substr($destination, 0, 8) != 'install/') {
 							// Default copy location
 							$base = DIR_OPENCART;


### PR DESCRIPTION
Both upgrade extractors write each zip entry under DIR_OPENCART guarded only by an install/ prefix test, with no rejection of `..` segments, so an entry like `opencart-<version>/upload/install/../admin/controller/x.php` resolves outside the install directory and lets a tampered upgrade archive write files anywhere in the tree. marketplace/installer.php already drops entries whose path contains `..`, but tool/upgrade.php and install/controller/upgrade/upgrade_3.php were missing that same guard. Added the check to both loops so traversal entries are skipped.