### PR TITLE
Mark session cookies as HttpOnly

### DIFF
--- a/upload/catalog/controller/startup/session.php
+++ b/upload/catalog/controller/startup/session.php
@@ -22,7 +22,7 @@ class ControllerStartupSession extends Controller {
 			
 			$this->session->start($session_id);
 			
-			setcookie($this->config->get('session_name'), $this->session->getId(), (ini_get('session.cookie_lifetime') ? time() + ini_get('session.cookie_lifetime') : 0), ini_get('session.cookie_path'), ini_get('session.cookie_domain'));	
+			setcookie($this->config->get('session_name'), $this->session->getId(), (ini_get('session.cookie_lifetime') ? time() + ini_get('session.cookie_lifetime') : 0), ini_get('session.cookie_path'), ini_get('session.cookie_domain'), false, true);	
 		}
 	}
 }

--- a/upload/system/framework.php
+++ b/upload/system/framework.php
@@ -119,7 +119,7 @@ if ($config->get('session_autostart')) {
 
 	$session->start($session_id);
 
-	setcookie($config->get('session_name'), $session->getId(), (ini_get('session.cookie_lifetime') ? time() + ini_get('session.cookie_lifetime') : 0), ini_get('session.cookie_path'), ini_get('session.cookie_domain'));
+	setcookie($config->get('session_name'), $session->getId(), (ini_get('session.cookie_lifetime') ? time() + ini_get('session.cookie_lifetime') : 0), ini_get('session.cookie_path'), ini_get('session.cookie_domain'), false, true);
 }
 
 // Cache


### PR DESCRIPTION
## What this changes

Marks OpenCart session cookies as `HttpOnly` in both bootstrap paths. This prevents client-side scripts from reading the session identifier and reduces the impact of XSS-based session theft.

## Scope

- System framework session cookie
- Catalog startup session cookie
- No cookie name, lifetime, path, domain, or session behavior changes

## Validation

- PHP syntax checked on PHP 8.5
- Verified both session cookie write paths receive the `HttpOnly` flag