### PR TITLE
Make storefront languages addressable by URL

### DIFF
--- a/upload/catalog/controller/common/header.php
+++ b/upload/catalog/controller/common/header.php
@@ -34,6 +34,7 @@ class ControllerCommonHeader extends Controller {
 		$data['scripts'] = $this->document->getScripts('header');
 		$data['lang'] = $this->language->get('code');
 		$data['direction'] = $this->language->get('direction');
+		$data['alternate_links'] = $this->getAlternateLinks();
 
 		$data['name'] = $this->config->get('config_name');
 
@@ -78,5 +79,57 @@ class ControllerCommonHeader extends Controller {
 		$data['menu'] = $this->load->controller('common/menu');
 
 		return $this->load->view('common/header', $data);
+	}
+
+	private function getAlternateLinks() {
+		if ($this->request->server['REQUEST_METHOD'] != 'GET') {
+			return array();
+		}
+
+		$this->load->model('localisation/language');
+
+		$languages = $this->model_localisation_language->getLanguages();
+
+		if (count($languages) < 2) {
+			return array();
+		}
+
+		$url_data = $this->request->get;
+		$route = isset($url_data['route']) ? $url_data['route'] : 'common/home';
+
+		unset($url_data['_route_'], $url_data['route'], $url_data['language'], $url_data['tracking']);
+
+		// A product has one canonical identity regardless of the category or
+		// manufacturer path used to reach it.
+		if ($route == 'product/product') {
+			unset($url_data['path'], $url_data['manufacturer_id']);
+		}
+
+		$alternate_links = array();
+		$default_href = '';
+
+		foreach ($languages as $code => $language) {
+			$language_url_data = $url_data;
+			$language_url_data['language'] = $code;
+			$href = $this->url->link($route, $language_url_data, $this->request->server['HTTPS']);
+
+			$alternate_links[] = array(
+				'href'     => $href,
+				'hreflang' => strtolower(str_replace('_', '-', $code))
+			);
+
+			if ($code == $this->config->get('config_language')) {
+				$default_href = $href;
+			}
+		}
+
+		if ($default_href) {
+			$alternate_links[] = array(
+				'href'     => $default_href,
+				'hreflang' => 'x-default'
+			);
+		}
+
+		return $alternate_links;
 	}
 }

--- a/upload/catalog/controller/common/home.php
+++ b/upload/catalog/controller/common/home.php
@@ -6,7 +6,7 @@ class ControllerCommonHome extends Controller {
 		$this->document->setKeywords($this->config->get('config_meta_keyword'));
 
 		if (isset($this->request->get['route'])) {
-			$this->document->addLink($this->config->get('config_url'), 'canonical');
+			$this->document->addLink($this->url->link('common/home'), 'canonical');
 		}
 
 		$data['column_left'] = $this->load->controller('common/column_left');

--- a/upload/catalog/controller/common/language.php
+++ b/upload/catalog/controller/common/language.php
@@ -3,9 +3,7 @@ class ControllerCommonLanguage extends Controller {
 	public function index() {
 		$this->load->language('common/language');
 
-		$data['action'] = $this->url->link('common/language/language', '', $this->request->server['HTTPS']);
-
-		$data['code'] = $this->session->data['language'];
+		$data['code'] = $this->config->get('config_language_code');
 
 		$this->load->model('localisation/language');
 
@@ -13,47 +11,89 @@ class ControllerCommonLanguage extends Controller {
 
 		$results = $this->model_localisation_language->getLanguages();
 
-		foreach ($results as $result) {
-			if ($result['status']) {
-				$data['languages'][] = array(
-					'name' => $result['name'],
-					'code' => $result['code']
-				);
-			}
+		if (!isset($this->request->get['route'])) {
+			$route = 'common/home';
+		} else {
+			$route = $this->request->get['route'];
 		}
 
-		if (!isset($this->request->get['route'])) {
-			$data['redirect'] = $this->url->link('common/home');
-		} else {
-			$url_data = $this->request->get;
+		$url_data = $this->request->get;
 
-			unset($url_data['_route_']);
+		unset($url_data['_route_'], $url_data['route'], $url_data['language']);
 
-			$route = $url_data['route'];
+		// Product context changes breadcrumbs, not product identity.
+		if ($route == 'product/product') {
+			unset($url_data['path'], $url_data['manufacturer_id']);
+		}
 
-			unset($url_data['route']);
+		foreach ($results as $result) {
+			if ($result['status']) {
+				$language_url_data = $url_data;
+				$language_url_data['language'] = $result['code'];
 
-			$url = '';
-
-			if ($url_data) {
-				$url = '&' . urldecode(http_build_query($url_data, '', '&'));
+				$data['languages'][] = array(
+					'name' => $result['name'],
+					'code' => $result['code'],
+					'href' => $this->url->link($route, $language_url_data, $this->request->server['HTTPS'])
+				);
 			}
-
-			$data['redirect'] = $this->url->link($route, $url, $this->request->server['HTTPS']);
 		}
 
 		return $this->load->view('common/language', $data);
 	}
 
 	public function language() {
-		if (isset($this->request->post['code'])) {
-			$this->session->data['language'] = $this->request->post['code'];
+		if (isset($this->request->post['redirect']) && (strpos($this->request->post['redirect'], $this->config->get('config_url')) === 0 || strpos($this->request->post['redirect'], $this->config->get('config_ssl')) === 0)) {
+			$redirect = $this->request->post['redirect'];
+		} else {
+			$redirect = $this->url->link('common/home');
 		}
 
-		if (isset($this->request->post['redirect']) && (strpos($this->request->post['redirect'], $this->config->get('config_url')) === 0 || strpos($this->request->post['redirect'], $this->config->get('config_ssl')) === 0)) {
-			$this->response->redirect($this->request->post['redirect']);
-		} else {
-			$this->response->redirect($this->url->link('common/home'));
+		// Keep the POST endpoint compatible with third-party themes while making
+		// the selected language part of the redirect URL.
+		if (isset($this->request->post['code']) && is_string($this->request->post['code'])) {
+			$this->load->model('localisation/language');
+
+			$languages = $this->model_localisation_language->getLanguages();
+
+			if (isset($languages[$this->request->post['code']])) {
+				$redirect = $this->setLanguage($redirect, $this->request->post['code']);
+			}
 		}
+
+		$this->response->redirect($redirect);
+	}
+
+	private function setLanguage($link, $code) {
+		$url_info = parse_url(str_replace('&amp;', '&', $link));
+		$data = array();
+
+		if (isset($url_info['query'])) {
+			parse_str($url_info['query'], $data);
+		}
+
+		if ($code == $this->config->get('config_language')) {
+			unset($data['language']);
+		} else {
+			$data['language'] = $code;
+		}
+
+		$redirect = $url_info['scheme'] . '://' . $url_info['host'];
+
+		if (isset($url_info['port'])) {
+			$redirect .= ':' . $url_info['port'];
+		}
+
+		$redirect .= $url_info['path'];
+
+		if ($data) {
+			$redirect .= '?' . http_build_query($data);
+		}
+
+		if (isset($url_info['fragment'])) {
+			$redirect .= '#' . $url_info['fragment'];
+		}
+
+		return $redirect;
 	}
 }

--- a/upload/catalog/controller/product/manufacturer.php
+++ b/upload/catalog/controller/product/manufacturer.php
@@ -20,6 +20,7 @@ class ControllerProductManufacturer extends Controller {
 		);
 
 		$data['categories'] = array();
+		$data['manufacturer'] = $this->url->link('product/manufacturer');
 
 		$results = $this->model_catalog_manufacturer->getManufacturers();
 

--- a/upload/catalog/controller/startup/language_url.php
+++ b/upload/catalog/controller/startup/language_url.php
@@ -1,0 +1,61 @@
+<?php
+class ControllerStartupLanguageUrl extends Controller {
+	private $languages = array();
+
+	public function index() {
+		$this->load->model('localisation/language');
+
+		$this->languages = $this->model_localisation_language->getLanguages();
+
+		if (count($this->languages) > 1) {
+			$this->url->addRewrite($this);
+		}
+	}
+
+	public function rewrite($link) {
+		$url_info = parse_url(str_replace('&amp;', '&', $link));
+
+		$data = array();
+
+		if (isset($url_info['query'])) {
+			parse_str($url_info['query'], $data);
+		}
+
+		if (isset($data['language']) && is_string($data['language']) && isset($this->languages[$data['language']])) {
+			$code = $data['language'];
+		} else {
+			$code = $this->config->get('config_language_code');
+		}
+
+		if ($code == $this->config->get('config_language')) {
+			unset($data['language']);
+		} else {
+			$data['language'] = $code;
+		}
+
+		$path = $url_info['path'];
+
+		if (isset($data['route']) && $data['route'] == 'common/home') {
+			unset($data['route']);
+			$path = preg_replace('~/index\\.php$~', '/', $path);
+		}
+
+		$url = $url_info['scheme'] . '://' . $url_info['host'];
+
+		if (isset($url_info['port'])) {
+			$url .= ':' . $url_info['port'];
+		}
+
+		$url .= $path;
+
+		if ($data) {
+			$url .= '?' . str_replace('&', '&amp;', http_build_query($data));
+		}
+
+		if (isset($url_info['fragment'])) {
+			$url .= '#' . $url_info['fragment'];
+		}
+
+		return $url;
+	}
+}

--- a/upload/catalog/controller/startup/seo_url.php
+++ b/upload/catalog/controller/startup/seo_url.php
@@ -74,10 +74,22 @@ class ControllerStartupSeoUrl extends Controller {
 
 		parse_str($url_info['query'], $data);
 
+		$language_id = (int)$this->config->get('config_language_id');
+
+		if (isset($data['language']) && is_string($data['language'])) {
+			$this->load->model('localisation/language');
+
+			$languages = $this->model_localisation_language->getLanguages();
+
+			if (isset($languages[$data['language']])) {
+				$language_id = (int)$languages[$data['language']]['language_id'];
+			}
+		}
+
 		foreach ($data as $key => $value) {
 			if (isset($data['route'])) {
 				if (($data['route'] == 'product/product' && $key == 'product_id') || (($data['route'] == 'product/manufacturer/info' || $data['route'] == 'product/product') && $key == 'manufacturer_id') || ($data['route'] == 'information/information' && $key == 'information_id')) {
-					$query = $this->db->query("SELECT * FROM " . DB_PREFIX . "seo_url WHERE `query` = '" . $this->db->escape($key . '=' . (int)$value) . "' AND store_id = '" . (int)$this->config->get('config_store_id') . "' AND language_id = '" . (int)$this->config->get('config_language_id') . "'");
+					$query = $this->db->query("SELECT * FROM " . DB_PREFIX . "seo_url WHERE `query` = '" . $this->db->escape($key . '=' . (int)$value) . "' AND store_id = '" . (int)$this->config->get('config_store_id') . "' AND language_id = '" . $language_id . "'");
 
 					if ($query->num_rows && $query->row['keyword']) {
 						$url .= '/' . $query->row['keyword'];
@@ -88,7 +100,7 @@ class ControllerStartupSeoUrl extends Controller {
 					$categories = explode('_', $value);
 
 					foreach ($categories as $category) {
-						$query = $this->db->query("SELECT * FROM " . DB_PREFIX . "seo_url WHERE `query` = 'category_id=" . (int)$category . "' AND store_id = '" . (int)$this->config->get('config_store_id') . "' AND language_id = '" . (int)$this->config->get('config_language_id') . "'");
+						$query = $this->db->query("SELECT * FROM " . DB_PREFIX . "seo_url WHERE `query` = 'category_id=" . (int)$category . "' AND store_id = '" . (int)$this->config->get('config_store_id') . "' AND language_id = '" . $language_id . "'");
 
 						if ($query->num_rows && $query->row['keyword']) {
 							$url .= '/' . $query->row['keyword'];

--- a/upload/catalog/controller/startup/startup.php
+++ b/upload/catalog/controller/startup/startup.php
@@ -59,55 +59,25 @@ class ControllerStartupStartup extends Controller {
 		$this->registry->set('url', new Url($this->config->get('config_url'), $this->config->get('config_ssl')));
 		
 		// Language
-		$code = '';
-		
 		$this->load->model('localisation/language');
 		
 		$languages = $this->model_localisation_language->getLanguages();
-		
-		if (isset($this->session->data['language'])) {
+
+		$is_ajax = isset($this->request->server['HTTP_X_REQUESTED_WITH']) && strtolower($this->request->server['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest';
+		$accepts_html = !isset($this->request->server['HTTP_ACCEPT']) || strpos($this->request->server['HTTP_ACCEPT'], 'text/html') !== false;
+		$is_document_request = $this->request->server['REQUEST_METHOD'] == 'GET' && !$is_ajax && $accepts_html;
+
+		// A public document URL must always resolve to the same language. The URL
+		// takes precedence and an unqualified document uses the default language.
+		if (isset($this->request->get['language']) && is_string($this->request->get['language']) && isset($languages[$this->request->get['language']])) {
+			$code = $this->request->get['language'];
+		} elseif (!$is_document_request && isset($this->session->data['language']) && isset($languages[$this->session->data['language']])) {
+			// Keep AJAX and form endpoints compatible with existing themes and
+			// extensions that do not include the public language parameter yet.
 			$code = $this->session->data['language'];
-		}
-				
-		if (isset($this->request->cookie['language']) && !array_key_exists($code, $languages)) {
+		} elseif (!$is_document_request && isset($this->request->cookie['language']) && isset($languages[$this->request->cookie['language']])) {
 			$code = $this->request->cookie['language'];
-		}
-		
-		// Language Detection
-		if (!empty($this->request->server['HTTP_ACCEPT_LANGUAGE']) && !array_key_exists($code, $languages)) {
-			$detect = '';
-			
-			$browser_languages = explode(',', $this->request->server['HTTP_ACCEPT_LANGUAGE']);
-			
-			// Try using local to detect the language
-			foreach ($browser_languages as $browser_language) {
-				foreach ($languages as $key => $value) {
-					if ($value['status']) {
-						$locale = explode(',', $value['locale']);
-						
-						if (in_array($browser_language, $locale)) {
-							$detect = $key;
-							break 2;
-						}
-					}
-				}	
-			}			
-			
-			if (!$detect) { 
-				// Try using language folder to detect the language
-				foreach ($browser_languages as $browser_language) {
-					if (array_key_exists(strtolower($browser_language), $languages)) {
-						$detect = strtolower($browser_language);
-						
-						break;
-					}
-				}
-			}
-			
-			$code = $detect ? $detect : '';
-		}
-		
-		if (!array_key_exists($code, $languages)) {
+		} else {
 			$code = $this->config->get('config_language');
 		}
 		
@@ -126,7 +96,8 @@ class ControllerStartupStartup extends Controller {
 		$this->registry->set('language', $language);
 		
 		// Set the config language_id
-		$this->config->set('config_language_id', $languages[$code]['language_id']);	
+		$this->config->set('config_language_id', $languages[$code]['language_id']);
+		$this->config->set('config_language_code', $code);
 
 		// Customer
 		$customer = new Cart\Customer($this->registry);

--- a/upload/catalog/view/javascript/common.js
+++ b/upload/catalog/view/javascript/common.js
@@ -22,6 +22,39 @@ function getURLVar(key) {
 	}
 }
 
+function addLanguage(url) {
+	var language = getURLVar('language');
+
+	if (language) {
+		language = decodeURIComponent(language.split('#')[0]);
+	}
+
+	if (!language || !url || /(^|[?&])language=/.test(url)) {
+		return url;
+	}
+
+	var link = document.createElement('a');
+	link.href = url;
+
+	if (link.host && link.host != window.location.host) {
+		return url;
+	}
+
+	var hash = '';
+	var hash_position = url.indexOf('#');
+
+	if (hash_position != -1) {
+		hash = url.substring(hash_position);
+		url = url.substring(0, hash_position);
+	}
+
+	return url + (url.indexOf('?') == -1 ? '?' : '&') + 'language=' + encodeURIComponent(language) + hash;
+}
+
+$.ajaxPrefilter(function(options) {
+	options.url = addLanguage(options.url);
+});
+
 $(document).ready(function() {
 	// Highlight any found errors
 	$('.text-danger').each(function() {
@@ -41,18 +74,9 @@ $(document).ready(function() {
 		$('#form-currency').submit();
 	});
 
-	// Language
-	$('#form-language .language-select').on('click', function(e) {
-		e.preventDefault();
-
-		$('#form-language input[name=\'code\']').val($(this).attr('name'));
-
-		$('#form-language').submit();
-	});
-
 	/* Search */
 	$('#search input[name=\'search\']').parent().find('button').on('click', function() {
-		var url = $('base').attr('href') + 'index.php?route=product/search';
+		var url = addLanguage($('base').attr('href') + 'index.php?route=product/search');
 
 		var value = $('header #search input[name=\'search\']').val();
 
@@ -193,7 +217,7 @@ var cart = {
 				}, 100);
 
 				if (getURLVar('route') == 'checkout/cart' || getURLVar('route') == 'checkout/checkout') {
-					location = 'index.php?route=checkout/cart';
+					location = addLanguage('index.php?route=checkout/cart');
 				} else {
 					$('#cart > ul').load('index.php?route=common/cart/info ul li');
 				}
@@ -222,7 +246,7 @@ var cart = {
 				}, 100);
 
 				if (getURLVar('route') == 'checkout/cart' || getURLVar('route') == 'checkout/checkout') {
-					location = 'index.php?route=checkout/cart';
+					location = addLanguage('index.php?route=checkout/cart');
 				} else {
 					$('#cart > ul').load('index.php?route=common/cart/info ul li');
 				}
@@ -257,7 +281,7 @@ var voucher = {
 				}, 100);
 
 				if (getURLVar('route') == 'checkout/cart' || getURLVar('route') == 'checkout/checkout') {
-					location = 'index.php?route=checkout/cart';
+					location = addLanguage('index.php?route=checkout/cart');
 				} else {
 					$('#cart > ul').load('index.php?route=common/cart/info ul li');
 				}

--- a/upload/catalog/view/theme/default/template/common/header.twig
+++ b/upload/catalog/view/theme/default/template/common/header.twig
@@ -33,6 +33,9 @@
 {% for link in links %}
 <link href="{{ link.href }}" rel="{{ link.rel }}" />
 {% endfor %}
+{% for link in alternate_links %}
+<link href="{{ link.href }}" rel="alternate" hreflang="{{ link.hreflang }}" />
+{% endfor %}
 {% for analytic in analytics %}
 {{ analytic }}
 {% endfor %}

--- a/upload/catalog/view/theme/default/template/common/language.twig
+++ b/upload/catalog/view/theme/default/template/common/language.twig
@@ -1,6 +1,6 @@
 {% if languages|length > 1 %}
 <div class="pull-left">
-  <form action="{{ action }}" method="post" enctype="multipart/form-data" id="form-language">
+  <div id="form-language">
     <div class="btn-group">
       <button class="btn btn-link dropdown-toggle" data-toggle="dropdown">
       {% for language in languages %}
@@ -12,13 +12,11 @@
       <ul class="dropdown-menu">
         {% for language in languages %}
         <li>
-          <button class="btn btn-link btn-block language-select" type="button" name="{{ language.code }}"><img src="catalog/language/{{ language.code }}/{{ language.code }}.png" alt="{{ language.name }}" title="{{ language.name }}" /> {{ language.name }}</button>
+          <a class="btn btn-link btn-block language-select" href="{{ language.href }}" hreflang="{{ language.code }}"><img src="catalog/language/{{ language.code }}/{{ language.code }}.png" alt="{{ language.name }}" title="{{ language.name }}" /> {{ language.name }}</a>
         </li>
         {% endfor %}
       </ul>
     </div>
-    <input type="hidden" name="code" value="" />
-    <input type="hidden" name="redirect" value="{{ redirect }}" />
-  </form>
+  </div>
 </div>
 {% endif %}

--- a/upload/catalog/view/theme/default/template/product/manufacturer_list.twig
+++ b/upload/catalog/view/theme/default/template/product/manufacturer_list.twig
@@ -17,7 +17,7 @@
       <h1>{{ heading_title }}</h1>
       {% if categories %}
       <p><strong>{{ text_index }}</strong> {% for category in categories %}
-        &nbsp;&nbsp;&nbsp;<a href="index.php?route=product/manufacturer#{{ category.name }}">{{ category.name }}</a> {% endfor %} </p>
+        &nbsp;&nbsp;&nbsp;<a href="{{ manufacturer }}#{{ category.name }}">{{ category.name }}</a> {% endfor %} </p>
       {% for category in categories %}
       <h2 id="{{ category.name }}">{{ category.name }}</h2>
       {% if category.manufacturer %}

--- a/upload/catalog/view/theme/default/template/product/search.twig
+++ b/upload/catalog/view/theme/default/template/product/search.twig
@@ -164,7 +164,7 @@
 </div>
 <script type="text/javascript"><!--
 $('#button-search').bind('click', function() {
-	url = 'index.php?route=product/search';
+	url = addLanguage('index.php?route=product/search');
 
 	var search = $('#content input[name=\'search\']').prop('value');
 

--- a/upload/system/config/catalog.php
+++ b/upload/system/config/catalog.php
@@ -35,7 +35,8 @@ $_['action_pre_action']  = array(
 	'startup/error',
 	'startup/event',
 	'startup/maintenance',
-	'startup/seo_url'
+	'startup/seo_url',
+	'startup/language_url'
 );
 
 // Action Events


### PR DESCRIPTION
## Summary

Makes each enabled catalog language independently addressable and crawlable without requiring SEO URLs or a theme-specific extension.

- Uses `?language=<code>` as the public language identifier for non-default languages
- Keeps the configured default language on the existing unqualified URL
- Makes public document responses deterministic: the URL selects the language, while a URL without a language selects the store default
- Replaces the POST language selector with ordinary links that crawlers and users can follow
- Preserves the active language in generated links, search/cart navigation and internal Ajax requests
- Keeps the legacy POST endpoint and session fallback for non-document requests so existing themes and extensions continue to work
- Uses the target language when rewriting product, category, manufacturer and information SEO keywords
- Outputs reciprocal `hreflang` links and `x-default`
- Removes category/manufacturer context from product language links because those parameters change breadcrumbs, not product identity
- Generates a language-aware home canonical URL

This intentionally does **not** introduce `/en` or `/ru` prefixes and does not add generic route aliases. Pretty paths remain an optional SEO/module concern; language identity and indexability work with both query URLs and the built-in SEO URL setting.

## Why

The current POST/session/cookie selector has no stable URL for each translation. Search engines therefore cannot reliably discover, index, or connect the language variants. A GET-addressable language plus reciprocal `hreflang` solves that independently of URL styling.

## Validation

- PHP syntax checked with PHP 8.5.9
- JavaScript syntax checked with Node
- Tested language URL rewriting with and without SEO paths
- Tested the combined SEO → language rewrite chain
- Tested current, target and default-language product keywords
- Tested default and non-default home URLs
- `git diff --check` passes