### PR TITLE
[Master] use strict comparison for captcha and authorize code checks

### DIFF
--- a/upload/admin/controller/common/authorize.php
+++ b/upload/admin/controller/common/authorize.php
@@ -149,7 +149,7 @@ class Authorize extends \Opencart\System\Engine\Controller {
 			$json['redirect'] = $this->url->link('common/authorize', 'user_token=' . $this->session->data['user_token'], true);
 		} elseif ($token_info['total'] > 2) {
 			$json['redirect'] = $this->url->link('common/authorize.reset', 'user_token=' . $this->session->data['user_token'], true);
-		} elseif (!isset($post_info['code']) || !isset($this->session->data['code']) || ($post_info['code'] != $this->session->data['code'])) {
+		} elseif (!isset($post_info['code']) || !isset($this->session->data['code']) || ($post_info['code'] !== $this->session->data['code'])) {
 			$total = $token_info['total'] + 1;
 
 			if ($total <= 2) {

--- a/upload/catalog/controller/account/authorize.php
+++ b/upload/catalog/controller/account/authorize.php
@@ -163,7 +163,7 @@ class Authorize extends \Opencart\System\Engine\Controller {
 				$json['redirect'] = $this->url->link('account/authorize', 'language=' . $this->config->get('config_language'), true);
 			} elseif ($token_info['total'] > 2) {
 				$json['redirect'] = $this->url->link('account/authorize.reset', 'language=' . $this->config->get('config_language'), true);
-			} elseif (!isset($post_info['code']) || !isset($this->session->data['code']) || $post_info['code'] != $this->session->data['code']) {
+			} elseif (!isset($post_info['code']) || !isset($this->session->data['code']) || $post_info['code'] !== $this->session->data['code']) {
 				$total = $token_info['total'] + 1;
 
 				if ($total <= 2) {

--- a/upload/extension/opencart/catalog/controller/captcha/basic.php
+++ b/upload/extension/opencart/catalog/controller/captcha/basic.php
@@ -29,7 +29,7 @@ class Basic extends \Opencart\System\Engine\Controller {
 	public function validate(): string {
 		$this->load->language('extension/opencart/captcha/basic');
 
-		if (!isset($this->session->data['captcha']) || !isset($this->request->post['captcha']) || ($this->session->data['captcha'] != $this->request->post['captcha'])) {
+		if (!isset($this->session->data['captcha']) || !isset($this->request->post['captcha']) || ($this->session->data['captcha'] !== $this->request->post['captcha'])) {
 			return $this->language->get('error_captcha');
 		} else {
 			return '';


### PR DESCRIPTION
The basic captcha validator and the admin and customer authorize handlers compare a server-generated oc_token(6) code against the submitted value with `!=`. Since bin2hex can produce a code like `0e5531`, PHP's loose comparison reads both sides as the number 0 and accepts `0` as a match, so a request that never carries the real code passes the captcha and can slip past the device authorization step. Switching those three checks to `!==` keeps every legitimate match working while requiring an exact string.