### PR TITLE
[Master] reject traversal extension codes in installer upload

### DIFF
--- a/upload/admin/controller/marketplace/installer.php
+++ b/upload/admin/controller/marketplace/installer.php
@@ -237,8 +237,8 @@ class Installer extends \Opencart\System\Engine\Controller {
 				$json['error'] = $this->language->get('error_filename');
 			}
 
-			// 3. Validate is ocmod file.
-			if (substr($filename, -10) != '.ocmod.zip') {
+			// 3. Validate is ocmod file and the extension code cannot escape the extension directory.
+			if (substr($filename, -10) != '.ocmod.zip' || $code == '.' || $code == '..') {
 				$json['error'] = $this->language->get('error_file_type');
 			}
 


### PR DESCRIPTION
installer upload() takes the extension code from the uploaded archive name with basename($filename, '.ocmod.zip'), and that returns '..' for a file named ...ocmod.zip, which passes both the length check and the .ocmod.zip check and gets stored by addInstall(). The code is later used as a directory component, so install() writes zip entries under DIR_EXTENSION . '../' (the existing `..` guard only looks at the entry names, not at the code prefix) and uninstall() hands DIR_EXTENSION . '../' to oc_directory_delete(), which walks the whole OpenCart root. Folded a '.'/'..' rejection into the ocmod file type check so the value never reaches the database. 4.x.x.x carries the same code, happy to open a separate PR for it.