### PR TITLE
[Master] fix escape bypass on directory in filemanager getList

### DIFF
--- a/upload/admin/controller/common/filemanager.php
+++ b/upload/admin/controller/common/filemanager.php
@@ -166,7 +166,7 @@ class FileManager extends \Opencart\System\Engine\Controller {
 		}
 
 		if (isset($this->request->get['directory'])) {
-			$data['directory'] = urldecode($this->request->get['directory']);
+			$data['directory'] = $this->request->get['directory'];
 		} else {
 			$data['directory'] = '';
 		}


### PR DESCRIPTION
getList() runs urldecode() over the directory parameter at filemanager.php:169, after Request::clean() has already applied htmlspecialchars to every GET value and with twig autoescape off, so that escaping is the only thing standing between the parameter and value="{{ directory }}" in filemanager_list.twig. A double encoded request such as common/filemanager.list&directory=%2522%20onfocus=alert(1)%20autofocus%20x=%2522 passes clean() untouched and is then decoded back into a bare quote, which breaks out of the attribute. PHP already decodes the query string once so the extra decode isn't buying anything, and the filter_name assignment six lines down reads straight from the request and renders fine in the same template.