### PR TITLE
Add session check before captcha generation

### DIFF
--- a/upload/catalog/controller/extension/captcha/basic.php
+++ b/upload/catalog/controller/extension/captcha/basic.php
@@ -25,6 +25,8 @@ class ControllerExtensionCaptchaBasic extends Controller {
 	}
 
 	public function captcha() {
+		if (!isset($this->session->data['captcha'])) exit();
+
 		$image = imagecreatetruecolor(150, 35);
 
 		$width = imagesx($image);


### PR DESCRIPTION
Fix PHP 8.1 warning:
PHP Unknown:  strlen(): Passing null to parameter #1 ($string) of type string is deprecated in /public_html/catalog/controller/extension/captcha/basic.php on line 48