### PR TITLE
[4.x.x.x] Security Storage Move

### DIFF
--- a/upload/admin/controller/common/security.php
+++ b/upload/admin/controller/common/security.php
@@ -215,19 +215,40 @@ class Security extends \Opencart\System\Engine\Controller {
 				$json['error'] = $this->language->get('error_storage');
 			}
 
-			// Check the chosen directory is not in the public webspace
-			$root = str_replace('\\', '/', realpath($this->request->server['DOCUMENT_ROOT'] . '/../'));
-
-			if ((substr($base_new, 0, strlen($root)) != $root) || ($root == $base_new)) {
-				$json['error'] = $this->language->get('error_storage_root');
+			if (!$json) {
+				// Check the chosen directory is not in the public webspace
+				$root = str_replace('\\', '/', realpath($this->request->server['DOCUMENT_ROOT']) . '/');
+				if (str_starts_with($base_new, $root)) {
+					$json['error'] = $this->language->get('error_storage_root');
+				}
 			}
 
-			if (!str_starts_with($name, 'storage')) {
-				$json['error'] = $this->language->get('error_storage_name');
+			if (!$json) {
+				// check the storage name starts with 'storage'
+				if (!str_starts_with($name, 'storage')) {
+					$json['error'] = $this->language->get('error_storage_name');
+				}
 			}
 
-			if (!is_writable(DIR_OPENCART . 'config.php') || !is_writable(DIR_APPLICATION . 'config.php')) {
-				$json['error'] = $this->language->get('error_writable');
+			if (!$json) {
+				// check the config files are writeable, needed for modifications
+				if (!is_writable(DIR_OPENCART . 'config.php') || !is_writable(DIR_APPLICATION . 'config.php')) {
+					$json['error'] = $this->language->get('error_writable');
+				}
+			}
+
+			if (!$json) {
+				if (!is_dir($base_new)) {
+					// check the new storage folder can be created
+					if (!is_writable($path)) {
+						$json['error'] = str_replace('%s', $path, $this->language->get('error_writable_path'));
+					}
+				} else {
+					// check the new storage folder can be written to
+					if (!is_writeable($base_new)) {
+						$json['error'] = str_replace('%s', $path, $this->language->get('error_writable_path'));
+					}
+				}
 			}
 		}
 

--- a/upload/admin/language/en-gb/common/security.php
+++ b/upload/admin/language/en-gb/common/security.php
@@ -43,4 +43,5 @@ $_['error_admin']                     = 'Warning: Admin directory does not exist
 $_['error_admin_allowed']             = 'Warning: This admin directory name can not be used!';
 $_['error_admin_exists']              = 'Warning: Admin directory already exists!';
 $_['error_writable']                  = 'Warning: config.php and admin/config.php need to be made writable!';
+$_['error_writable_path']             = 'Warning: The folder \'%s\' needs to be writable!';
 $_['error_remove']                    = 'Warning: Directory does not exist to remove!';

--- a/upload/admin/language/fr-fr/common/security.php
+++ b/upload/admin/language/fr-fr/common/security.php
@@ -42,4 +42,5 @@ $_['error_admin']                     = 'Attention: Le répertoire admin n\'exis
 $_['error_admin_allowed']             = 'Attention: Le nom de répertoire admin ne peut être utilisé!';
 $_['error_admin_exists']              = 'Attention: Le nom du répertoire admin existe déjà!';
 $_['error_writable']                  = 'Attention: Les fichiers config.php et admin/config.php doivent être rendus modifiables!';
+$_['error_writable_path']             = 'Attention: Le répertoire \'%s\' doit être modifiable!';
 $_['error_remove']                    = 'Attention: Le répertoire à supprimer n\'existe pas!';


### PR DESCRIPTION
Fixes to make sure the moved storage folder is above the document root, also to check that the new storage folder is writable.