### PR TITLE
[4.x.x.x] Add $args parameter type to Url::link() docblock. - #15630

### DIFF
--- a/upload/system/library/url.php
+++ b/upload/system/library/url.php
@@ -52,9 +52,9 @@ class Url {
 	 *
 	 * Generates a URL
 	 *
-	 * @param string $route
-	 * @param mixed  $args
-	 * @param bool   $js
+	 * @param string                      $route
+	 * @param array<string, mixed>|string $args
+	 * @param bool                        $js
 	 *
 	 * @return string
 	 */


### PR DESCRIPTION
See https://github.com/opencart/opencart/pull/15630 for details.