### PR TITLE
[4.x.x.x] Fix admin redirect and use of config_url

### DIFF
--- a/upload/admin/controller/common/language.php
+++ b/upload/admin/controller/common/language.php
@@ -100,7 +100,7 @@ class Language extends \Opencart\System\Engine\Controller {
 
 			setcookie('language', $code, $option);
 
-			if ($redirect && str_starts_with($redirect, $this->config->get('config_url'))) {
+			if ($redirect && str_starts_with($redirect, HTTP_SERVER)) {
 				$json['redirect'] = $redirect;
 			} elseif (isset($this->session->data['user_token'])) {
 				$json['redirect'] = $this->url->link('common/dashboard', 'user_token=' . $this->session->data['user_token'], true);

--- a/upload/admin/controller/common/login.php
+++ b/upload/admin/controller/common/login.php
@@ -72,8 +72,7 @@ class Login extends \Opencart\System\Engine\Controller {
 		// Stop any undefined index messages.
 		$required = [
 			'username' => '',
-			'password' => '',
-			'redirect' => ''
+			'password' => ''
 		];
 
 		$post_info = $this->request->post + $required;

--- a/upload/admin/controller/mail/transaction.php
+++ b/upload/admin/controller/mail/transaction.php
@@ -61,7 +61,7 @@ class Transaction extends \Opencart\System\Engine\Controller {
 				$store_url = $store_info['store_url'];
 			} else {
 				$store_name = html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8');
-				$store_url = $this->config->get('config_url');
+				$store_url = HTTP_CATALOG;
 			}
 
 			// Language


### PR DESCRIPTION
config_url is not available in admin, so security check always passed. Use HTTP_SERVER and HTTP_CATALOG constants instead of config_url. Also remove 'redirect' from required POST fields in the login controller.