### PR TITLE
use hash_equals for legacy password hash checks in login

### DIFF
--- a/upload/system/library/cart/customer.php
+++ b/upload/system/library/cart/customer.php
@@ -111,9 +111,9 @@ class Customer {
 			if (!$override) {
 				if (password_verify($password, $customer_query->row['password'])) {
 					$rehash = password_needs_rehash($customer_query->row['password'], PASSWORD_DEFAULT);
-				} elseif (isset($customer_query->row['salt']) && $customer_query->row['password'] == sha1($customer_query->row['salt'] . sha1($customer_query->row['salt'] . sha1($password)))) {
+				} elseif (isset($customer_query->row['salt']) && hash_equals((string)$customer_query->row['password'], sha1($customer_query->row['salt'] . sha1($customer_query->row['salt'] . sha1($password))))) {
 					$rehash = true;
-				} elseif ($customer_query->row['password'] == md5($password)) {
+				} elseif (hash_equals((string)$customer_query->row['password'], md5($password))) {
 					$rehash = true;
 				} else {
 					return false;

--- a/upload/system/library/cart/user.php
+++ b/upload/system/library/cart/user.php
@@ -103,9 +103,9 @@ class User {
 		if ($user_query->num_rows) {
 			if (password_verify($password, $user_query->row['password'])) {
 				$rehash = password_needs_rehash($user_query->row['password'], PASSWORD_DEFAULT);
-			} elseif (isset($user_query->row['salt']) && $user_query->row['password'] == sha1($user_query->row['salt'] . sha1($user_query->row['salt'] . sha1($password)))) {
+			} elseif (isset($user_query->row['salt']) && hash_equals((string)$user_query->row['password'], sha1($user_query->row['salt'] . sha1($user_query->row['salt'] . sha1($password))))) {
 				$rehash = true;
-			} elseif ($user_query->row['password'] == md5($password)) {
+			} elseif (hash_equals((string)$user_query->row['password'], md5($password))) {
 				$rehash = true;
 			} else {
 				return false;


### PR DESCRIPTION
The legacy fallbacks in Customer::login() and User::login() compare the stored md5/sha1 hash against the recomputed hash with ==, so an un-migrated account whose stored hash is a magic-hash string (0e followed by only digits) authenticates against any password whose hash has the same form. Switch the four comparisons to hash_equals(), the same call the API signature check already uses. password_verify() still runs first, so bcrypt accounts and valid legacy logins behave exactly as before.