### PR TITLE
[Master] set httponly on the session cookie

### DIFF
--- a/upload/admin/controller/startup/session.php
+++ b/upload/admin/controller/startup/session.php
@@ -30,7 +30,7 @@ class Session extends \Opencart\System\Engine\Controller {
 			'expires'  => $this->config->get('session_expire') ? time() + (int)$this->config->get('session_expire') : 0,
 			'path'     => $this->config->get('session_path'),
 			'secure'   => $this->request->server['HTTPS'],
-			'httponly' => false,
+			'httponly' => true,
 			'SameSite' => $this->config->get('session_samesite')
 		];
 

--- a/upload/catalog/controller/startup/session.php
+++ b/upload/catalog/controller/startup/session.php
@@ -55,7 +55,7 @@ class Session extends \Opencart\System\Engine\Controller {
 			'expires'  => time() + (int)$this->config->get('session_expire'),
 			'path'     => $this->config->get('session_path'),
 			'secure'   => $this->request->server['HTTPS'],
-			'httponly' => false,
+			'httponly' => true,
 			'SameSite' => $this->config->get('session_samesite')
 		];
 

--- a/upload/system/framework.php
+++ b/upload/system/framework.php
@@ -134,7 +134,7 @@ if ($config->get('session_autostart')) {
 		'path'     => $config->get('session_path'),
 		'domain'   => $config->get('session_domain'),
 		'secure'   => $request->server['HTTPS'],
-		'httponly' => false,
+		'httponly' => true,
 		'SameSite' => $config->get('session_samesite')
 	];
 


### PR DESCRIPTION
All three places that set the OCSESSID cookie pass 'httponly' => false, so the header goes out as `Set-Cookie: OCSESSID=...; path=/; secure; SameSite=Strict` and document.cookie hands the storefront or admin session id to any script that runs in the page. Two of the three sites have the comment "Require higher security for session cookies" sitting directly above the option array, and 4.x.x.x already sets true in catalog/controller/startup/session.php and system/framework.php, so this just brings master in line with the value you already ship there.

Nothing reads the cookie from the client side, so turning the flag on doesn't change any working behaviour: OCSESSID appears nowhere in the JS or Twig, and the API takes api_token from the URL rather than the cookie. I left the notification=1 flag cookie in task/system/notification.php alone since it holds no secret.

On 4.x.x.x the admin cookie is still false at upload/admin/controller/startup/session.php, same one-liner, if you want that as a separate PR like #15578.