### PR TITLE
[4.x.x.x] Honor configured 2FA authorization expiry on 4.x

### DIFF
--- a/upload/admin/controller/common/authorize.php
+++ b/upload/admin/controller/common/authorize.php
@@ -36,17 +36,19 @@ class Authorize extends \Opencart\System\Engine\Controller {
 		if (!$token_info) {
 			// Create a token that can be stored as a cookie and will be used to identify device is safe.
 			$token = oc_token(32);
+			$expire = max(1, (int)$this->config->get('config_2fa_expire'));
 
 			$authorize_data = [
 				'token'      => $token,
 				'ip'         => oc_get_ip(),
-				'user_agent' => $this->request->server['HTTP_USER_AGENT']
+				'user_agent' => $this->request->server['HTTP_USER_AGENT'],
+				'expire'     => $expire
 			];
 
 			$this->model_user_user->addAuthorize($this->user->getId(), $authorize_data);
 
 			$option = [
-				'expires'  => time() + 60 * 60 * 24 * 90,
+				'expires'  => time() + 60 * 60 * 24 * $expire,
 				'secure'   => $this->request->server['HTTPS'],
 				'httponly' => true,
 				'samesite' => $this->config->get('config_session_samesite')

--- a/upload/admin/model/user/user.php
+++ b/upload/admin/model/user/user.php
@@ -520,7 +520,8 @@ class User extends \Opencart\System\Engine\Model {
 	 * $user_authorize_data = [
 	 *     'token'      => '',
 	 *     'ip'         => '',
-	 *     'user_agent' => ''
+	 *     'user_agent' => '',
+	 *     'expire'     => 90
 	 * ];
 	 *
 	 * $this->load->model('user/user');
@@ -528,7 +529,7 @@ class User extends \Opencart\System\Engine\Model {
 	 * $this->model_user_user->addAuthorize($user_id, $user_authorize_data);
 	 */
 	public function addAuthorize(int $user_id, array $data): void {
-		$this->db->query("INSERT INTO `" . DB_PREFIX . "user_authorize` SET `user_id` = '" . (int)$user_id . "', `token` = '" . $this->db->escape($data['token']) . "', `ip` = '" . $this->db->escape($data['ip']) . "', `user_agent` = '" . $this->db->escape($data['user_agent']) . "', `date_added` = NOW(), `date_expire` = NOW()");
+		$this->db->query("INSERT INTO `" . DB_PREFIX . "user_authorize` SET `user_id` = '" . (int)$user_id . "', `token` = '" . $this->db->escape($data['token']) . "', `ip` = '" . $this->db->escape($data['ip']) . "', `user_agent` = '" . $this->db->escape($data['user_agent']) . "', `date_added` = NOW(), `date_expire` = DATE_ADD(NOW(), INTERVAL " . (int)$data['expire'] . " DAY)");
 	}
 
 	/**
@@ -653,7 +654,7 @@ class User extends \Opencart\System\Engine\Model {
 	 * $authorize_info = $this->model_user_user->getAuthorizeByToken($user_id, $token);
 	 */
 	public function getAuthorizeByToken(int $user_id, string $token): array {
-		$query = $this->db->query("SELECT *, (SELECT SUM(`total`) FROM `" . DB_PREFIX . "user_authorize` WHERE `user_id` = '" . (int)$user_id . "') AS `attempts` FROM `" . DB_PREFIX . "user_authorize` WHERE `user_id` = '" . (int)$user_id . "' AND `token` = '" . $this->db->escape($token) . "'");
+		$query = $this->db->query("SELECT *, (SELECT SUM(`total`) FROM `" . DB_PREFIX . "user_authorize` WHERE `user_id` = '" . (int)$user_id . "' AND `date_expire` > NOW()) AS `attempts` FROM `" . DB_PREFIX . "user_authorize` WHERE `user_id` = '" . (int)$user_id . "' AND `token` = '" . $this->db->escape($token) . "' AND `date_expire` > NOW()");
 
 		return $query->row;
 	}

--- a/upload/catalog/controller/account/authorize.php
+++ b/upload/catalog/controller/account/authorize.php
@@ -41,17 +41,19 @@ class Authorize extends \Opencart\System\Engine\Controller {
 		if (!$token_info) {
 			// Create a token that can be stored as a cookie and will be used to identify device is safe.
 			$token = oc_token(32);
+			$expire = max(1, (int)$this->config->get('config_2fa_expire'));
 
 			$authorize_data = [
 				'token'      => $token,
 				'ip'         => oc_get_ip(),
-				'user_agent' => $this->request->server['HTTP_USER_AGENT']
+				'user_agent' => $this->request->server['HTTP_USER_AGENT'],
+				'expire'     => $expire
 			];
 
 			$this->model_account_customer->addAuthorize($this->customer->getId(), $authorize_data);
 
 			$option = [
-				'expires'  => time() + 60 * 60 * 24 * 90,
+				'expires'  => time() + 60 * 60 * 24 * $expire,
 				'path'     => $this->config->get('session_path'),
 				'secure'   => $this->request->server['HTTPS'],
 				'httponly' => true,

--- a/upload/catalog/model/account/customer.php
+++ b/upload/catalog/model/account/customer.php
@@ -432,7 +432,8 @@ class Customer extends \Opencart\System\Engine\Model {
 	 *     'customer_id' => 1,
 	 *     'token'       => '',
 	 *     'ip'          => '',
-	 *     'user_agent'  => ''
+	 *     'user_agent'  => '',
+	 *     'expire'      => 90
 	 * ];
 	 *
 	 * $this->load->model('account/customer');
@@ -440,7 +441,7 @@ class Customer extends \Opencart\System\Engine\Model {
 	 * $this->model_account_customer->addAuthorize($customer_id, $authorize_data);
 	 */
 	public function addAuthorize(int $customer_id, array $data): void {
-		$this->db->query("INSERT INTO `" . DB_PREFIX . "customer_authorize` SET `customer_id` = '" . (int)$customer_id . "', `token` = '" . $this->db->escape($data['token']) . "', `ip` = '" . $this->db->escape($data['ip']) . "', `user_agent` = '" . $this->db->escape($data['user_agent']) . "', `date_added` = NOW(), `date_expire` = NOW()");
+		$this->db->query("INSERT INTO `" . DB_PREFIX . "customer_authorize` SET `customer_id` = '" . (int)$customer_id . "', `token` = '" . $this->db->escape($data['token']) . "', `ip` = '" . $this->db->escape($data['ip']) . "', `user_agent` = '" . $this->db->escape($data['user_agent']) . "', `date_added` = NOW(), `date_expire` = DATE_ADD(NOW(), INTERVAL " . (int)$data['expire'] . " DAY)");
 	}
 
 	/**
@@ -544,7 +545,7 @@ class Customer extends \Opencart\System\Engine\Model {
 	 * $login_info = $this->model_account_customer->getAuthorizeByToken($customer_id, $token);
 	 */
 	public function getAuthorizeByToken(int $customer_id, string $token): array {
-		$query = $this->db->query("SELECT *, (SELECT SUM(`total`) FROM `" . DB_PREFIX . "customer_authorize` WHERE `customer_id` = '" . (int)$customer_id . "') AS `attempts` FROM `" . DB_PREFIX . "customer_authorize` WHERE `customer_id` = '" . (int)$customer_id . "' AND `token` = '" . $this->db->escape($token) . "'");
+		$query = $this->db->query("SELECT *, (SELECT SUM(`total`) FROM `" . DB_PREFIX . "customer_authorize` WHERE `customer_id` = '" . (int)$customer_id . "' AND `date_expire` > NOW()) AS `attempts` FROM `" . DB_PREFIX . "customer_authorize` WHERE `customer_id` = '" . (int)$customer_id . "' AND `token` = '" . $this->db->escape($token) . "' AND `date_expire` > NOW()");
 
 		return $query->row;
 	}


### PR DESCRIPTION
## Summary

- use `config_2fa_expire` for admin and customer trusted-device cookies
- store the matching database expiry and reject expired authorization tokens
- exclude expired authorization rows from attempt totals

This ports #15612 to `4.x.x.x`, as requested in the maintainer review.

## Tests

- PHP syntax checks for all four changed files
- targeted PHPStan analysis: no errors
- local regression harness exercising both models, including integer sanitization and expiry filtering

## Assistance

OpenAI Codex (`gpt-5.6-sol`) assisted with analysis and preparation. I reviewed and tested the changes and take responsibility for them.