### PR TITLE
{Master] Enable HttpOnly for session cookies

### DIFF
--- a/upload/admin/controller/startup/session.php
+++ b/upload/admin/controller/startup/session.php
@@ -30,7 +30,7 @@ class Session extends \Opencart\System\Engine\Controller {
 			'expires'  => $this->config->get('session_expire') ? time() + (int)$this->config->get('session_expire') : 0,
 			'path'     => $this->config->get('session_path'),
 			'secure'   => $this->request->server['HTTPS'],
-			'httponly' => false,
+			'httponly' => true,
 			'SameSite' => $this->config->get('session_samesite')
 		];
 

--- a/upload/catalog/controller/startup/session.php
+++ b/upload/catalog/controller/startup/session.php
@@ -55,7 +55,7 @@ class Session extends \Opencart\System\Engine\Controller {
 			'expires'  => time() + (int)$this->config->get('session_expire'),
 			'path'     => $this->config->get('session_path'),
 			'secure'   => $this->request->server['HTTPS'],
-			'httponly' => false,
+			'httponly' => true,
 			'SameSite' => $this->config->get('session_samesite')
 		];
 

--- a/upload/system/framework.php
+++ b/upload/system/framework.php
@@ -134,7 +134,7 @@ if ($config->get('session_autostart')) {
 		'path'     => $config->get('session_path'),
 		'domain'   => $config->get('session_domain'),
 		'secure'   => $request->server['HTTPS'],
-		'httponly' => false,
+		'httponly' => true,
 		'SameSite' => $config->get('session_samesite')
 	];
 


### PR DESCRIPTION
## Summary

Enable the `HttpOnly` attribute for session cookies created by the admin startup controller, catalog startup controller, and framework autostart path. This prevents client-side scripts from reading the session identifier and applies the defense-in-depth measure consistently across all session bootstrap paths.

Fixes #15550

## Pull request details

| Questions | Answers |
| --- | --- |
| Branch? | master |
| Description? | Set `httponly` to `true` for all three session cookie creation paths. |
| Type? | improvement |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Start the admin and catalog applications, inspect each session `Set-Cookie` response header, and confirm that `HttpOnly` is present. |
| UI Tests | Not applicable; no UI behavior changes. |
| Fixed issue or discussion? | Fixes #15550 |
| Related PRs | None |
| Sponsor company | Not applicable |

## Verification

- All 1,319 non-vendor PHP files pass `php -l -n`.
- PHPStan reports no errors for the three changed files.
- A controller-level harness captured the cookie options for the admin and catalog startup paths and confirmed `httponly === true`; it also checked the framework autostart path.
- `git diff --check` passes.