### PR TITLE
validate backup table name against real tables in getRecords

### DIFF
--- a/upload/admin/model/tool/backup.php
+++ b/upload/admin/model/tool/backup.php
@@ -51,6 +51,10 @@ class Backup extends \Opencart\System\Engine\Model {
 	 * $records = $this->model_tool_backup->getRecords($table, $start, $limit);
 	 */
 	public function getRecords(string $table, int $start = 0, int $limit = 100): array {
+		if (!in_array($table, $this->getTables())) {
+			return [];
+		}
+
 		$primary_data = [];
 
 		$query = $this->db->query("SELECT COLUMN_NAME AS `name` FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = '" . DB_DATABASE . "' AND TABLE_NAME = '" . $table . "' AND COLUMN_KEY = 'PRI'");
@@ -98,6 +102,10 @@ class Backup extends \Opencart\System\Engine\Model {
 	 * $record_total = $this->model_tool_backup->getTotalRecords($table);
 	 */
 	public function getTotalRecords(string $table): int {
+		if (!in_array($table, $this->getTables())) {
+			return 0;
+		}
+
 		$query = $this->db->query("SELECT COUNT(*) AS `total` FROM `" . $table . "`");
 
 		if ($query->num_rows) {


### PR DESCRIPTION
check $table against getTables() at the top of getRecords() and getTotalRecords(), otherwise the name flows straight into `SELECT * FROM `$table`` and the information_schema lookup unescaped, and a backup[] value like `oc_category` UNION SELECT username, password FROM oc_user -- ` passes the str_starts_with($table, DB_PREFIX) guard in tool/backup and task/system/backup, breaks out of the backtick identifier, and dumps the disallowed oc_user rows into the downloadable backup file.