### PR TITLE
[Master] validate password when adding a new user or customer

### DIFF
--- a/upload/admin/controller/customer/customer.php
+++ b/upload/admin/controller/customer/customer.php
@@ -610,7 +610,7 @@ class Customer extends \Opencart\System\Engine\Controller {
 			}
 		}
 
-		if ($post_info['password'] || !isset($post_info['customer_id'])) {
+		if ($post_info['password'] || !$post_info['customer_id']) {
 			$password = html_entity_decode($post_info['password'], ENT_QUOTES, 'UTF-8');
 
 			if (!oc_validate_length($password, $this->config->get('config_password_length'), 40)) {

--- a/upload/admin/controller/user/user.php
+++ b/upload/admin/controller/user/user.php
@@ -395,7 +395,7 @@ class User extends \Opencart\System\Engine\Controller {
 			$json['error']['warning'] = $this->language->get('error_email_exists');
 		}
 
-		if ($post_info['password'] || (!isset($post_info['user_id']))) {
+		if ($post_info['password'] || !$post_info['user_id']) {
 			$password = html_entity_decode($post_info['password'], ENT_QUOTES, 'UTF-8');
 
 			if (!oc_validate_length($password, (int)$this->config->get('config_user_password_length'), 40)) {


### PR DESCRIPTION
User::save and Customer::save gate the password rules behind `!isset($post_info['user_id'])` (and the customer_id form), but $post_info is seeded from the $required defaults so that key is always present and the branch is dead. A new user or customer posted with an empty password then skips every length and complexity check, and addUser/addCustomer stores a blank password that password_verify() later accepts. Switch the guard to `!$post_info['user_id']` / `!$post_info['customer_id']`, the same add-versus-edit test used lower down to choose insert over update.