### PR TITLE
[4.x.x.x] reject traversal extension codes in installer upload

### DIFF
--- a/upload/admin/controller/marketplace/installer.php
+++ b/upload/admin/controller/marketplace/installer.php
@@ -274,8 +274,8 @@ class Installer extends \Opencart\System\Engine\Controller {
 				$json['error'] = $this->language->get('error_filename');
 			}
 
-			// 3. Validate is ocmod file.
-			if (substr($filename, -10) != '.ocmod.zip') {
+			// 3. Validate is ocmod file and the extension code cannot escape the extension directory.
+			if (substr($filename, -10) != '.ocmod.zip' || $code == '.' || $code == '..') {
 				$json['error'] = $this->language->get('error_file_type');
 			}
 


### PR DESCRIPTION
Same issue as #15608, against 4.x.x.x.

`upload()` derives the extension code from the uploaded archive name with `basename($filename, '.ocmod.zip')`, and that returns `..` for a file named `...ocmod.zip` (and `.` for `..ocmod.zip`). Both names pass the length check and the `.ocmod.zip` check, so the code `..` gets stored by `addInstall()`.

The code is then used as a directory component:

- `install()` builds `$path = $code . '/' . $destination` under `$base = DIR_EXTENSION`, so entries are written to `DIR_EXTENSION . '../'`, i.e. the OpenCart root. The existing `in_array('..', explode('/', $destination))` guard only inspects the zip entry name, not the code prefix.
- `uninstall()` passes `DIR_EXTENSION . $code . '/'` to `oc_directory_delete()`, which resolves to `DIR_EXTENSION . '../'` and walks the whole installation.

The page 1 `is_dir()` test doesn't stop it either: with `page=2` the check flips to "directory must exist", and `DIR_EXTENSION . '../'` does exist.

Fix folds a `.`/`..` rejection into the existing ocmod file type check in `upload()`, so the value never reaches the database. Normal names such as `mymodule.ocmod.zip` are unaffected.

Name handling, before and after the patch:

```
upload=mymodule.ocmod.zip     code='mymodule'   accepted(before)=true  accepted(after)=true
   install() writes to : /var/www/opencart/extension/mymodule/catalog/controller/x.php
   uninstall() deletes : /var/www/opencart/extension/mymodule/

upload=...ocmod.zip           code='..'         accepted(before)=true  accepted(after)=false
   install() writes to : /var/www/opencart/extension/../catalog/controller/x.php
   uninstall() deletes : /var/www/opencart/extension/../

upload=..ocmod.zip            code='.'          accepted(before)=true  accepted(after)=false
   install() writes to : /var/www/opencart/extension/./catalog/controller/x.php
   uninstall() deletes : /var/www/opencart/extension/./
```

After the patch the traversal names are rejected with `Invalid file type!`.
