### PR TITLE
[Master] check return ownership before showing return history

### DIFF
--- a/upload/catalog/controller/account/returns.php
+++ b/upload/catalog/controller/account/returns.php
@@ -508,9 +508,9 @@ class Returns extends \Opencart\System\Engine\Controller {
 
 		$this->load->model('account/returns');
 
-		$subscription_info = $this->model_account_returns->getReturns($return_id);
+		$return_info = $this->model_account_returns->getReturn($return_id);
 
-		if (!$subscription_info) {
+		if (!$return_info) {
 			return '';
 		}
 


### PR DESCRIPTION
account/return.history checks the requested return_id by calling getReturns(), the customer-scoped list method whose first argument is a pagination offset, so ownership is never actually verified and getHistories()/getTotalHistories() then read the return_history rows for any return_id. A logged in customer who owns more returns than a given id can pull another customer's return status and comments through it. Swap in the owner-scoped getReturn() that info() and the order and subscription history controllers already use.