### PR TITLE
[4.x.x.x] More error handler changes

### DIFF
--- a/upload/admin/controller/startup/error.php
+++ b/upload/admin/controller/startup/error.php
@@ -63,7 +63,7 @@ class Error extends \Opencart\System\Engine\Controller {
 
 		if ($this->config->get('config_error_display')) {
 			echo '<b>' . $error . '</b>: ' . $message . ' in <b>' . $file . '</b> on line <b>' . $line . '</b>';
-		} else {
+		} elseif ($error === 'Fatal Error' || $error === 'Unknown') {
 			header('Location: ' . $this->config->get('error_page'));
 			exit();
 		}

--- a/upload/catalog/controller/startup/error.php
+++ b/upload/catalog/controller/startup/error.php
@@ -63,7 +63,7 @@ class Error extends \Opencart\System\Engine\Controller {
 
 		if ($this->config->get('config_error_display')) {
 			echo '<b>' . $error . '</b>: ' . $message . ' in <b>' . $file . '</b> on line <b>' . $line . '</b>';
-		} else {
+		} elseif ($error === 'Fatal Error' || $error === 'Unknown') {
 			header('Location: ' . $this->config->get('error_page'));
 			exit();
 		}

--- a/upload/cron.php
+++ b/upload/cron.php
@@ -81,7 +81,7 @@ set_error_handler(function(int $code, string $message, string $file, int $line) 
 	// If error display is turned on, output clean plaintext to the console instead of HTML tags
 	if ($config->get('error_display')) {
 		echo PHP_EOL . "PHP {$error}: {$message} in {$file} on line {$line}" . PHP_EOL;
-	} else {
+	} elseif ($error === 'Fatal Error' || $error === 'Unknown') {
 		// Never call header() or exit with a successful code (0) on a fatal cron crash.
 		// Instead, we exit with a non-zero code to let the server's cron daemon know the task failed.
 		exit(1);

--- a/upload/system/framework.php
+++ b/upload/system/framework.php
@@ -71,7 +71,7 @@ set_error_handler(function(int $code, string $message, string $file, int $line) 
 
 	if ($config->get('error_display')) {
 		echo '<b>' . $error . '</b>: ' . $message . ' in <b>' . $file . '</b> on line <b>' . $line . '</b>';
-	} else {
+	} elseif ($error === 'Fatal Error' || $error === 'Unknown') {
 		if (!headers_sent()) {
 			header('Location: ' . $config->get('error_page'));
 		}


### PR DESCRIPTION
If there is no error display then redirect to an error pages if the error was 'Fatal Error' or 'Unknown'.