### PR TITLE
Harden admin file and package handling

### DIFF
--- a/upload/admin/controller/design/sass.php
+++ b/upload/admin/controller/design/sass.php
@@ -354,7 +354,7 @@ class Template extends \Opencart\System\Engine\Controller {
 			$file = $directory . '/' . implode('/', $part) . '.twig';
 		}
 
-		if (!is_file($file) || (substr(str_replace('\\', '/', realpath($file)), 0, strlen($directory)) != $directory)) {
+		if (!$this->isFileInDirectory($file, $directory)) {
 			$json['code'] = '';
 		}
 
@@ -393,7 +393,7 @@ class Template extends \Opencart\System\Engine\Controller {
 		$directory = DIR_CATALOG . 'view/template';
 		$file = $directory . '/' . (string)$post_info['route'] . '.html';
 
-		if (!is_file($file) || (substr(str_replace('\\', '/', realpath($file)), 0, strlen($directory)) != $directory)) {
+		if (!$this->isFileInDirectory($file, $directory)) {
 			$json['error'] = $this->language->get('error_file');
 		}
 
@@ -410,7 +410,7 @@ class Template extends \Opencart\System\Engine\Controller {
 
 			$file = $directory . '/' . $route . '.html';
 
-			if (!is_file($file) || substr(str_replace('\\', '/', realpath($file)), 0, strlen($directory)) != $directory) {
+			if (!$this->isFileInDirectory($file, $directory)) {
 				$json['error'] = $this->language->get('error_file');
 			}
 		}
@@ -538,5 +538,27 @@ class Template extends \Opencart\System\Engine\Controller {
 
 		$this->response->addHeader('Content-Type: application/json');
 		$this->response->setOutput(json_encode($json));
+	}
+
+	/**
+	 * Is File In Directory
+	 *
+	 * @param string $file
+	 * @param string $directory
+	 *
+	 * @return bool
+	 */
+	private function isFileInDirectory(string $file, string $directory): bool {
+		$directory = realpath($directory);
+		$file = realpath($file);
+
+		if ($directory === false || $file === false || !is_file($file)) {
+			return false;
+		}
+
+		$directory = rtrim(str_replace('\\', '/', $directory), '/') . '/';
+		$file = str_replace('\\', '/', $file);
+
+		return str_starts_with($file, $directory);
 	}
 }

--- a/upload/admin/controller/design/template.php
+++ b/upload/admin/controller/design/template.php
@@ -339,7 +339,7 @@ class Template extends \Opencart\System\Engine\Controller {
 			$file = $directory . '/' . implode('/', $part) . '.twig';
 		}
 
-		if (!is_file($file) || (substr(str_replace('\\', '/', realpath($file)), 0, strlen($directory)) != $directory)) {
+		if (!$this->isFileInDirectory($file, $directory)) {
 			$json['code'] = '';
 		}
 
@@ -378,7 +378,7 @@ class Template extends \Opencart\System\Engine\Controller {
 		$directory = DIR_CATALOG . 'view/template';
 		$file = $directory . '/' . (string)$post_info['route'] . '.html';
 
-		if (!is_file($file) || (substr(str_replace('\\', '/', realpath($file)), 0, strlen($directory)) != $directory)) {
+		if (!$this->isFileInDirectory($file, $directory)) {
 			$json['error'] = $this->language->get('error_file');
 		}
 
@@ -395,7 +395,7 @@ class Template extends \Opencart\System\Engine\Controller {
 
 			$file = $directory . '/' . $route . '.html';
 
-			if (!is_file($file) || substr(str_replace('\\', '/', realpath($file)), 0, strlen($directory)) != $directory) {
+			if (!$this->isFileInDirectory($file, $directory)) {
 				$json['error'] = $this->language->get('error_file');
 			}
 		}
@@ -523,5 +523,27 @@ class Template extends \Opencart\System\Engine\Controller {
 
 		$this->response->addHeader('Content-Type: application/json');
 		$this->response->setOutput(json_encode($json));
+	}
+
+	/**
+	 * Is File In Directory
+	 *
+	 * @param string $file
+	 * @param string $directory
+	 *
+	 * @return bool
+	 */
+	private function isFileInDirectory(string $file, string $directory): bool {
+		$directory = realpath($directory);
+		$file = realpath($file);
+
+		if ($directory === false || $file === false || !is_file($file)) {
+			return false;
+		}
+
+		$directory = rtrim(str_replace('\\', '/', $directory), '/') . '/';
+		$file = str_replace('\\', '/', $file);
+
+		return str_starts_with($file, $directory);
 	}
 }

--- a/upload/admin/controller/marketplace/installer.php
+++ b/upload/admin/controller/marketplace/installer.php
@@ -33,7 +33,7 @@ class Installer extends \Opencart\System\Engine\Controller {
 
 		$data['config_file_max_size'] = ((int)preg_filter('/[^0-9]/', '', ini_get('upload_max_filesize')) * 1024 * 1024);
 
-		$data['upload'] = $this->url->link('tool/installer.upload', 'user_token=' . $this->session->data['user_token']);
+		$data['upload'] = $this->url->link('marketplace/installer.upload', 'user_token=' . $this->session->data['user_token']);
 
 		$data['list'] = $this->getList();
 
@@ -191,8 +191,15 @@ class Installer extends \Opencart\System\Engine\Controller {
 
 		$json = [];
 
+		if (!$this->user->hasPermission('modify', 'marketplace/installer')) {
+			$json['error'] = $this->language->get('error_permission');
+		}
+
+		// Extension
+		$this->load->model('setting/extension');
+
 		// 1. Validate the file uploaded.
-		if (isset($this->request->files['file']['name'])) {
+		if (!$json && isset($this->request->files['file']['name'])) {
 			$filename = basename($this->request->files['file']['name']);
 			$code = basename($filename, '.ocmod.zip');
 
@@ -238,7 +245,7 @@ class Installer extends \Opencart\System\Engine\Controller {
 			}
 
 			// 3. Validate is ocmod file.
-			if (substr($filename, -10) != '.ocmod.zip') {
+			if (substr($filename, -10) != '.ocmod.zip' || !preg_match('/^[A-Za-z0-9._-]+\.ocmod\.zip$/', $filename) || !preg_match('/^[A-Za-z0-9_][A-Za-z0-9._-]*$/', $code)) {
 				$json['error'] = $this->language->get('error_file_type');
 			}
 
@@ -258,7 +265,7 @@ class Installer extends \Opencart\System\Engine\Controller {
 			if ($this->model_setting_extension->getInstallByCode($code)) {
 				$json['error'] = $this->language->get('error_installed');
 			}
-		} else {
+		} elseif (!$json) {
 			$json['error'] = $this->language->get('error_upload');
 		}
 
@@ -316,8 +323,6 @@ class Installer extends \Opencart\System\Engine\Controller {
 				'author'                => $install_info['author'],
 				'link'                  => $install_info['link']
 			];
-
-			$this->load->model('setting/extension');
 
 			$this->model_setting_extension->addInstall($extension_data);
 

--- a/upload/admin/controller/tool/backup.php
+++ b/upload/admin/controller/tool/backup.php
@@ -212,6 +212,10 @@ class Backup extends \Opencart\System\Engine\Controller {
 
 		$file = DIR_STORAGE . 'backup/' . $filename;
 
+		if (!str_ends_with(strtolower($filename), '.sql')) {
+			$json['error'] = $this->language->get('error_file_type');
+		}
+
 		if (!is_file($file)) {
 			$json['error'] = $this->language->get('error_file');
 		}
@@ -262,7 +266,7 @@ class Backup extends \Opencart\System\Engine\Controller {
 			}
 
 			// Allowed file extension types
-			if (str_ends_with(strtolower($filename), '.sql')) {
+			if (!str_ends_with(strtolower($filename), '.sql')) {
 				$json['error'] = $this->language->get('error_file_type');
 			}
 		}
@@ -297,6 +301,10 @@ class Backup extends \Opencart\System\Engine\Controller {
 		}
 
 		$file = DIR_STORAGE . 'backup/' . $filename;
+
+		if (!str_ends_with(strtolower($filename), '.sql')) {
+			$this->response->redirect($this->url->link('error/not_found', 'user_token=' . $this->session->data['user_token'], true));
+		}
 
 		if (!is_file($file)) {
 			$this->response->redirect($this->url->link('error/not_found', 'user_token=' . $this->session->data['user_token'], true));
@@ -344,6 +352,10 @@ class Backup extends \Opencart\System\Engine\Controller {
 		}
 
 		$file = DIR_STORAGE . 'backup/' . $filename;
+
+		if (!str_ends_with(strtolower($filename), '.sql')) {
+			$json['error'] = $this->language->get('error_file_type');
+		}
 
 		if (!is_file($file)) {
 			$json['error'] = $this->language->get('error_file');

--- a/upload/admin/controller/tool/upgrade.php
+++ b/upload/admin/controller/tool/upgrade.php
@@ -193,6 +193,10 @@ class Upgrade extends \Opencart\System\Engine\Controller {
 						// Only extract the contents of the upload folder
 						$destination = str_replace('\\', '/', substr($source, strlen($remove)));
 
+						if ($destination === '' || str_starts_with($destination, '/') || str_contains($destination, "\0") || in_array('..', explode('/', $destination), true)) {
+							continue;
+						}
+
 						if (substr($destination, 0, 8) == 'install/') {
 							// Default copy location
 							$path = '';

--- a/upload/catalog/controller/startup/api.php
+++ b/upload/catalog/controller/startup/api.php
@@ -71,12 +71,12 @@ class Api extends \Opencart\System\Engine\Controller {
 					$status = false;
 				}
 
-				$time = $this->request->get['time'];
+				$time = (string)$this->request->get['time'];
 
 				$time_start = time() - 450;
 				$time_end = time() + 450;
 
-				if ($time < $time_start && $time > $time_end) {
+				if (!ctype_digit($time) || (int)$time < $time_start || (int)$time > $time_end) {
 					$status = false;
 				}
 			}


### PR DESCRIPTION
## Summary
- enforce API timestamp window validation for signed catalog API requests
- require admin modify permission and stricter package names for marketplace uploads
- restrict backup restore/download/delete operations to SQL backup files
- skip unsafe upgrade archive destinations with traversal, absolute paths, or NUL bytes
- use realpath-based directory containment checks in template and Sass editors

## Testing
- git diff --check HEAD~1..HEAD
- php -l upload/catalog/controller/startup/api.php
- php -l upload/admin/controller/marketplace/installer.php
- php -l upload/admin/controller/tool/backup.php
- php -l upload/admin/controller/tool/upgrade.php
- php -l upload/admin/controller/design/template.php
- php -l upload/admin/controller/design/sass.php