### PR TITLE
restore root containment check in storage directory move

### DIFF
--- a/upload/admin/controller/common/security.php
+++ b/upload/admin/controller/common/security.php
@@ -187,7 +187,7 @@ class Security extends \Opencart\System\Engine\Controller {
 			// Check the chosen directory is not in the public webspace C:/xampp/htdocs
 			$root = str_replace('\\', '/', realpath($this->request->server['DOCUMENT_ROOT'] . '/../')) . '/';
 
-			if ((substr($base_new, 0, strlen($root)) != $path) || ($root == $base_new)) {
+			if ((substr($base_new, 0, strlen($root)) != $root) || ($root == $base_new)) {
 				$json['error'] = $this->language->get('error_storage_root');
 			}
 


### PR DESCRIPTION
security.php storage() checks the admin-chosen new storage path against the server root with substr($base_new, 0, strlen($root)) != $path, comparing the destination prefix to the user-supplied $path rather than $root (the document-root parent), so the guard collapses to a length match and the storage directory can be pointed at a location outside the validated root while config.php is rewritten to follow it. Released 4.0.2.3 and 4.1.0.3 compare against $root here; master regressed to $path. Restore the $root comparison so the destination has to sit under the document-root parent.