### PR TITLE
[Master] match api routes case insensitively in the startup gate

### DIFF
--- a/upload/catalog/controller/startup/api.php
+++ b/upload/catalog/controller/startup/api.php
@@ -12,8 +12,9 @@ class Api extends \Opencart\System\Engine\Controller {
 	 * @return \Opencart\System\Engine\Action|null
 	 */
 	public function index() {
+		// Controller resolution is case insensitive, so normalise before matching
 		if (isset($this->request->get['route'])) {
-			$route = (string)$this->request->get['route'];
+			$route = strtolower((string)$this->request->get['route']);
 		} else {
 			$route = '';
 		}

--- a/upload/catalog/controller/startup/session.php
+++ b/upload/catalog/controller/startup/session.php
@@ -18,7 +18,7 @@ class Session extends \Opencart\System\Engine\Controller {
 		$this->registry->set('session', $session);
 
 		// Api
-		if (isset($this->request->get['route']) && substr((string)$this->request->get['route'], 0, 4) == 'api/' && isset($this->request->get['api_token'])) {
+		if (isset($this->request->get['route']) && substr(strtolower((string)$this->request->get['route']), 0, 4) == 'api/' && isset($this->request->get['api_token'])) {
 			$this->load->model('setting/api');
 
 			$this->model_setting_api->cleanSessions();


### PR DESCRIPTION
startup/api.php picks the signed-request path with substr($route, 0, 4) == 'api/' and in_array($route, $allowed), but route resolution is case insensitive, so index.php?route=API/order misses both tests and still loads catalog/controller/api/order.php with no username, IP, time window or signature check ever running, which leaves calls like history_add reachable by anyone. Lowercasing the route before the comparison puts the mixed case form back on the signed path, where it fails on the signature; the api prefix test in startup/session.php that attaches the api_token session had the same problem. 4.x.x.x carries the same code, happy to send a separate pull request for that branch.