### PR TITLE
[Master] check modify permission in installer upload

### DIFF
--- a/upload/admin/controller/marketplace/installer.php
+++ b/upload/admin/controller/marketplace/installer.php
@@ -191,6 +191,10 @@ class Installer extends \Opencart\System\Engine\Controller {
 
 		$json = [];
 
+		if (!$this->user->hasPermission('modify', 'marketplace/installer')) {
+			$json['error'] = $this->language->get('error_permission');
+		}
+
 		// 1. Validate the file uploaded.
 		if (isset($this->request->files['file']['name'])) {
 			$filename = basename($this->request->files['file']['name']);


### PR DESCRIPTION
marketplace/installer.php upload() writes the uploaded .ocmod.zip into storage and adds an extension install record, but unlike install(), vendor(), uninstall() and delete() it never checks the modify permission. The admin startup filter only enforces the access permission for a route, so a user granted access-only rights to marketplace/installer can still upload packages and register installs. This adds the same modify check the sibling methods already use.