### PR TITLE
[4.x.x.x] Adjust cache-control headers

### DIFF
--- a/upload/admin/view/template/common/header.twig
+++ b/upload/admin/view/template/common/header.twig
@@ -11,8 +11,6 @@
     <meta name="keywords" content="{{ keywords }}"/>
   {% endif %}
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
-  <meta http-equiv="cache-control" content="no-cache">
-  <meta http-equiv="expires" content="0">
   <link href="{{ bootstrap }}" rel="stylesheet" media="screen"/>
   <link href="{{ icons }}" rel="stylesheet" type="text/css"/>
   <link href="{{ stylesheet }}" rel="stylesheet" type="text/css"/>

--- a/upload/catalog/controller/startup/session.php
+++ b/upload/catalog/controller/startup/session.php
@@ -68,8 +68,6 @@ class Session extends \Opencart\System\Engine\Controller {
 			'samesite' => $this->config->get('session_samesite') ?: 'Lax'
 		];
 
-		$this->response->addHeader('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0');
-
 		setcookie($this->config->get('session_name'), $session->getId(), $option);
 	}
 }

--- a/upload/extension/opencart/catalog/controller/captcha/basic.php
+++ b/upload/extension/opencart/catalog/controller/captcha/basic.php
@@ -65,8 +65,6 @@ class Basic extends \Opencart\System\Engine\Controller {
 		imagestring($image, 10, (int)(($width - (strlen($this->session->data['captcha']) * 9)) / 2), (int)(($height - 15) / 2), $this->session->data['captcha'], $black);
 
 		header('Content-type: image/jpeg');
-		header('Cache-Control: no-cache');
-		header('Expires: Sat, 26 Jul 1997 05:00:00 GMT');
 
 		imagejpeg($image);
 

--- a/upload/system/framework.php
+++ b/upload/system/framework.php
@@ -142,8 +142,9 @@ $response->addHeader('Access-Control-Allow-Credentials: true');
 $response->addHeader('Access-Control-Max-Age: 1000');
 $response->addHeader('Access-Control-Allow-Headers: X-Requested-With, Content-Type, Origin, Cache-Control, Pragma, Authorization, Accept, Accept-Encoding');
 $response->addHeader('Access-Control-Allow-Methods: PUT, POST, GET, OPTIONS, DELETE');
-$response->addHeader('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0');
-$response->addHeader('Pragma: no-cache');
+header('Expires: Thu, 19 Nov 1981 08:52:00 GMT');
+header('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0');
+header('Pragma: no-cache');
 $response->setCompression((int)$config->get('response_compression'));
 
 // Database


### PR DESCRIPTION
Remove redundant HTML/meta cache tags and controller cache headers. Use header function so headers are sent on redirects.