### PR TITLE
check manufacturer permission in disable status toggle

### DIFF
--- a/upload/admin/controller/catalog/manufacturer.php
+++ b/upload/admin/controller/catalog/manufacturer.php
@@ -534,7 +534,7 @@ class Manufacturer extends \Opencart\System\Engine\Controller {
 			$selected = [];
 		}
 
-		if (!$this->user->hasPermission('modify', 'catalog/information')) {
+		if (!$this->user->hasPermission('modify', 'catalog/manufacturer')) {
 			$json['error'] = $this->language->get('error_permission');
 		}
 


### PR DESCRIPTION
**Disable checks the wrong permission route**

`disable()` gates the status change on `catalog/information`, while `save()`, `enable()` and `delete()` all check `catalog/manufacturer`. Since the admin startup gate only enforces the `access` permission for a route, the per-action modify check is what protects the change, so switched it to `catalog/manufacturer` to line up with the siblings.