### PR TITLE
[3.0.x.x] mail update

### DIFF
--- a/upload/system/library/mail/mail.php
+++ b/upload/system/library/mail/mail.php
@@ -77,26 +77,8 @@ class Mail extends \stdClass {
 
 		ini_set('sendmail_from', $this->from);
 
-		// Define a temporary error handler that converts warnings into exceptions
-		set_error_handler(function ($severity, $message, $file, $line) {
-			if ($severity === E_WARNING) {
-				throw new \ErrorException($message, 0, $severity, $file, $line);
-			}
-			return false; // Let non-warnings pass to normal handling
-		});
+		$extraParam = !empty($this->parameter) ? (string)$this->parameter : '';
 
-		try {
-			// Run existing mail calls
-			if ($this->parameter) {
-				mail($to, '=?UTF-8?B?' . base64_encode($this->subject) . '?=', $message, $header, $this->parameter);
-			} else {
-				mail($to, '=?UTF-8?B?' . base64_encode($this->subject) . '?=', $message, $header);
-			}
-		} catch (\ErrorException $e) {
-			// The PHP 8.5 warning is safely caught here! We ignore it.
-		} finally {
-			// Always restore the server's original error handler
-			restore_error_handler();
-		}
+		mail($to, '=?UTF-8?B?' . base64_encode($this->subject) . '?=', $message, $header, $extraParam);
 	}
 }


### PR DESCRIPTION
In PHP 8.5, if the sendmail binary crashes, exits with an error code, or fails unexpectedly, it emits a warning and returns false.