### PR TITLE
[4.x.x.x] Storage move changes

### DIFF
--- a/upload/admin/controller/common/security.php
+++ b/upload/admin/controller/common/security.php
@@ -191,13 +191,13 @@ class Security extends \Opencart\System\Engine\Controller {
 		}
 
 		if (isset($this->request->get['name'])) {
-			$name = preg_replace('/[^a-zA-Z0-9_\.]/', '', basename(html_entity_decode(trim($this->request->get['name']), ENT_QUOTES, 'UTF-8')));
+			$name = preg_replace('/[^a-zA-Z0-9_\.-]/', '', basename(html_entity_decode(trim($this->request->get['name']), ENT_QUOTES, 'UTF-8')));
 		} else {
 			$name = '';
 		}
 
 		if (isset($this->request->get['path'])) {
-			$path = preg_replace('/[^a-zA-Z0-9_\:\/\.]/', '', html_entity_decode(trim($this->request->get['path']), ENT_QUOTES, 'UTF-8'));
+			$path = preg_replace('/[^a-zA-Z0-9_\:\/\.-]/', '', html_entity_decode(trim($this->request->get['path']), ENT_QUOTES, 'UTF-8'));
 		} else {
 			$path = '';
 		}
@@ -217,8 +217,9 @@ class Security extends \Opencart\System\Engine\Controller {
 
 			if (!$json) {
 				// Check the chosen directory is not in the public webspace
-				$root = str_replace('\\', '/', realpath($this->request->server['DOCUMENT_ROOT']) . '/');
-				if (str_starts_with($base_new, $root)) {
+				$root = str_replace('\\', '/', realpath($this->request->server['DOCUMENT_ROOT']));
+
+				if (!str_starts_with($root, rtrim($path, '/') . '/')) {
 					$json['error'] = $this->language->get('error_storage_root');
 				}
 			}


### PR DESCRIPTION
Allow hyphen in both 'name' and 'path'.

Check that storage path is an ancestor of document root only. Previous change would allow ```/anything/storage/```. realpath always returns without the trailing slash, so can just check the root starts with the new path with a slash on the end.