### PR TITLE
{Master] Honor configured 2FA authorization expiry

### DIFF
--- a/upload/admin/controller/common/authorize.php
+++ b/upload/admin/controller/common/authorize.php
@@ -36,16 +36,18 @@ class Authorize extends \Opencart\System\Engine\Controller {
 		if (!$token_info) {
 			// Create a token that can be stored as a cookie and will be used to identify device is safe.
 			$token = oc_token(32);
+			$expire = max(1, (int)$this->config->get('config_2fa_expire'));
 
 			$authorize_data = [
 				'token'      => $token,
 				'ip'         => oc_get_ip(),
-				'user_agent' => $this->request->server['HTTP_USER_AGENT']
+				'user_agent' => $this->request->server['HTTP_USER_AGENT'],
+				'expire'     => $expire
 			];
 
 			$this->model_user_user->addAuthorize($this->user->getId(), $authorize_data);
 
-			setcookie('admin_authorize', $token, time() + 60 * 60 * 24 * 90);
+			setcookie('admin_authorize', $token, time() + 60 * 60 * 24 * $expire);
 		}
 
 		// Set the code to be emailed

--- a/upload/admin/model/user/user.php
+++ b/upload/admin/model/user/user.php
@@ -521,7 +521,8 @@ class User extends \Opencart\System\Engine\Model {
 	 * $user_authorize_data = [
 	 *     'token'      => '',
 	 *     'ip'         => '',
-	 *     'user_agent' => ''
+	 *     'user_agent' => '',
+	 *     'expire'     => 90
 	 * ];
 	 *
 	 * $this->load->model('user/user');
@@ -529,7 +530,7 @@ class User extends \Opencart\System\Engine\Model {
 	 * $this->model_user_user->addAuthorize($user_id, $user_authorize_data);
 	 */
 	public function addAuthorize(int $user_id, array $data): void {
-		$this->db->query("INSERT INTO `" . DB_PREFIX . "user_authorize` SET `user_id` = '" . (int)$user_id . "', `token` = '" . $this->db->escape($data['token']) . "', `ip` = '" . $this->db->escape($data['ip']) . "', `user_agent` = '" . $this->db->escape($data['user_agent']) . "', `date_added` = NOW(), `date_expire` = NOW()");
+		$this->db->query("INSERT INTO `" . DB_PREFIX . "user_authorize` SET `user_id` = '" . (int)$user_id . "', `token` = '" . $this->db->escape($data['token']) . "', `ip` = '" . $this->db->escape($data['ip']) . "', `user_agent` = '" . $this->db->escape($data['user_agent']) . "', `date_added` = NOW(), `date_expire` = DATE_ADD(NOW(), INTERVAL " . (int)$data['expire'] . " DAY)");
 	}
 
 	/**
@@ -654,7 +655,7 @@ class User extends \Opencart\System\Engine\Model {
 	 * $authorize_info = $this->model_user_user->getAuthorizeByToken($user_id, $token);
 	 */
 	public function getAuthorizeByToken(int $user_id, string $token): array {
-		$query = $this->db->query("SELECT *, (SELECT SUM(`total`) FROM `" . DB_PREFIX . "user_authorize` WHERE `user_id` = '" . (int)$user_id . "') AS `attempts` FROM `" . DB_PREFIX . "user_authorize` WHERE `user_id` = '" . (int)$user_id . "' AND `token` = '" . $this->db->escape($token) . "'");
+		$query = $this->db->query("SELECT *, (SELECT SUM(`total`) FROM `" . DB_PREFIX . "user_authorize` WHERE `user_id` = '" . (int)$user_id . "' AND `date_expire` > NOW()) AS `attempts` FROM `" . DB_PREFIX . "user_authorize` WHERE `user_id` = '" . (int)$user_id . "' AND `token` = '" . $this->db->escape($token) . "' AND `date_expire` > NOW()");
 
 		return $query->row;
 	}

--- a/upload/catalog/controller/account/authorize.php
+++ b/upload/catalog/controller/account/authorize.php
@@ -43,16 +43,18 @@ class Authorize extends \Opencart\System\Engine\Controller {
 		if (!$token_info) {
 			// Create a token that can be stored as a cookie and will be used to identify device is safe.
 			$token = oc_token(32);
+			$expire = max(1, (int)$this->config->get('config_2fa_expire'));
 
 			$authorize_data = [
 				'token'      => $token,
 				'ip'         => oc_get_ip(),
-				'user_agent' => $this->request->server['HTTP_USER_AGENT']
+				'user_agent' => $this->request->server['HTTP_USER_AGENT'],
+				'expire'     => $expire
 			];
 
 			$this->model_account_customer->addAuthorize($this->customer->getId(), $authorize_data);
 
-			setcookie('customer_authorize', $token, time() + 60 * 60 * 24 * 90);
+			setcookie('customer_authorize', $token, time() + 60 * 60 * 24 * $expire);
 		}
 
 		// Set the code to be emailed

--- a/upload/catalog/model/account/customer.php
+++ b/upload/catalog/model/account/customer.php
@@ -430,7 +430,8 @@ class Customer extends \Opencart\System\Engine\Model {
 	 *     'customer_id' => 1,
 	 *     'token'       => '',
 	 *     'ip'          => '',
-	 *     'user_agent'  => ''
+	 *     'user_agent'  => '',
+	 *     'expire'      => 90
 	 * ];
 	 *
 	 * $this->load->model('account/customer');
@@ -438,7 +439,7 @@ class Customer extends \Opencart\System\Engine\Model {
 	 * $this->model_account_customer->addAuthorize($customer_id, $authorize_data);
 	 */
 	public function addAuthorize(int $customer_id, array $data): void {
-		$this->db->query("INSERT INTO `" . DB_PREFIX . "customer_authorize` SET `customer_id` = '" . (int)$customer_id . "', `token` = '" . $this->db->escape($data['token']) . "', `ip` = '" . $this->db->escape($data['ip']) . "', `user_agent` = '" . $this->db->escape($data['user_agent']) . "', `date_added` = NOW(), `date_expire` = NOW()");
+		$this->db->query("INSERT INTO `" . DB_PREFIX . "customer_authorize` SET `customer_id` = '" . (int)$customer_id . "', `token` = '" . $this->db->escape($data['token']) . "', `ip` = '" . $this->db->escape($data['ip']) . "', `user_agent` = '" . $this->db->escape($data['user_agent']) . "', `date_added` = NOW(), `date_expire` = DATE_ADD(NOW(), INTERVAL " . (int)$data['expire'] . " DAY)");
 	}
 
 	/**
@@ -542,7 +543,7 @@ class Customer extends \Opencart\System\Engine\Model {
 	 * $login_info = $this->model_account_customer->getAuthorizeByToken($customer_id, $token);
 	 */
 	public function getAuthorizeByToken(int $customer_id, string $token): array {
-		$query = $this->db->query("SELECT *, (SELECT SUM(`total`) FROM `" . DB_PREFIX . "customer_authorize` WHERE `customer_id` = '" . (int)$customer_id . "') AS `attempts` FROM `" . DB_PREFIX . "customer_authorize` WHERE `customer_id` = '" . (int)$customer_id . "' AND `token` = '" . $this->db->escape($token) . "'");
+		$query = $this->db->query("SELECT *, (SELECT SUM(`total`) FROM `" . DB_PREFIX . "customer_authorize` WHERE `customer_id` = '" . (int)$customer_id . "' AND `date_expire` > NOW()) AS `attempts` FROM `" . DB_PREFIX . "customer_authorize` WHERE `customer_id` = '" . (int)$customer_id . "' AND `token` = '" . $this->db->escape($token) . "' AND `date_expire` > NOW()");
 
 		return $query->row;
 	}


### PR DESCRIPTION
## Summary

- use the configured 2FA lifetime for admin and customer trusted-device cookies
- persist that lifetime in `date_expire` instead of storing the creation time as the expiry
- reject expired authorization tokens and exclude expired records from attempt aggregation

## Why

The authorization tables and settings UI already expose a token expiry, but the setting was not applied. New records stored `date_expire = NOW()`, token lookups never checked that column, and both cookies were hard-coded to 90 days. A configured shorter lifetime therefore had no effect, and the server continued accepting the trusted-device token after that lifetime.

The minimum of one day also prevents a missing or zero setting from immediately invalidating a newly issued challenge.

## Validation

- PHP syntax checks pass for all four changed files
- focused model regression verifies both INSERT queries use the configured day interval
- focused model regression verifies both token lookups enforce expiry in the selected token and aggregate attempt count
- targeted PHP CS Fixer dry run reports no formatting changes in the modified sections
- `git diff --check` passes for the staged patch