### PR TITLE
[4.x.x.x] Installer fix file size check for upload validation. Part2

### DIFF
--- a/upload/admin/controller/marketplace/installer.php
+++ b/upload/admin/controller/marketplace/installer.php
@@ -28,10 +28,12 @@ class Installer extends \Opencart\System\Engine\Controller {
 			'href' => $this->url->link('marketplace/installer', 'user_token=' . $this->session->data['user_token'])
 		];
 
-		// Use the configuration option to get the max file size
-		$data['error_upload_size'] = sprintf($this->language->get('error_upload_size'), ini_get('upload_max_filesize'));
+		// Use the configuration option to get the max file size both from upload_max_filesize and post_max_size
+		$upload_max_filesize = min(((int)preg_filter('/[^0-9]/', '', ini_get('upload_max_filesize')) * 1024 * 1024), ((int)preg_filter('/[^0-9]/', '', ini_get('post_max_size')) * 1024 * 1024));
 
-		$data['config_file_max_size'] = ((int)preg_filter('/[^0-9]/', '', ini_get('upload_max_filesize')) * 1024 * 1024);
+		$data['error_upload_size'] = sprintf($this->language->get('error_upload_size'), $upload_max_filesize / 1024 / 1024);
+
+		$data['config_file_max_size'] =  $upload_max_filesize;
 
 		$data['upload'] = $this->url->link('tool/installer.upload', 'user_token=' . $this->session->data['user_token']);
 

--- a/upload/admin/language/en-gb/marketplace/installer.php
+++ b/upload/admin/language/en-gb/marketplace/installer.php
@@ -42,6 +42,7 @@ $_['error_directory_exists'] = 'Path %s already exists!';
 $_['error_unzip']            = 'Zip file could not be opened!';
 $_['error_upload']           = 'File could not be uploaded!';
 $_['error_unknown']          = 'An unknown error occurred!';
+$_['error_upload_size']      = 'Warning: The uploaded file size exceeds the upload_max_filesize and post_max_size directives of %smb in php.ini!';
 
 // Zip errors
 $_['zip_error_exists']       = 'File already exists!';

--- a/upload/admin/language/en-gb/marketplace/installer.php
+++ b/upload/admin/language/en-gb/marketplace/installer.php
@@ -42,7 +42,7 @@ $_['error_directory_exists'] = 'Path %s already exists!';
 $_['error_unzip']            = 'Zip file could not be opened!';
 $_['error_upload']           = 'File could not be uploaded!';
 $_['error_unknown']          = 'An unknown error occurred!';
-$_['error_upload_size']      = 'Warning: The uploaded file size exceeds the upload_max_filesize and post_max_size directives of %smb in php.ini!';
+$_['error_upload_size']      = 'Warning: The uploaded file size exceeds the upload_max_filesize and post_max_size directives of %sM in php.ini!';
 
 // Zip errors
 $_['zip_error_exists']       = 'File already exists!';

--- a/upload/admin/language/fr-fr/marketplace/installer.php
+++ b/upload/admin/language/fr-fr/marketplace/installer.php
@@ -42,6 +42,7 @@ $_['error_directory_exists'] = 'Le chemin %s existe déjà!';
 $_['error_unzip']            = 'Impossible d\'ouvrir le fichier .zip!';
 $_['error_upload']           = 'Le fichier n\'a pu être téléchargé!';
 $_['error_unknown']          = 'Une erreur inconnue s’est produite!';
+$_['error_upload_size']      = 'Attention: La taille du fichier téléchargé dépasse les directives upload_max_filesize et post_max_size de %sM dans php.ini!';
 
 // Zip erreur
 $_['zip_error_exists']       = 'Le fichier existe déjà!';


### PR DESCRIPTION
Max upload file size must be taken both from `upload_max_filesize` and `post_max_size`. If any of these values is smaller than the uploaded file size, the user will not be able to upload it.