### PR TITLE
Rename Google Sitemap to XML Sitemap and expose robots directive

### DIFF
--- a/upload/admin/controller/extension/feed/google_sitemap.php
+++ b/upload/admin/controller/extension/feed/google_sitemap.php
@@ -51,6 +51,7 @@ class ControllerExtensionFeedGoogleSitemap extends Controller {
 		}
 
 		$data['data_feed'] = HTTP_CATALOG . 'index.php?route=extension/feed/google_sitemap';
+		$data['robots_directive'] = 'Sitemap: ' . $data['data_feed'];
 
 		$data['header'] = $this->load->controller('common/header');
 		$data['column_left'] = $this->load->controller('common/column_left');

--- a/upload/admin/language/en-gb/extension/feed/google_sitemap.php
+++ b/upload/admin/language/en-gb/extension/feed/google_sitemap.php
@@ -1,15 +1,19 @@
 <?php
 // Heading
-$_['heading_title']    = 'Google Sitemap';
+$_['heading_title']           = 'XML Sitemap';
 
 // Text
-$_['text_extension']   = 'Extensions';
-$_['text_success']     = 'Success: You have modified Google Sitemap feed!';
-$_['text_edit']        = 'Edit Google Sitemap';
+$_['text_extension']          = 'Extensions';
+$_['text_success']            = 'Success: You have modified the XML Sitemap feed!';
+$_['text_edit']               = 'Edit XML Sitemap';
 
 // Entry
-$_['entry_status']     = 'Status';
-$_['entry_data_feed']  = 'Data Feed Url';
+$_['entry_status']            = 'Status';
+$_['entry_data_feed']         = 'Sitemap URL';
+$_['entry_robots_directive']  = 'Robots.txt directive';
+
+// Help
+$_['help_robots_directive']   = 'Add this line to robots.txt so search engines can discover the sitemap automatically.';
 
 // Error
-$_['error_permission'] = 'Warning: You do not have permission to modify Google Sitemap feed!';
+$_['error_permission']        = 'Warning: You do not have permission to modify the XML Sitemap feed!';

--- a/upload/admin/view/template/extension/feed/google_sitemap.twig
+++ b/upload/admin/view/template/extension/feed/google_sitemap.twig
@@ -45,6 +45,12 @@
               <textarea rows="5" readonly id="input-data-feed" class="form-control">{{ data_feed }}</textarea>
             </div>
           </div>
+          <div class="form-group">
+            <label class="col-sm-2 control-label" for="input-robots-directive"><span data-toggle="tooltip" title="{{ help_robots_directive }}">{{ entry_robots_directive }}</span></label>
+            <div class="col-sm-10">
+              <input type="text" readonly value="{{ robots_directive }}" id="input-robots-directive" class="form-control" />
+            </div>
+          </div>
         </form>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- rename the visible Google Sitemap feed to the vendor-neutral XML Sitemap
- keep the existing controller route and configuration key for backward compatibility
- show a ready-to-copy `Sitemap:` directive for `robots.txt`

## Rationale
The XML Sitemap protocol is not Google-specific. A static `robots.txt` cannot include an absolute store URL in the distributed package, while the admin controller already knows `HTTP_CATALOG` and can present the exact directive without changing sitemap routing or output.

## Validation
- PHP syntax checked on PHP 8.5
- verified sitemap XML output remains unchanged
- verified the existing URL service continues to apply custom SEO rewrites