### PR TITLE
validate ip from forwarded headers in oc_get_ip

### DIFF
--- a/upload/system/helper/general.php
+++ b/upload/system/helper/general.php
@@ -23,16 +23,17 @@ function oc_get_ip(): string {
 
 	foreach ($headers as $header) {
 		if (array_key_exists($header, $_SERVER)) {
-			$ip = $_SERVER[$header];
+			// A proxy may send a comma separated list, the client address is the first entry.
+			$ip = trim(explode(',', $_SERVER[$header])[0]);
 
-			// This line might or might not be used.
-			$ip = trim(explode(',', $ip)[0]);
-
-			return $ip;
+			// Only trust the forwarded header when it actually holds an IP address.
+			if (filter_var($ip, FILTER_VALIDATE_IP)) {
+				return $ip;
+			}
 		}
 	}
 
-	return $_SERVER['REMOTE_ADDR'];
+	return filter_var($_SERVER['REMOTE_ADDR'] ?? '', FILTER_VALIDATE_IP) ?: '';
 }
 
 // Sting functions


### PR DESCRIPTION
oc_get_ip() returns the first forwarding header (X-Forwarded-For, CF-Connecting-IP and the others) straight from $_SERVER without checking it is an IP, so an anonymous request carrying something like X-Forwarded-For: "><script>...</script> makes it return that raw markup. The value is stored as the visitor address by common/footer through model_tool_online->addOnline() and later printed with {{ customer.ip }} on the Reports > Who's Online screen where Twig autoescape is off, so it runs as stored XSS in the admin session. This validates each candidate with filter_var() and only returns a value that parses as an IP, falling back to a checked REMOTE_ADDR.