### PR TITLE
[4.x.x.x] Bump required version badge to 8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%208.0-8892BF.svg?style=flat-square)](https://php.net/)
+[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%208.1-8892BF.svg?style=flat-square)](https://php.net/)
 [![GitHub release](https://img.shields.io/github/v/release/opencart/opencart)](https://github.com/opencart/opencart)
 [![Lint](https://github.com/opencart/opencart/actions/workflows/Lint-4.yml/badge.svg)](https://github.com/opencart/opencart/actions/workflows/Lint-4.yml)
 


### PR DESCRIPTION
Because composer.json says so