### PR TITLE
Redirect legacy query URLs to SEO URLs

### DIFF
--- a/upload/catalog/controller/startup/seo_url.php
+++ b/upload/catalog/controller/startup/seo_url.php
@@ -62,7 +62,7 @@ class ControllerStartupSeoUrl extends Controller {
 					$this->request->get['route'] = 'information/information';
 				}
 			}
-		} elseif ($this->request->server['REQUEST_METHOD'] == 'GET') {
+		} elseif (in_array($this->request->server['REQUEST_METHOD'], array('GET', 'HEAD'))) {
 			$this->redirectQueryUrl();
 		}
 	}

--- a/upload/catalog/controller/startup/seo_url.php
+++ b/upload/catalog/controller/startup/seo_url.php
@@ -62,6 +62,41 @@ class ControllerStartupSeoUrl extends Controller {
 					$this->request->get['route'] = 'information/information';
 				}
 			}
+		} elseif ($this->request->server['REQUEST_METHOD'] == 'GET') {
+			$this->redirectQueryUrl();
+		}
+	}
+
+	private function redirectQueryUrl() {
+		if (!isset($this->request->get['route'])) {
+			return;
+		}
+
+		$route = $this->request->get['route'];
+		$seo_routes = array(
+			'product/product'           => 'product_id',
+			'product/category'          => 'path',
+			'product/manufacturer/info' => 'manufacturer_id',
+			'information/information'   => 'information_id'
+		);
+
+		if (!isset($seo_routes[$route]) || !isset($this->request->get[$seo_routes[$route]])) {
+			return;
+		}
+
+		$url_data = $this->request->get;
+
+		unset($url_data['_route_'], $url_data['route'], $url_data['tracking']);
+
+		if ($route == 'product/product') {
+			$url_data = array('product_id' => (int)$this->request->get['product_id']);
+		}
+
+		$url = $this->url->link($route, $url_data, $this->request->server['HTTPS']);
+		$path = parse_url(str_replace('&amp;', '&', $url), PHP_URL_PATH);
+
+		if ($path && substr($path, -10) != '/index.php') {
+			$this->response->redirect($url, 301);
 		}
 	}
 


### PR DESCRIPTION
## Summary

Redirects legacy GET URLs for products, categories, manufacturers and information pages to their configured SEO URLs when a rewrite is available.

For product pages, navigation-only parameters such as `path` and `manufacturer_id` are deliberately removed so all legacy variants converge on one product URL. Tracking is processed earlier in startup and is not copied into the canonical redirect.

If no SEO keyword exists, the original query URL continues to work and no redirect is issued.

## Validation

- PHP syntax checked on PHP 8.5
- Verified HTTP 301 behavior
- Verified that product URLs with `manufacturer_id`, `path`, or only `product_id` resolve to the same SEO URL
- Verified that missing SEO mappings do not cause redirect loops