### PR TITLE
[Master] keep computed status authoritative in cms/comment add

### DIFF
--- a/upload/catalog/controller/cms/comment.php
+++ b/upload/catalog/controller/cms/comment.php
@@ -374,10 +374,10 @@ class Comment extends \Opencart\System\Engine\Controller {
 				$status = 0;
 			}
 
-			$comment_data = $post_info + [
+			$comment_data = [
 				'parent_id' => $parent_id,
 				'status'    => $status
-			];
+			] + $post_info;
 
 			$this->model_cms_article->addComment($article_id, $comment_data);
 


### PR DESCRIPTION
**Comment moderation bypass via posted status**
`add()` merges the raw POST body with the server-computed status using `$post_info + [...]`, and PHP keeps the left operand on key collisions, so a logged-in customer who posts `status=1` lands an approved comment straight past the moderation queue, the anti-spam check and the non-commenter restriction. Flipped the union so the computed `parent_id`/`status` win and only `author`/`comment` come from the request.