### PR TITLE
[4.0.x.x] Fix email validation logic

### DIFF
--- a/upload/system/helper/validation.php
+++ b/upload/system/helper/validation.php
@@ -24,18 +24,6 @@ function oc_validate_email(string $email): bool {
 		return false;
 	}
 
-	if (oc_strrpos($email, '@') === false) {
-		return false;
-	}
-
-	if (function_exists('idn_to_ascii')) {
-		$local = oc_substr($email, 0, oc_strrpos($email, '@'));
-
-		$domain = oc_substr($email, (oc_strrpos($email, '@') + 1));
-
-		$email = $local . '@' . idn_to_ascii($domain, IDNA_NONTRANSITIONAL_TO_ASCII, INTL_IDNA_VARIANT_UTS46);
-	}
-
 	return filter_var($email, FILTER_VALIDATE_EMAIL) !== false;
 }
 


### PR DESCRIPTION
Removed redundant email validation checks and IDN conversion.

Was only allowing the domain part and not the local part to contain contain international characters. Would not be guaranteed to work without changes to the mail classes.

Allowing international characters in any part of the email address causes an issue with the GDPR functions, allowing them to leak or remove information in some circumstances.