### PR TITLE
Fix API auth replay/IP trust and login attempt bypass

### DIFF
--- a/upload/admin/model/customer/customer.php
+++ b/upload/admin/model/customer/customer.php
@@ -1299,9 +1299,13 @@ class Customer extends \Opencart\System\Engine\Model {
 	 * $login_info = $this->model_customer_customer->getTotalLoginAttempts($email);
 	 */
 	public function getTotalLoginAttempts(string $email): array {
-		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "customer_login` WHERE `email` = '" . $this->db->escape(oc_strtolower($email)) . "'");
+		$query = $this->db->query("SELECT SUM(`total`) AS `total`, MAX(`date_modified`) AS `date_modified` FROM `" . DB_PREFIX . "customer_login` WHERE `email` = '" . $this->db->escape(oc_strtolower($email)) . "'");
 
-		return $query->row;
+		if ($query->row['total']) {
+			return $query->row;
+		}
+
+		return [];
 	}
 
 	/**

--- a/upload/catalog/controller/startup/api.php
+++ b/upload/catalog/controller/startup/api.php
@@ -30,6 +30,7 @@ class Api extends \Opencart\System\Engine\Controller {
 
 		if (in_array($route, $allowed)) {
 			$status = true;
+			$request_ip = oc_get_ip(false);
 
 			$required = [
 				'route',
@@ -64,7 +65,7 @@ class Api extends \Opencart\System\Engine\Controller {
 						$ip_data[] = trim($result['ip']);
 					}
 
-					if (!in_array(oc_get_ip(), $ip_data)) {
+					if (!in_array($request_ip, $ip_data)) {
 						$status = false;
 					}
 				} else {
@@ -76,7 +77,7 @@ class Api extends \Opencart\System\Engine\Controller {
 				$time_start = time() - 450;
 				$time_end = time() + 450;
 
-				if ($time < $time_start && $time > $time_end) {
+				if ($time < $time_start || $time > $time_end) {
 					$status = false;
 				}
 			}
@@ -99,7 +100,7 @@ class Api extends \Opencart\System\Engine\Controller {
 			}
 
 			if ($status) {
-				$this->model_user_api->addHistory($api_info['api_id'], $this->request->get['call'], oc_get_ip());
+				$this->model_user_api->addHistory($api_info['api_id'], $this->request->get['call'], $request_ip);
 			} else {
 				return new \Opencart\System\Engine\Action('startup/api.permission');
 			}

--- a/upload/catalog/model/account/customer.php
+++ b/upload/catalog/model/account/customer.php
@@ -369,10 +369,11 @@ class Customer extends \Opencart\System\Engine\Model {
 	 * $this->model_account_customer->addLoginAttempt($email);
 	 */
 	public function addLoginAttempt(string $email): void {
-		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "customer_login` WHERE LCASE(`email`) = '" . $this->db->escape(oc_strtolower((string)$email)) . "' AND `ip` = '" . $this->db->escape(oc_get_ip()) . "'");
+		$ip = oc_get_ip(false);
+		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "customer_login` WHERE LCASE(`email`) = '" . $this->db->escape(oc_strtolower((string)$email)) . "' AND `ip` = '" . $this->db->escape($ip) . "'");
 
 		if (!$query->num_rows) {
-			$this->db->query("INSERT INTO `" . DB_PREFIX . "customer_login` SET `email` = '" . $this->db->escape(oc_strtolower((string)$email)) . "', `ip` = '" . $this->db->escape(oc_get_ip()) . "', `total` = '1', `date_added` = '" . $this->db->escape(date('Y-m-d H:i:s')) . "', `date_modified` = '" . $this->db->escape(date('Y-m-d H:i:s')) . "'");
+			$this->db->query("INSERT INTO `" . DB_PREFIX . "customer_login` SET `email` = '" . $this->db->escape(oc_strtolower((string)$email)) . "', `ip` = '" . $this->db->escape($ip) . "', `total` = '1', `date_added` = '" . $this->db->escape(date('Y-m-d H:i:s')) . "', `date_modified` = '" . $this->db->escape(date('Y-m-d H:i:s')) . "'");
 		} else {
 			$this->db->query("UPDATE `" . DB_PREFIX . "customer_login` SET `total` = (`total` + 1), `date_modified` = '" . $this->db->escape(date('Y-m-d H:i:s')) . "' WHERE `customer_login_id` = '" . (int)$query->row['customer_login_id'] . "'");
 		}
@@ -409,9 +410,13 @@ class Customer extends \Opencart\System\Engine\Model {
 	 * $results = $this->model_account_customer->getLoginAttempts($email);
 	 */
 	public function getLoginAttempts(string $email): array {
-		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "customer_login` WHERE LCASE(`email`) = '" . $this->db->escape(oc_strtolower($email)) . "'");
+		$query = $this->db->query("SELECT SUM(`total`) AS `total`, MAX(`date_modified`) AS `date_modified` FROM `" . DB_PREFIX . "customer_login` WHERE LCASE(`email`) = '" . $this->db->escape(oc_strtolower($email)) . "'");
 
-		return $query->row;
+		if ($query->row['total']) {
+			return $query->row;
+		}
+
+		return [];
 	}
 
 	/**

--- a/upload/catalog/model/setting/api.php
+++ b/upload/catalog/model/setting/api.php
@@ -42,7 +42,7 @@ class Api extends \Opencart\System\Engine\Model {
 	 * $api_info = $this->model_setting_api->getApiByToken($token);
 	 */
 	public function getApiByToken(string $token): array {
-		$query = $this->db->query("SELECT DISTINCT * FROM `" . DB_PREFIX . "api` `a` LEFT JOIN `" . DB_PREFIX . "api_session` `as` ON (`a`.`api_id` = `as`.`api_id`) LEFT JOIN `" . DB_PREFIX . "api_ip` `ai` ON (`a`.`api_id` = `ai`.`api_id`) WHERE `a`.`status` = '1' AND `as`.`session_id` = '" . $this->db->escape($token) . "' AND `ai`.`ip` = '" . $this->db->escape(oc_get_ip()) . "'");
+		$query = $this->db->query("SELECT DISTINCT * FROM `" . DB_PREFIX . "api` `a` LEFT JOIN `" . DB_PREFIX . "api_session` `as` ON (`a`.`api_id` = `as`.`api_id`) LEFT JOIN `" . DB_PREFIX . "api_ip` `ai` ON (`a`.`api_id` = `ai`.`api_id`) WHERE `a`.`status` = '1' AND `as`.`session_id` = '" . $this->db->escape($token) . "' AND `ai`.`ip` = '" . $this->db->escape(oc_get_ip(false)) . "'");
 
 		return $query->row;
 	}

--- a/upload/system/helper/general.php
+++ b/upload/system/helper/general.php
@@ -11,28 +11,30 @@ function oc_token(int $length = 32): string {
 }
 
 /** @return string */
-function oc_get_ip(): string {
-	$headers = [
-		'HTTP_CF_CONNECTING_IP', // CloudFlare
-		'HTTP_X_FORWARDED_FOR',  // AWS LB and other reverse-proxies
-		'HTTP_X_REAL_IP',
-		'HTTP_X_CLIENT_IP',
-		'HTTP_CLIENT_IP',
-		'HTTP_X_CLUSTER_CLIENT_IP',
-	];
+function oc_get_ip(bool $forwarded = true): string {
+	if ($forwarded) {
+		$headers = [
+			'HTTP_CF_CONNECTING_IP', // CloudFlare
+			'HTTP_X_FORWARDED_FOR',  // AWS LB and other reverse-proxies
+			'HTTP_X_REAL_IP',
+			'HTTP_X_CLIENT_IP',
+			'HTTP_CLIENT_IP',
+			'HTTP_X_CLUSTER_CLIENT_IP',
+		];
 
-	foreach ($headers as $header) {
-		if (array_key_exists($header, $_SERVER)) {
-			$ip = $_SERVER[$header];
+		foreach ($headers as $header) {
+			if (array_key_exists($header, $_SERVER)) {
+				$ip = $_SERVER[$header];
 
-			// This line might or might not be used.
-			$ip = trim(explode(',', $ip)[0]);
+				// This line might or might not be used.
+				$ip = trim(explode(',', $ip)[0]);
 
-			return $ip;
+				return $ip;
+			}
 		}
 	}
 
-	return $_SERVER['REMOTE_ADDR'];
+	return $_SERVER['REMOTE_ADDR'] ?? '';
 }
 
 // Sting functions

--- a/upload/system/startup.php
+++ b/upload/system/startup.php
@@ -45,11 +45,6 @@ if ((isset($_SERVER['HTTPS']) && (($_SERVER['HTTPS'] == 'on') || ($_SERVER['HTTP
 	$_SERVER['HTTPS'] = false;
 }
 
-// Check IP
-if (!empty($_SERVER['HTTP_CLIENT_IP'])) {
-	$_SERVER['REMOTE_ADDR'] = $_SERVER['HTTP_CLIENT_IP'];
-}
-
 // OpenCart Autoloader
 require_once(DIR_SYSTEM . 'engine/autoloader.php');
 


### PR DESCRIPTION
## Summary

This change fixes two independent authentication control issues.

- reject stale signed storefront API requests by enforcing the intended plus-or-minus 450 second freshness window
- stop using client-supplied forwarding headers for security-sensitive API IP allowlist and API session checks
- preserve current forwarded-header behavior for non-security logging paths, while allowing security-sensitive callsites to require the direct peer address
- make customer login lockout checks aggregate all failed attempts for an email address so lockouts cannot be bypassed by spreading failures across multiple stored IP rows
- record customer login-attempt source IPs from the direct peer address in the failed-login path

## Root cause

### 1. Storefront API replay / IP trust weakness

The storefront API startup gate contained an impossible time-window comparison, so signed requests were never rejected as stale. The same gate also trusted client-controlled forwarding headers for API IP allowlist decisions, which let callers spoof an allowed address unless a trusted proxy stripped those headers first.

### 2. Customer login lockout bypass

Failed login attempts were stored per email-plus-IP, but lockout enforcement later read only by email and did not aggregate duplicate rows. A caller could therefore vary the apparent source IP and keep each stored row below the configured threshold. Accepting arbitrary forwarding headers made that bypass trivial from a single host.

## Impact

- storefront API signatures now expire as intended and can no longer be replayed indefinitely
- API IP allowlists and API token session checks now bind to the actual remote peer instead of spoofable request headers
- customer account lockouts now apply to the account as configured, even when failures originate from multiple stored IP rows

## Validation

- php -l upload/system/helper/general.php
- php -l upload/system/startup.php
- php -l upload/catalog/controller/startup/api.php
- php -l upload/catalog/model/setting/api.php
- php -l upload/catalog/model/account/customer.php
- php -l upload/admin/model/customer/customer.php
