### PR TITLE
[Master] check subscription permission in subscription api call

### DIFF
--- a/upload/admin/controller/sale/subscription.php
+++ b/upload/admin/controller/sale/subscription.php
@@ -747,7 +747,7 @@ class Subscription extends \Opencart\System\Engine\Controller {
 			$currency = (string)$this->config->get('config_currency');
 		}
 
-		if (!$this->user->hasPermission('modify', 'sale/order')) {
+		if (!$this->user->hasPermission('modify', 'sale/subscription')) {
 			$json['error'] = $this->language->get('error_permission');
 		}
 


### PR DESCRIPTION
call() checks modify on sale/order instead of sale/subscription, so an admin with order-modify but view-only subscription rights can drive api/subscription through it while a user actually granted sale/subscription modify gets blocked, and switching the route string lines it up with delete() and addHistory() in the same file.