### PR TITLE
[4.x.x.x] Only show the order fraud info tab if it's not empty.

### DIFF
--- a/upload/admin/controller/sale/order.php
+++ b/upload/admin/controller/sale/order.php
@@ -1102,7 +1102,7 @@ class Order extends \Opencart\System\Engine\Controller {
 
 				$output = $this->load->controller('extension/' . $extension['extension'] . '/fraud/' . $extension['code'] . '.order');
 
-				if (!$output instanceof \Exception) {
+				if ($output && !$output instanceof \Exception) {
 					$data['tabs'][] = [
 						'code'    => $extension['extension'],
 						'title'   => $this->language->get('extension_heading_title'),


### PR DESCRIPTION
Matches behavior in OpenCart 3.x and 2.x.