### PR TITLE
Add Content-Security-Policy with per-request nonces; replace inline event handlers

### DIFF
--- a/upload/admin/view/javascript/handlers.js
+++ b/upload/admin/view/javascript/handlers.js
@@ -1,0 +1,70 @@
+/**
+ * CSP handler delegation.
+ *
+ * Replaces inline event handler attributes (onclick="...") so pages can run
+ * under a strict Content-Security-Policy (script-src with a per-request
+ * nonce). Handlers are declared as data-attributes instead:
+ *
+ *   data-confirm="message"      ask for confirmation before following the action
+ *   data-remove="#selector"     remove the matched element
+ *   data-toggle="#selector"     toggle the d-none class on the matched element
+ *   data-select-all             click all input[name*="selected"] checkboxes
+ *   data-call="fn"              call window.fn(), optional data-call-arg="..."
+ *   data-location="url"         navigate to the url
+ *
+ * Delegation on document also covers rows added dynamically via JS.
+ */
+document.addEventListener('click', function(e) {
+	const target = e.target.closest('[data-confirm], [data-remove], [data-toggle], [data-select-all], [data-call], [data-location]');
+
+	if (!target) {
+		return;
+	}
+
+	if (target.hasAttribute('data-confirm')) {
+		if (!window.confirm(target.getAttribute('data-confirm'))) {
+			e.preventDefault();
+			e.stopPropagation();
+			return;
+		}
+	}
+
+	if (target.hasAttribute('data-location')) {
+		window.location = target.getAttribute('data-location');
+		return;
+	}
+
+	if (target.hasAttribute('data-remove')) {
+		const element = document.querySelector(target.getAttribute('data-remove'));
+
+		if (element) {
+			element.remove();
+		}
+	}
+
+	if (target.hasAttribute('data-toggle')) {
+		const element = document.querySelector(target.getAttribute('data-toggle'));
+
+		if (element) {
+			element.classList.toggle('d-none');
+		}
+	}
+
+	if (target.hasAttribute('data-select-all')) {
+		document.querySelectorAll('input[name*=\'selected\']').forEach(function(checkbox) {
+			checkbox.click();
+		});
+	}
+
+	if (target.hasAttribute('data-call')) {
+		const fn = window[target.getAttribute('data-call')];
+
+		if (typeof fn === 'function') {
+			fn(target.getAttribute('data-call-arg'));
+		}
+	}
+
+	if (target.hasAttribute('data-confirm')) {
+		e.preventDefault();
+	}
+}, false);

--- a/upload/admin/view/stylesheet/stylesheet.css
+++ b/upload/admin/view/stylesheet/stylesheet.css
@@ -1,5 +1,5 @@
 @charset "UTF-8";
-@import url(//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800&subset=latin,cyrillic-ext,greek-ext,vietnamese);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800&subset=latin,cyrillic-ext,greek-ext,vietnamese);
 @import "../fonts/fontawesome/css/all.min.css";
 /*!
    * Bootstrap  v5.3.7 (https://getbootstrap.com/)

--- a/upload/admin/view/template/catalog/attribute.twig
+++ b/upload/admin/view/template/catalog/attribute.twig
@@ -4,7 +4,7 @@
     <div class="container-fluid">
       <div class="float-end">
         <a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" form="form-attribute" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+        <button type="submit" form="form-attribute" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/catalog/attribute_form.twig
+++ b/upload/admin/view/template/catalog/attribute_form.twig
@@ -62,7 +62,7 @@
                         <div id="error-attribute-{{ attribute_row }}-{{ language.language_id }}" class="invalid-feedback"></div>
                       {% endfor %}</td>
                     <td class="text-end"><input type="text" name="attribute[{{ attribute_row }}][sort_order]" value="{{ attribute.sort_order }}" placeholder="{{ entry_sort_order }}" class="form-control"/></td>
-                    <td class="text-end"><button type="button" onclick="$('#attribute-row-{{ attribute_row }}').remove();" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
+                    <td class="text-end"><button type="button" data-remove="#attribute-row-{{ attribute_row }}" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
                   </tr>
                   {% set attribute_row = attribute_row + 1 %}
                 {% endfor %}
@@ -93,7 +93,7 @@
         <div id="error-attribute-{{ attribute_row }}-{{ language.language_id }}" class="invalid-feedback"></div>
       {% endfor %}</td>
     <td class="text-end"><input type="text" name="attribute[{{ attribute_row }}][sort_order]" value="" placeholder="{{ entry_sort_order }}" class="form-control"/></td>
-    <td class="text-end"><button type="button" onclick="$('#attribute-row-{{ attribute_row }}').remove();" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
+    <td class="text-end"><button type="button" data-remove="#attribute-row-{{ attribute_row }}" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
   </tr>
 </template>
 {{ footer }}

--- a/upload/admin/view/template/catalog/category.twig
+++ b/upload/admin/view/template/catalog/category.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end">
-        <button id="filter-category-button" type="button" title="{{ button_filter }}" onclick="$('#filter-category').toggleClass('d-none');" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
+        <button id="filter-category-button" type="button" title="{{ button_filter }}" data-toggle="#filter-category" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
         <a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
         <button type="button" id="button-repair" title="{{ button_rebuild }}" class="btn btn-warning"><i class="fa-solid fa-rotate"></i></button>
         <div class="btn-group">
@@ -12,7 +12,7 @@
             <li><button type="submit" form="form-category" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-category" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
             <li><hr class="dropdown-divider"></li>
-            <li><button type="submit" form="form-category" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
+            <li><button type="submit" form="form-category" formaction="{{ delete }}" data-confirm="{{ text_confirm }}" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>
       </div>

--- a/upload/admin/view/template/catalog/download.twig
+++ b/upload/admin/view/template/catalog/download.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end"><a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" form="form-download" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button></div>
+        <button type="submit" form="form-download" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button></div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">
         {% for breadcrumb in breadcrumbs %}

--- a/upload/admin/view/template/catalog/filter.twig
+++ b/upload/admin/view/template/catalog/filter.twig
@@ -3,7 +3,7 @@
 	<div class="page-header">
 		<div class="container-fluid">
 			<div class="float-end"><a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-				<button type="submit" form="form-filter" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+				<button type="submit" form="form-filter" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
 			</div>
 			<h1>{{ heading_title }}</h1>
 			<ol class="breadcrumb">

--- a/upload/admin/view/template/catalog/filter_form.twig
+++ b/upload/admin/view/template/catalog/filter_form.twig
@@ -62,7 +62,7 @@
                         <div id="error-filter-{{ filter_row }}-{{ language.language_id }}" class="invalid-feedback"></div>
                       {% endfor %}</td>
                     <td class="text-end"><input type="text" name="filter[{{ filter_row }}][sort_order]" value="{{ filter.sort_order }}" placeholder="{{ entry_sort_order }}" class="form-control"/></td>
-                    <td class="text-end"><button type="button" onclick="$('#filter-row-{{ filter_row }}').remove();" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
+                    <td class="text-end"><button type="button" data-remove="#filter-row-{{ filter_row }}" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
                   </tr>
                   {% set filter_row = filter_row + 1 %}
                 {% endfor %}

--- a/upload/admin/view/template/catalog/information.twig
+++ b/upload/admin/view/template/catalog/information.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end">
-        <button type="button" title="{{ button_filter }}" onclick="$('#filter-information').toggleClass('d-none');" class="btn btn-light d-md-none d-lg-none"><i class="fa-solid fa-filter"></i></button>
+        <button type="button" title="{{ button_filter }}" data-toggle="#filter-information" class="btn btn-light d-md-none d-lg-none"><i class="fa-solid fa-filter"></i></button>
         <a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
         <div class="btn-group">
           <button type="button" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown"><i class="fa-solid fa-list-check"></i> {{ button_action }} <i class="fa-solid fa-caret-down fa-fw"></i></button>
@@ -13,7 +13,7 @@
             <li>
               <hr class="dropdown-divider">
             </li>
-            <li><button type="submit" form="form-information" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
+            <li><button type="submit" form="form-information" formaction="{{ delete }}" data-confirm="{{ text_confirm }}" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>
       </div>

--- a/upload/admin/view/template/catalog/manufacturer.twig
+++ b/upload/admin/view/template/catalog/manufacturer.twig
@@ -2,7 +2,7 @@
 <div id="content">
   <div class="page-header">
     <div class="container-fluid">
-      <button type="button" title="{{ button_filter }}" onclick="$('#filter-manufacturer').toggleClass('d-none');" class="btn btn-light d-md-none d-lg-none"><i class="fa-solid fa-filter"></i></button>
+      <button type="button" title="{{ button_filter }}" data-toggle="#filter-manufacturer" class="btn btn-light d-md-none d-lg-none"><i class="fa-solid fa-filter"></i></button>
       <div class="float-end">
         <a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
         <div class="btn-group">
@@ -13,7 +13,7 @@
             <li>
               <hr class="dropdown-divider">
             </li>
-            <li><button type="submit" form="form-manufacturer" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
+            <li><button type="submit" form="form-manufacturer" formaction="{{ delete }}" data-confirm="{{ text_confirm }}" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>
       </div>

--- a/upload/admin/view/template/catalog/option.twig
+++ b/upload/admin/view/template/catalog/option.twig
@@ -3,7 +3,7 @@
 	<div class="page-header">
 		<div class="container-fluid">
 			<div class="float-end"><a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-				<button type="submit" form="form-option" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+				<button type="submit" form="form-option" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
 			</div>
 			<h1>{{ heading_title }}</h1>
 			<ol class="breadcrumb">

--- a/upload/admin/view/template/catalog/option_form.twig
+++ b/upload/admin/view/template/catalog/option_form.twig
@@ -103,7 +103,7 @@
                       </div>
                     </td>
                     <td class="text-end"><input type="text" name="option_value[{{ option_value_row }}][sort_order]" value="{{ option_value.sort_order }}" placeholder="{{ entry_sort_order }}" class="form-control"/></td>
-                    <td class="text-end"><button type="button" onclick="$('#option-value-row-{{ option_value_row }}').remove();" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
+                    <td class="text-end"><button type="button" data-remove="#option-value-row-{{ option_value_row }}" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
                   </tr>
                   {% set option_value_row = option_value_row + 1 %}
                 {% endfor %}
@@ -148,7 +148,7 @@
 
     <td class="text-end"><input type="text" name="option_value[{{ option_value_row }}][sort_order]" value="" placeholder="{{ entry_sort_order }}" class="form-control"/></td>
 
-    <td class="text-end"><button type="button" onclick="$('#option-value-row-{{ option_value_row }}').remove();" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
+    <td class="text-end"><button type="button" data-remove="#option-value-row-{{ option_value_row }}" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
 
   </tr>
 </template>

--- a/upload/admin/view/template/catalog/product.twig
+++ b/upload/admin/view/template/catalog/product.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end">
-        <button type="button" title="{{ button_filter }}" onclick="$('#filter-product').toggleClass('d-none');" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
+        <button type="button" title="{{ button_filter }}" data-toggle="#filter-product" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
         <a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
         <div class="btn-group">
           <button type="button" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown"><i class="fa-solid fa-list-check"></i> {{ button_action }} <i class="fa-solid fa-caret-down fa-fw"></i></button>
@@ -13,7 +13,7 @@
             <li><button type="submit" form="form-product" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-product" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
             <li><hr class="dropdown-divider"></li>
-            <li><button type="submit" form="form-product" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
+            <li><button type="submit" form="form-product" formaction="{{ delete }}" data-confirm="{{ text_confirm }}" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>
       </div>

--- a/upload/admin/view/template/catalog/product_form.twig
+++ b/upload/admin/view/template/catalog/product_form.twig
@@ -616,7 +616,7 @@
                               <textarea name="product_attribute[{{ attribute_row }}][product_attribute_description][{{ language.language_id }}][text]" rows="5" placeholder="{{ entry_text }}" id="input-text-{{ attribute_row }}-{{ language.language_id }}" class="form-control">{{ product_attribute.description[language.code] ? product_attribute.description[language.code].text }}</textarea>
                             </div>
                           {% endfor %}</td>
-                        <td class="text-end"><button type="button" onclick="$('#attribute-row-{{ attribute_row }}').remove();" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
+                        <td class="text-end"><button type="button" data-remove="#attribute-row-{{ attribute_row }}" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
                       </tr>
                       {% set attribute_row = attribute_row + 1 %}
                     {% endfor %}
@@ -716,7 +716,7 @@
                                       <td class="text-end">{{ product_option_value.points }}
                                         <input type="hidden" name="product_option[{{ option_row }}][product_option_value][{{ option_value_row }}][points]" value="{{ product_option_value.points }}"/></td>
                                       <td class="text-end">{{ product_option_value.weight }} <input type="hidden" name="product_option[{{ option_row }}][product_option_value][{{ option_value_row }}][weight]" value="{{ product_option_value.weight }}"/></td>
-                                      <td class="text-end"><button type="button" title="{{ button_edit }}" data-option-row="{{ option_row }}" data-option-value-row="{{ option_value_row }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></button> <button type="button" onclick="$('#option-value-row-{{ option_value_row }}').remove();" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
+                                      <td class="text-end"><button type="button" title="{{ button_edit }}" data-option-row="{{ option_row }}" data-option-value-row="{{ option_value_row }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></button> <button type="button" data-remove="#option-value-row-{{ option_value_row }}" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
                                     </tr>
                                     {% set option_value_row = option_value_row + 1 %}
                                   {% endfor %}
@@ -740,7 +740,7 @@
                         </div>
 
                         <div class="col">
-                          <button type="button" class="btn btn-danger" title="{{ button_remove }}" onclick="$('#option-row-{{ option_row }}').remove();"><i class="fa-solid fa-minus-circle"></i></button>
+                          <button type="button" class="btn btn-danger" title="{{ button_remove }}" data-remove="#option-row-{{ option_row }}"><i class="fa-solid fa-minus-circle"></i></button>
                         </div>
                       </div>
                     </fieldset>
@@ -964,7 +964,7 @@
                           </select></td>
                         <td><input type="text" name="product_subscription[{{ subscription_row }}][trial_price]" value="{{ product_subscription.trial_price }}" placeholder="{{ entry_trial_price }}" class="form-control"/></td>
                         <td><input type="text" name="product_subscription[{{ subscription_row }}][price]" value="{{ product_subscription.price }}" placeholder="{{ entry_price }}" class="form-control"/></td>
-                        <td class="text-end"><button type="button" onclick="$('#subscription-row-{{ subscription_row }}').remove()" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
+                        <td class="text-end"><button type="button" data-remove="#subscription-row-{{ subscription_row }}" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
                       </tr>
                       {% set subscription_row = subscription_row + 1 %}
                     {% endfor %}
@@ -1013,7 +1013,7 @@
                           </select></td>
                         <td><input type="date" name="product_discount[{{ discount_row }}][date_start]" value="{{ product_discount.date_start }}" placeholder="{{ entry_date_start }}" class="form-control"/></td>
                         <td><input type="date" name="product_discount[{{ discount_row }}][date_end]" value="{{ product_discount.date_end }}" placeholder="{{ entry_date_end }}" class="form-control"/></td>
-                        <td class="text-end"><button type="button" onclick="$('#discount-row-{{ discount_row }}').remove();" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
+                        <td class="text-end"><button type="button" data-remove="#discount-row-{{ discount_row }}" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
                       </tr>
                       {% set discount_row = discount_row + 1 %}
                     {% endfor %}
@@ -1065,7 +1065,7 @@
                             </div>
                           </td>
                           <td><input type="text" name="product_image[{{ image_row }}][sort_order]" value="{{ product_image.sort_order }}" placeholder="{{ entry_sort_order }}" class="form-control"/></td>
-                          <td class="text-end"><button type="button" onclick="$('#product-image-row-{{ image_row }}').remove();" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
+                          <td class="text-end"><button type="button" data-remove="#product-image-row-{{ image_row }}" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
                         </tr>
                         {% set image_row = image_row + 1 %}
                       {% endfor %}
@@ -1202,7 +1202,7 @@
           <textarea name="product_attribute[{{ attribute_row }}][product_attribute_description][{{ language.language_id }}][text]" rows="5" placeholder="{{ entry_text }}" id="input-text-{{ attribute_row }}-{{ language.language_id }}" class="form-control"></textarea>
         </div>
       {% endfor %}</td>
-    <td class="text-end"><button type="button" onclick="$('#attribute-row-{{ attribute_row }}').remove();" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
+    <td class="text-end"><button type="button" data-remove="#attribute-row-{{ attribute_row }}" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
   </tr>
 </template>
 

--- a/upload/admin/view/template/catalog/review.twig
+++ b/upload/admin/view/template/catalog/review.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end">
-        <button type="button" title="{{ button_filter }}" onclick="$('#filter-review').toggleClass('d-none');" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
+        <button type="button" title="{{ button_filter }}" data-toggle="#filter-review" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
         <a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
         <button type="button" id="button-rating" title="{{ button_rating }}" class="btn btn-warning"><i class="fa-solid fa-rotate"></i></button>
         <div class="btn-group">
@@ -12,7 +12,7 @@
             <li><button type="submit" form="form-review" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-review" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
             <li><hr class="dropdown-divider"></li>
-            <li><button type="submit" form="form-review" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
+            <li><button type="submit" form="form-review" formaction="{{ delete }}" data-confirm="{{ text_confirm }}" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>
       </div>

--- a/upload/admin/view/template/catalog/subscription_plan.twig
+++ b/upload/admin/view/template/catalog/subscription_plan.twig
@@ -12,7 +12,7 @@
             <li><button type="submit" form="form-subscription-plan" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-subscription-plan" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
             <li><hr class="dropdown-divider"></li>
-            <li><button type="submit" form="form-subscription-plan" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
+            <li><button type="submit" form="form-subscription-plan" formaction="{{ delete }}" data-confirm="{{ text_confirm }}" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>
       </div>

--- a/upload/admin/view/template/cms/antispam.twig
+++ b/upload/admin/view/template/cms/antispam.twig
@@ -4,7 +4,7 @@
     <div class="container-fluid">
       <div class="float-end">
         <a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" form="form-antispam" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+        <button type="submit" form="form-antispam" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/cms/article.twig
+++ b/upload/admin/view/template/cms/article.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end">
-        <button type="button" title="{{ button_filter }}" onclick="$('#filter-article').toggleClass('d-none');" class="btn btn-light d-md-none d-lg-none"><i class="fa-solid fa-filter"></i></button>
+        <button type="button" title="{{ button_filter }}" data-toggle="#filter-article" class="btn btn-light d-md-none d-lg-none"><i class="fa-solid fa-filter"></i></button>
         <a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
         <button type="button" id="button-rating" title="{{ button_rating }}" class="btn btn-warning"><i class="fa-solid fa-sync"></i></button>
         <div class="btn-group">
@@ -14,7 +14,7 @@
             <li>
               <hr class="dropdown-divider">
             </li>
-            <li><button type="submit" form="form-article" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
+            <li><button type="submit" form="form-article" formaction="{{ delete }}" data-confirm="{{ text_confirm }}" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>
       </div>

--- a/upload/admin/view/template/cms/comment.twig
+++ b/upload/admin/view/template/cms/comment.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end">
-        <button type="button" title="{{ button_filter }}" onclick="$('#filter-comment').toggleClass('d-none');" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
+        <button type="button" title="{{ button_filter }}" data-toggle="#filter-comment" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
         <button type="button" id="button-rating" title="{{ button_rating }}" class="btn btn-light"><i class="fa-solid fa-sync"></i></button>
         <div class="btn-group">
           <button type="button" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown"><i class="fa-solid fa-list-check"></i> {{ button_action }} <i class="fa-solid fa-caret-down fa-fw"></i></button>
@@ -11,7 +11,7 @@
             <li><button type="submit" form="form-comment" formaction="{{ approve }}" class="dropdown-item"><i class="fa-solid fa-check text-success"></i> {{ button_approve }}</button></li>
             <li><button type="submit" form="form-comment" formaction="{{ spam }}" class="dropdown-item"><i class="fa-solid fa-ban text-danger"></i> {{ button_spam }}</button></li>
             <li><hr class="dropdown-divider"></li>
-            <li><button type="submit" form="form-comment" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
+            <li><button type="submit" form="form-comment" formaction="{{ delete }}" data-confirm="{{ text_confirm }}" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>
       </div>

--- a/upload/admin/view/template/cms/topic.twig
+++ b/upload/admin/view/template/cms/topic.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end">
-        <button type="button" title="{{ button_filter }}" onclick="$('#filter-topic').toggleClass('d-none');" class="btn btn-light d-md-none d-lg-none"><i class="fa-solid fa-filter"></i></button>
+        <button type="button" title="{{ button_filter }}" data-toggle="#filter-topic" class="btn btn-light d-md-none d-lg-none"><i class="fa-solid fa-filter"></i></button>
         <a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
         <div class="btn-group">
           <button type="button" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown"><i class="fa-solid fa-list-check"></i> {{ button_action }} <i class="fa-solid fa-caret-down fa-fw"></i></button>
@@ -13,7 +13,7 @@
             <li>
               <hr class="dropdown-divider">
             </li>
-            <li><button type="submit" form="form-topic" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
+            <li><button type="submit" form="form-topic" formaction="{{ delete }}" data-confirm="{{ text_confirm }}" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>
       </div>

--- a/upload/admin/view/template/cms/topic.twig
+++ b/upload/admin/view/template/cms/topic.twig
@@ -75,7 +75,7 @@
     </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#form-filter').on('submit', function(e) {
     e.preventDefault();
 

--- a/upload/admin/view/template/cms/topic_form.twig
+++ b/upload/admin/view/template/cms/topic_form.twig
@@ -174,7 +174,7 @@
     </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('textarea[data-oc-toggle=\'ckeditor\']').ckeditor({
     language: '{{ ckeditor }}'
 });

--- a/upload/admin/view/template/common/dashboard.twig
+++ b/upload/admin/view/template/common/dashboard.twig
@@ -32,7 +32,7 @@
   </div>
   {{ security }}
 </div>
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{ nonce }}">
 document.addEventListener('DOMContentLoaded', async () => {
     let response = await fetch('index.php?route=common/developer&user_token={{ user_token }}');
 

--- a/upload/admin/view/template/common/footer.twig
+++ b/upload/admin/view/template/common/footer.twig
@@ -5,6 +5,7 @@
 </div>
 <script src="../assets/bootstrap/js/bootstrap.bundle.min.js" type="module"></script>
 <script src="./view/javascript/index.js" type="module"></script>
+<script src="./view/javascript/handlers.js"></script>
 {% for script in scripts %}
   <script src="{{ script.href }}" type="module"></script>
 {% endfor %}

--- a/upload/admin/view/template/customer/address_list.twig
+++ b/upload/admin/view/template/customer/address_list.twig
@@ -28,7 +28,7 @@
             {% endif %}
             {{ address.country }}</td>
           <td>{% if address.default %}<strong>{{ text_default }}</strong>{% endif %}</td>
-          <td class="text-end"><button type="button" value="{{ address.edit }}" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></button> <button type="submit" form="form-address-list" formaction="{{ address.delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button></td>
+          <td class="text-end"><button type="button" value="{{ address.edit }}" title="{{ button_edit }}" class="btn btn-primary"><i class="fa-solid fa-pencil"></i></button> <button type="submit" form="form-address-list" formaction="{{ address.delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button></td>
         </tr>
       {% endfor %}
     </tbody>

--- a/upload/admin/view/template/customer/custom_field.twig
+++ b/upload/admin/view/template/customer/custom_field.twig
@@ -10,7 +10,7 @@
             <li><button type="submit" form="form-custom-field" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-custom-field" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
             <li><hr class="dropdown-divider"></li>
-            <li><button type="submit" form="form-custom-field" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
+            <li><button type="submit" form="form-custom-field" formaction="{{ delete }}" data-confirm="{{ text_confirm }}" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>
       </div>

--- a/upload/admin/view/template/customer/custom_field_form.twig
+++ b/upload/admin/view/template/customer/custom_field_form.twig
@@ -146,7 +146,7 @@
                           <div id="error-custom-field-{{ custom_field_value_row }}-{{ language.language_id }}" class="invalid-feedback"></div>
                         {% endfor %}</td>
                       <td class="text-end"><input type="text" name="custom_field_value[{{ custom_field_value_row }}][sort_order]" value="{{ custom_field_value.sort_order }}" placeholder="{{ entry_sort_order }}" class="form-control"/></td>
-                      <td class="text-end"><button type="button" onclick="$('#custom-field-value-row-{{ custom_field_value_row }}').remove();" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
+                      <td class="text-end"><button type="button" data-remove="#custom-field-value-row-{{ custom_field_value_row }}" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
                     </tr>
                     {% set custom_field_value_row = custom_field_value_row + 1 %}
                   {% endfor %}
@@ -154,7 +154,7 @@
                 <tfoot>
                   <tr>
                     <td colspan="2"></td>
-                    <td class="text-end"><button type="button" onclick="addCustomFieldValue();" title="{{ button_custom_field_value_add }}" class="btn btn-primary"><i class="fa-solid fa-plus-circle"></i></button></td>
+                    <td class="text-end"><button type="button" data-call="addCustomFieldValue" title="{{ button_custom_field_value_add }}" class="btn btn-primary"><i class="fa-solid fa-plus-circle"></i></button></td>
                   </tr>
                 </tfoot>
               </table>

--- a/upload/admin/view/template/customer/customer.twig
+++ b/upload/admin/view/template/customer/customer.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end">
-        <button type="button" title="{{ button_filter }}" onclick="$('#filter-customer').toggleClass('d-none');" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
+        <button type="button" title="{{ button_filter }}" data-toggle="#filter-customer" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
         <a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
         <div class="btn-group">
           <button type="button" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown"><i class="fa-solid fa-list-check"></i> <i class="fa-solid fa-caret-down fa-fw"></i></button>
@@ -11,7 +11,7 @@
             <li><button type="submit" form="form-customer" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-customer" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
             <li><hr class="dropdown-divider"></li>
-            <li><button type="submit" form="form-customer" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
+            <li><button type="submit" form="form-customer" formaction="{{ delete }}" data-confirm="{{ text_confirm }}" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>
       </div>

--- a/upload/admin/view/template/customer/customer_approval.twig
+++ b/upload/admin/view/template/customer/customer_approval.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end">
-        <button type="button" title="{{ button_filter }}" onclick="$('#filter-customer').toggleClass('d-none');" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
+        <button type="button" title="{{ button_filter }}" data-toggle="#filter-customer" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
         <button type="submit" form="form-customer-approval" formaction="{{ approve }}" title="{{ text_approve }}" class="btn btn-success"><i class="fa-solid fa-thumbs-up"></i></button>
         <button type="submit" form="form-customer-approval" formaction="{{ deny }}" title="{{ text_deny }}" class="btn btn-danger"><i class="fa-solid fa-thumbs-down"></i></button>
       </div>

--- a/upload/admin/view/template/customer/customer_group.twig
+++ b/upload/admin/view/template/customer/customer_group.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end"><a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" form="form-customer-group" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+        <button type="submit" form="form-customer-group" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/customer/gdpr.twig
+++ b/upload/admin/view/template/customer/gdpr.twig
@@ -3,10 +3,10 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end">
-        <button type="button" title="{{ button_filter }}" onclick="$('#filter-gdpr').toggleClass('d-none');" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
+        <button type="button" title="{{ button_filter }}" data-toggle="#filter-gdpr" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
         <button type="submit" form="form-gdpr" formaction="{{ approve }}" title="{{ text_approve }}" class="btn btn-success"><i class="fa-solid fa-check"></i></button>
         <button type="submit" form="form-gdpr" formaction="{{ deny }}" title="{{ text_deny }}" class="btn btn-warning"><i class="fa-solid fa-circle-xmark"></i></button>
-        <button type="submit" form="form-gdpr" formaction="{{ delete }}" title="{{ text_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+        <button type="submit" form="form-gdpr" formaction="{{ delete }}" title="{{ text_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/design/banner.twig
+++ b/upload/admin/view/template/design/banner.twig
@@ -10,7 +10,7 @@
             <li><button type="submit" form="form-banner" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-banner" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
             <li><hr class="dropdown-divider"></li>
-            <li><button type="submit" form="form-banner" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
+            <li><button type="submit" form="form-banner" formaction="{{ delete }}" data-confirm="{{ text_confirm }}" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>
       </div>

--- a/upload/admin/view/template/design/banner_form.twig
+++ b/upload/admin/view/template/design/banner_form.twig
@@ -73,7 +73,7 @@
                                   <div id="error-image-{{ language.language_id }}-{{ image_row }}-link" class="invalid-feedback"></div>
                                 </td>
                                 <td class="text-end" style="width: 10%;"><input type="text" name="banner_image[{{ language.language_id }}][{{ image_row }}][sort_order]" value="{{ banner_image.sort_order }}" placeholder="{{ entry_sort_order }}" id="input-image-{{ language.language_id }}-{{ image_row }}-sort-order" class="form-control"/></td>
-                                <td class="text-end"><button type="button" onclick="$('#image-row-{{ image_row }}').remove();" title="{{ button_remove|escape('js') }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
+                                <td class="text-end"><button type="button" data-remove="#image-row-{{ image_row }}" title="{{ button_remove|escape('js') }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
                               </tr>
                               {% set image_row = image_row + 1 %}
                             {% endfor %}

--- a/upload/admin/view/template/design/layout.twig
+++ b/upload/admin/view/template/design/layout.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end"><a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" form="form-layout" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+        <button type="submit" form="form-layout" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/design/layout_form.twig
+++ b/upload/admin/view/template/design/layout_form.twig
@@ -49,7 +49,7 @@
                         {% endfor %}
                       </select></td>
                       <td><input type="text" name="layout_route[{{ route_row }}][route]" value="{{ layout_route.route }}" placeholder="{{ entry_route }}" class="form-control"/></td>
-                      <td class="text-end"><button type="button" onclick="$('#route-row-{{ route_row }}').remove();" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
+                      <td class="text-end"><button type="button" data-remove="#route-row-{{ route_row }}" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
                   </tr>
                   {% set route_row = route_row + 1 %}
                 {% endfor %}
@@ -57,7 +57,7 @@
               <tfoot>
                 <tr>
                   <td colspan="2"></td>
-                  <td class="text-end"><button type="button" onclick="addRoute();" title="{{ button_route_add }}" class="btn btn-primary"><i class="fa-solid fa-plus-circle"></i></button></td>
+                  <td class="text-end"><button type="button" data-call="addRoute" title="{{ button_route_add }}" class="btn btn-primary"><i class="fa-solid fa-plus-circle"></i></button></td>
                 </tr>
               </tfoot>
             </table>
@@ -93,7 +93,7 @@
                               {% endfor %}
                               </select>
                               <input type="hidden" name="layout_module[{{ module_row }}][position]" value="{{ layout_module.position }}"/><input type="hidden" name="layout_module[{{ module_row }}][sort_order]" value="{{ layout_module.sort_order }}"/> <a href="{{ layout_module.edit }}" title="{{ button_edit }}" class="btn btn-primary btn-sm"><i class="fa-solid fa-pencil fa-fw"></i></a>
-                              <button type="button" onclick="$('#module-row-{{ module_row }}').remove();" title="{{ button_remove }}" class="btn btn-danger btn-sm"><i class="fa-solid fa-minus-circle fa-fw"></i></button>
+                              <button type="button" data-remove="#module-row-{{ module_row }}" title="{{ button_remove }}" class="btn btn-danger btn-sm"><i class="fa-solid fa-minus-circle fa-fw"></i></button>
                             </div>
                           </td>
                         </tr>
@@ -103,7 +103,7 @@
                   </tbody>
                   <tfoot>
                     <tr>
-                      <td class="text-end"><button type="button" onclick="addModule('column-left');" title="{{ button_module_add }}" class="btn btn-primary btn-sm"><i class="fa-solid fa-plus-circle fa-fw"></i></button></td>
+                      <td class="text-end"><button type="button" data-call="addModule" data-call-arg="column-left" title="{{ button_module_add }}" class="btn btn-primary btn-sm"><i class="fa-solid fa-plus-circle fa-fw"></i></button></td>
                     </tr>
                   </tfoot>
                 </table>
@@ -135,7 +135,7 @@
                                 {% endfor %}
                               </select>
                               <input type="hidden" name="layout_module[{{ module_row }}][position]" value="{{ layout_module.position }}"/> <input type="hidden" name="layout_module[{{ module_row }}][sort_order]" value="{{ layout_module.sort_order }}"/> <a href="{{ layout_module.edit }}" title="{{ button_edit }}" class="btn btn-primary btn-sm"><i class="fa-solid fa-pencil fa-fw"></i></a>
-                              <button type="button" onclick="$('#module-row-{{ module_row }}').remove();" title="{{ button_remove }}" class="btn btn-danger btn-sm"><i class="fa-solid fa-minus-circle fa-fw"></i></button>
+                              <button type="button" data-remove="#module-row-{{ module_row }}" title="{{ button_remove }}" class="btn btn-danger btn-sm"><i class="fa-solid fa-minus-circle fa-fw"></i></button>
                             </div></td>
                         </tr>
                         {% set module_row = module_row + 1 %}
@@ -144,7 +144,7 @@
                   </tbody>
                   <tfoot>
                     <tr>
-                      <td class="text-end"><button type="button" onclick="addModule('content-top');" title="{{ button_module_add }}" class="btn btn-primary btn-sm"><i class="fa-solid fa-plus-circle fa-fw"></i></button></td>
+                      <td class="text-end"><button type="button" data-call="addModule" data-call-arg="content-top" title="{{ button_module_add }}" class="btn btn-primary btn-sm"><i class="fa-solid fa-plus-circle fa-fw"></i></button></td>
                     </tr>
                   </tfoot>
                 </table>
@@ -174,7 +174,7 @@
                                 {% endfor %}
                               </select>
                               <input type="hidden" name="layout_module[{{ module_row }}][position]" value="{{ layout_module.position }}"/> <input type="hidden" name="layout_module[{{ module_row }}][sort_order]" value="{{ layout_module.sort_order }}"/> <a href="{{ layout_module.edit }}" title="{{ button_edit }}" class="btn btn-primary btn-sm"><i class="fa-solid fa-pencil fa-fw"></i></a>
-                              <button type="button" onclick="$('#module-row-{{ module_row }}').remove();" title="{{ button_remove }}" class="btn btn-danger btn-sm"><i class="fa-solid fa-minus-circle fa-fw"></i></button>
+                              <button type="button" data-remove="#module-row-{{ module_row }}" title="{{ button_remove }}" class="btn btn-danger btn-sm"><i class="fa-solid fa-minus-circle fa-fw"></i></button>
                             </div></td>
                         </tr>
                         {% set module_row = module_row + 1 %}
@@ -183,7 +183,7 @@
                   </tbody>
                   <tfoot>
                     <tr>
-                      <td class="text-end"><button type="button" onclick="addModule('content-bottom');" title="{{ button_module_add }}" class="btn btn-primary btn-sm"><i class="fa-solid fa-plus-circle fa-fw"></i></button></td>
+                      <td class="text-end"><button type="button" data-call="addModule" data-call-arg="content-bottom" title="{{ button_module_add }}" class="btn btn-primary btn-sm"><i class="fa-solid fa-plus-circle fa-fw"></i></button></td>
                     </tr>
                   </tfoot>
                 </table>
@@ -215,7 +215,7 @@
                                 {% endfor %}
                               </select>
                               <input type="hidden" name="layout_module[{{ module_row }}][position]" value="{{ layout_module.position }}"/> <input type="hidden" name="layout_module[{{ module_row }}][sort_order]" value="{{ layout_module.sort_order }}"/> <a href="{{ layout_module.edit }}" title="{{ button_edit }}" class="btn btn-primary btn-sm"><i class="fa-solid fa-pencil fa-fw"></i></a>
-                              <button type="button" onclick="$('#module-row-{{ module_row }}').remove();" title="{{ button_remove }}" class="btn btn-danger btn-sm"><i class="fa-solid fa-minus-circle fa-fw"></i></button>
+                              <button type="button" data-remove="#module-row-{{ module_row }}" title="{{ button_remove }}" class="btn btn-danger btn-sm"><i class="fa-solid fa-minus-circle fa-fw"></i></button>
                             </div></td>
                         </tr>
                         {% set module_row = module_row + 1 %}
@@ -224,7 +224,7 @@
                   </tbody>
                   <tfoot>
                     <tr>
-                      <td class="text-end"><button type="button" onclick="addModule('column-right');" title="{{ button_module_add }}" class="btn btn-primary btn-sm"><i class="fa-solid fa-plus-circle fa-fw"></i></button></td>
+                      <td class="text-end"><button type="button" data-call="addModule" data-call-arg="column-right" title="{{ button_module_add }}" class="btn btn-primary btn-sm"><i class="fa-solid fa-plus-circle fa-fw"></i></button></td>
                     </tr>
                   </tfoot>
                 </table>

--- a/upload/admin/view/template/design/seo_regex.twig
+++ b/upload/admin/view/template/design/seo_regex.twig
@@ -4,7 +4,7 @@
     <div class="container-fluid">
       <div class="float-end">
         <a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" form="form-seo-regex" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+        <button type="submit" form="form-seo-regex" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/design/seo_url.twig
+++ b/upload/admin/view/template/design/seo_url.twig
@@ -3,9 +3,9 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end">
-        <button type="button" title="{{ button_filter }}" onclick="$('#filter-seo').toggleClass('d-none');" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
+        <button type="button" title="{{ button_filter }}" data-toggle="#filter-seo" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
         <a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" form="form-seo-url" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+        <button type="submit" form="form-seo-url" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/design/seo_url.twig
+++ b/upload/admin/view/template/design/seo_url.twig
@@ -64,7 +64,7 @@
     </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#form-filter').on('submit', function(e) {
     e.preventDefault();
 

--- a/upload/admin/view/template/design/template.twig
+++ b/upload/admin/view/template/design/template.twig
@@ -66,7 +66,7 @@
     </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#form-filter').on('submit', function(e) {
     e.preventDefault();
 

--- a/upload/admin/view/template/design/template.twig
+++ b/upload/admin/view/template/design/template.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end">
-        <button type="button" title="{{ button_filter }}" onclick="$('#filter-template').toggleClass('d-none');" class="btn btn-light d-md-none d-lg-none"><i class="fa-solid fa-filter"></i></button>
+        <button type="button" title="{{ button_filter }}" data-toggle="#filter-template" class="btn btn-light d-md-none d-lg-none"><i class="fa-solid fa-filter"></i></button>
         <a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
         <div class="btn-group">
           <button type="button" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown"><i class="fa-solid fa-list-check"></i> {{ button_action }} <i class="fa-solid fa-caret-down fa-fw"></i></button>
@@ -13,7 +13,7 @@
             <li>
               <hr class="dropdown-divider">
             </li>
-            <li><button type="submit" form="form-template" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
+            <li><button type="submit" form="form-template" formaction="{{ delete }}" data-confirm="{{ text_confirm }}" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>
       </div>

--- a/upload/admin/view/template/design/translation.twig
+++ b/upload/admin/view/template/design/translation.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end">
-        <button type="button" title="{{ button_filter }}" onclick="$('#filter-translation').toggleClass('d-none');" class="btn btn-light d-md-none d-lg-none"><i class="fa-solid fa-filter"></i></button>
+        <button type="button" title="{{ button_filter }}" data-toggle="#filter-translation" class="btn btn-light d-md-none d-lg-none"><i class="fa-solid fa-filter"></i></button>
         <a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
         <div class="btn-group">
           <button type="button" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown"><i class="fa-solid fa-list-check"></i> {{ button_action }} <i class="fa-solid fa-caret-down fa-fw"></i></button>
@@ -13,7 +13,7 @@
             <li>
               <hr class="dropdown-divider">
             </li>
-            <li><button type="submit" form="form-translation" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
+            <li><button type="submit" form="form-translation" formaction="{{ delete }}" data-confirm="{{ text_confirm }}" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>
       </div>

--- a/upload/admin/view/template/design/translation.twig
+++ b/upload/admin/view/template/design/translation.twig
@@ -73,7 +73,7 @@
     </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#form-filter').on('submit', function(e) {
     e.preventDefault();
 

--- a/upload/admin/view/template/localisation/address_format.twig
+++ b/upload/admin/view/template/localisation/address_format.twig
@@ -4,7 +4,7 @@
     <div class="container-fluid">
       <div class="float-end">
         <a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" form="form-address-format" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+        <button type="submit" form="form-address-format" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/localisation/country.twig
+++ b/upload/admin/view/template/localisation/country.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end">
-        <button type="button" title="{{ button_filter }}" onclick="$('#filter-country').toggleClass('d-none');" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
+        <button type="button" title="{{ button_filter }}" data-toggle="#filter-country" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
         <a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
         <div class="btn-group">
           <button type="button" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown"><i class="fa-solid fa-list-check"></i> {{ button_action }} <i class="fa-solid fa-caret-down fa-fw"></i></button>
@@ -11,7 +11,7 @@
             <li><button type="submit" form="form-country" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-country" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
             <li><hr class="dropdown-divider"></li>
-            <li><button type="submit" form="form-country" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
+            <li><button type="submit" form="form-country" formaction="{{ delete }}" data-confirm="{{ text_confirm }}" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>
       </div>

--- a/upload/admin/view/template/localisation/currency.twig
+++ b/upload/admin/view/template/localisation/currency.twig
@@ -11,7 +11,7 @@
             <li><button type="submit" form="form-currency" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-currency" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
             <li><hr class="dropdown-divider"></li>
-            <li><button type="submit" form="form-currency" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
+            <li><button type="submit" form="form-currency" formaction="{{ delete }}" data-confirm="{{ text_confirm }}" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>
       </div>

--- a/upload/admin/view/template/localisation/geo_zone.twig
+++ b/upload/admin/view/template/localisation/geo_zone.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end"><a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" form="form-geo-zone" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+        <button type="submit" form="form-geo-zone" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/localisation/geo_zone_form.twig
+++ b/upload/admin/view/template/localisation/geo_zone_form.twig
@@ -52,7 +52,7 @@
                     <td><x-zone name="zone_to_geo_zone[{{ zone_to_geo_zone_row }}][zone_id]" value="{{ zone_to_geo_zone.zone_id }}" id="x-zone-{{ zone_to_geo_zone_row }}" country_id="{{ zone_to_geo_zone.country_id }}" input-id="input-zone-{{ zone_to_geo_zone_row }}" input-class="form-select">
                         <option value="0">{{ text_all_zones }}</option>
                       </x-zone></td>
-                    <td class="text-end"><button type="button" onclick="$('#zone-to-geo-zone-row-{{ zone_to_geo_zone_row }}').remove();" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
+                    <td class="text-end"><button type="button" data-remove="#zone-to-geo-zone-row-{{ zone_to_geo_zone_row }}" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
                   </tr>
                   {% set zone_to_geo_zone_row = zone_to_geo_zone_row + 1 %}
                 {% endfor %}

--- a/upload/admin/view/template/localisation/identifier.twig
+++ b/upload/admin/view/template/localisation/identifier.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end"><a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" form="form-manufacturer" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+        <button type="submit" form="form-manufacturer" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/localisation/language.twig
+++ b/upload/admin/view/template/localisation/language.twig
@@ -10,7 +10,7 @@
             <li><button type="submit" form="form-language" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-language" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
             <li><hr class="dropdown-divider"></li>
-            <li><button type="submit" form="form-language" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
+            <li><button type="submit" form="form-language" formaction="{{ delete }}" data-confirm="{{ text_confirm }}" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>
       </div>

--- a/upload/admin/view/template/localisation/length_class.twig
+++ b/upload/admin/view/template/localisation/length_class.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end"><a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" form="form-length-class" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+        <button type="submit" form="form-length-class" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/localisation/location.twig
+++ b/upload/admin/view/template/localisation/location.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end"><a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" form="form-location" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+        <button type="submit" form="form-location" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/localisation/order_status.twig
+++ b/upload/admin/view/template/localisation/order_status.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end"><a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" form="form-order-status" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+        <button type="submit" form="form-order-status" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/localisation/return_action.twig
+++ b/upload/admin/view/template/localisation/return_action.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end"><a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" form="form-return-action" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+        <button type="submit" form="form-return-action" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/localisation/return_reason.twig
+++ b/upload/admin/view/template/localisation/return_reason.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end"><a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" form="form-return-reason" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+        <button type="submit" form="form-return-reason" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/localisation/return_status.twig
+++ b/upload/admin/view/template/localisation/return_status.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end"><a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" form="form-return-status" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+        <button type="submit" form="form-return-status" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/localisation/stock_status.twig
+++ b/upload/admin/view/template/localisation/stock_status.twig
@@ -4,7 +4,7 @@
     <div class="container-fluid">
       <div class="float-end">
         <a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" form="form-stock-status" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+        <button type="submit" form="form-stock-status" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/localisation/subscription_status.twig
+++ b/upload/admin/view/template/localisation/subscription_status.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end"><a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" form="form-subscription-status" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+        <button type="submit" form="form-subscription-status" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/localisation/tax_class.twig
+++ b/upload/admin/view/template/localisation/tax_class.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end"><a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" form="form-tax-class" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+        <button type="submit" form="form-tax-class" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/localisation/tax_class_form.twig
+++ b/upload/admin/view/template/localisation/tax_class_form.twig
@@ -73,7 +73,7 @@
                         {% endif %}
                       </select></td>
                     <td><input type="text" name="tax_rule[{{ tax_rule_row }}][priority]" value="{{ tax_rule.priority }}" placeholder="{{ entry_priority }}" class="form-control"/></td>
-                    <td class="text-end"><button type="button" onclick="$('#tax-rule-row-{{ tax_rule_row }}').remove();" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
+                    <td class="text-end"><button type="button" data-remove="#tax-rule-row-{{ tax_rule_row }}" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
                   </tr>
                   {% set tax_rule_row = tax_rule_row + 1 %}
                 {% endfor %}

--- a/upload/admin/view/template/localisation/tax_rate.twig
+++ b/upload/admin/view/template/localisation/tax_rate.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end"><a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" form="form-tax-rate" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+        <button type="submit" form="form-tax-rate" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/localisation/weight_class.twig
+++ b/upload/admin/view/template/localisation/weight_class.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end"><a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" form="form-weight-class" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+        <button type="submit" form="form-weight-class" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/localisation/zone.twig
+++ b/upload/admin/view/template/localisation/zone.twig
@@ -78,7 +78,7 @@
     </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#form-filter').on('submit', function(e) {
     e.preventDefault();
 

--- a/upload/admin/view/template/localisation/zone.twig
+++ b/upload/admin/view/template/localisation/zone.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end">
-        <button type="button" title="{{ button_filter }}" onclick="$('#filter-zone').toggleClass('d-none');" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
+        <button type="button" title="{{ button_filter }}" data-toggle="#filter-zone" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
         <a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
         <div class="btn-group">
           <button type="button" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown"><i class="fa-solid fa-list-check"></i> {{ button_action }} <i class="fa-solid fa-caret-down fa-fw"></i></button>
@@ -11,7 +11,7 @@
             <li><button type="submit" form="form-zone" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-zone" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
             <li><hr class="dropdown-divider"></li>
-            <li><button type="submit" form="form-zone" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
+            <li><button type="submit" form="form-zone" formaction="{{ delete }}" data-confirm="{{ text_confirm }}" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>
       </div>

--- a/upload/admin/view/template/marketing/affiliate.twig
+++ b/upload/admin/view/template/marketing/affiliate.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end">
-        <button type="button" title="{{ button_filter }}" onclick="$('#filter-affiliate').toggleClass('d-none');" class="btn btn-light d-md-none"><i class="fa-solid fa-filter"></i></button>
+        <button type="button" title="{{ button_filter }}" data-toggle="#filter-affiliate" class="btn btn-light d-md-none"><i class="fa-solid fa-filter"></i></button>
         <a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
         <button type="button" id="button-calculate" title="{{ button_calculate }}" class="btn btn-warning"><i class="fa-solid fa-sync"></i></button>
         <div class="btn-group">
@@ -15,7 +15,7 @@
             <li><button type="submit" form="form-affiliate" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-affiliate" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
             <li><hr class="dropdown-divider"></li>
-            <li><button type="submit" form="form-affiliate" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
+            <li><button type="submit" form="form-affiliate" formaction="{{ delete }}" data-confirm="{{ text_confirm }}" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>
       </div>

--- a/upload/admin/view/template/marketing/coupon.twig
+++ b/upload/admin/view/template/marketing/coupon.twig
@@ -10,7 +10,7 @@
             <li><button type="submit" form="form-coupon" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-coupon" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
             <li><hr class="dropdown-divider"></li>
-            <li><button type="submit" form="form-coupon" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
+            <li><button type="submit" form="form-coupon" formaction="{{ delete }}" data-confirm="{{ text_confirm }}" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>
       </div>

--- a/upload/admin/view/template/marketing/marketing.twig
+++ b/upload/admin/view/template/marketing/marketing.twig
@@ -3,9 +3,9 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end">
-        <button type="button" title="{{ button_filter }}" onclick="$('#filter-marketing').toggleClass('d-none');" class="btn btn-light d-md-none"><i class="fa-solid fa-filter"></i></button>
+        <button type="button" title="{{ button_filter }}" data-toggle="#filter-marketing" class="btn btn-light d-md-none"><i class="fa-solid fa-filter"></i></button>
         <a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" form="form-marketing" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+        <button type="submit" form="form-marketing" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/marketplace/cron.twig
+++ b/upload/admin/view/template/marketplace/cron.twig
@@ -9,7 +9,7 @@
             <li><button type="submit" form="form-cron" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-cron" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
             <li><hr class="dropdown-divider"></li>
-            <li><button type="submit" form="form-cron" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
+            <li><button type="submit" form="form-cron" formaction="{{ delete }}" data-confirm="{{ text_confirm }}" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>
       </div>

--- a/upload/admin/view/template/marketplace/event.twig
+++ b/upload/admin/view/template/marketplace/event.twig
@@ -11,7 +11,7 @@
             <li>
               <hr class="dropdown-divider">
             </li>
-            <li><button type="submit" form="form-event" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
+            <li><button type="submit" form="form-event" formaction="{{ delete }}" data-confirm="{{ text_confirm }}" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>
       </div>

--- a/upload/admin/view/template/marketplace/event.twig
+++ b/upload/admin/view/template/marketplace/event.twig
@@ -58,7 +58,7 @@
     </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#form-filter').on('submit', function(e) {
     e.preventDefault();
 

--- a/upload/admin/view/template/marketplace/ssr.twig
+++ b/upload/admin/view/template/marketplace/ssr.twig
@@ -9,7 +9,7 @@
             <li><button type="submit" form="form-ssr" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-ssr" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
             <li><hr class="dropdown-divider"></li>
-            <li><button type="submit" form="form-ssr" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
+            <li><button type="submit" form="form-ssr" formaction="{{ delete }}" data-confirm="{{ text_confirm }}" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>
       </div>

--- a/upload/admin/view/template/marketplace/startup.twig
+++ b/upload/admin/view/template/marketplace/startup.twig
@@ -9,7 +9,7 @@
             <li><button type="submit" form="form-startup" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-startup" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
             <li><hr class="dropdown-divider"></li>
-            <li><button type="submit" form="form-startup" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
+            <li><button type="submit" form="form-startup" formaction="{{ delete }}" data-confirm="{{ text_confirm }}" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>
       </div>

--- a/upload/admin/view/template/marketplace/task.twig
+++ b/upload/admin/view/template/marketplace/task.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end">
-        <button type="button" title="{{ button_filter }}" onclick="$('#filter-task').toggleClass('d-none');" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
+        <button type="button" title="{{ button_filter }}" data-toggle="#filter-task" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
         <button type="button" id="button-refresh" title="{{ button_refresh }}" class="btn btn-light"><i class="fa-solid fa-sync"></i></button>
         <button type="button" id="button-start" title="{{ button_run }}" class="btn btn-success"><i class="fa-solid fa-play"></i></button>
         <button type="button" id="button-clear" title="{{ button_clear }}" class="btn btn-danger"><i class="fa-solid fa-eraser"></i></button>
@@ -19,7 +19,7 @@
             <li>
               <hr class="dropdown-divider">
             </li>
-            <li><button type="submit" form="form-task" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
+            <li><button type="submit" form="form-task" formaction="{{ delete }}" data-confirm="{{ text_confirm }}" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>
       </div>

--- a/upload/admin/view/template/report/online.twig
+++ b/upload/admin/view/template/report/online.twig
@@ -2,7 +2,7 @@
 <div id="content">
   <div class="page-header">
     <div class="container-fluid">
-      <div class="float-end"><button type="button" title="{{ button_filter }}" onclick="$('#filter-online').toggleClass('d-none');" class="btn btn-light d-md-none"><i class="fa-solid fa-filter"></i></button>
+      <div class="float-end"><button type="button" title="{{ button_filter }}" data-toggle="#filter-online" class="btn btn-light d-md-none"><i class="fa-solid fa-filter"></i></button>
         <button type="button" id="button-refresh" title="{{ button_refresh }}" class="btn btn-light"><i class="fa-solid fa-rotate"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>

--- a/upload/admin/view/template/report/online.twig
+++ b/upload/admin/view/template/report/online.twig
@@ -46,7 +46,7 @@
     </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#form-filter').on('submit', function(e) {
     e.preventDefault();
 

--- a/upload/admin/view/template/report/report.twig
+++ b/upload/admin/view/template/report/report.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end">
-        <button type="button" title="{{ button_filter }}" onclick="$('#filter-report').toggleClass('d-none');" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
+        <button type="button" title="{{ button_filter }}" data-toggle="#filter-report" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/report/report.twig
+++ b/upload/admin/view/template/report/report.twig
@@ -34,7 +34,7 @@
     <div id="report"></div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#input-report').on('change', function(e) {
     if ($(this).val()) {
         $('#report').load(this.value);

--- a/upload/admin/view/template/sale/order.twig
+++ b/upload/admin/view/template/sale/order.twig
@@ -3,11 +3,11 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end">
-        <button type="button" title="{{ button_filter }}" onclick="$('#filter-order').toggleClass('d-none');" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
+        <button type="button" title="{{ button_filter }}" data-toggle="#filter-order" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
         <button type="submit" id="button-invoice" form="form-order" formaction="{{ invoice }}" formtarget="_blank" title="{{ button_invoice_print }}" class="btn btn-info"><i class="fa-solid fa-print"></i></button>
         <button type="submit" id="button-shipping" form="form-order" formaction="{{ shipping }}" formtarget="_blank" title="{{ button_shipping_print }}" class="btn btn-info"><i class="fa-solid fa-truck"></i></button>
         <a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" data-oc-toggle="ajax" form="form-order" formaction="{{ delete }}"  title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+        <button type="submit" data-oc-toggle="ajax" form="form-order" formaction="{{ delete }}"  title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/sale/order_list.twig
+++ b/upload/admin/view/template/sale/order_list.twig
@@ -3,7 +3,7 @@
     <table class="table table-bordered table-hover">
       <thead>
         <tr>
-          <th class="text-center" style="width: 1px;"><input type="checkbox" onclick="$('input[name*=\'selected\']').trigger('click');" class="form-check-input"/></th>
+          <th class="text-center" style="width: 1px;"><input type="checkbox" data-select-all class="form-check-input"/></th>
           <th class="text-end"><a href="{{ sort_order }}"{% if sort == 'order_id' %} class="{{ order|lower }}"{% endif %}>{{ column_order_id }}</a></th>
           <th><a href="{{ sort_store_name }}"{% if sort == 'store' %} class="{{ order|lower }}"{% endif %}>{{ column_store }}</a></th>
           <th><a href="{{ sort_customer }}"{% if sort == 'customer' %} class="{{ order|lower }}"{% endif %}>{{ column_customer }}</a></th>

--- a/upload/admin/view/template/sale/returns.twig
+++ b/upload/admin/view/template/sale/returns.twig
@@ -3,9 +3,9 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end">
-        <button type="button" title="{{ button_filter }}" onclick="$('#filter-return').toggleClass('d-none');" class="btn btn-light d-md-none"><i class="fa-solid fa-filter"></i></button>
+        <button type="button" title="{{ button_filter }}" data-toggle="#filter-return" class="btn btn-light d-md-none"><i class="fa-solid fa-filter"></i></button>
         <a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" form="form-return" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+        <button type="submit" form="form-return" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/sale/subscription.twig
+++ b/upload/admin/view/template/sale/subscription.twig
@@ -3,9 +3,9 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end">
-        <button type="button" title="{{ button_filter }}" onclick="$('#filter-subscription').toggleClass('d-none');" class="btn btn-light d-md-none"><i class="fa-solid fa-filter"></i></button>
+        <button type="button" title="{{ button_filter }}" data-toggle="#filter-subscription" class="btn btn-light d-md-none"><i class="fa-solid fa-filter"></i></button>
         <a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" form="form-subscription" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+        <button type="submit" form="form-subscription" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/sale/subscription_list.twig
+++ b/upload/admin/view/template/sale/subscription_list.twig
@@ -3,7 +3,7 @@
     <table class="table table-bordered table-hover">
       <thead>
         <tr>
-          <th class="text-center" style="width: 1px;"><input type="checkbox" onclick="$('input[name*=\'selected\']').trigger('click');" class="form-check-input"/></th>
+          <th class="text-center" style="width: 1px;"><input type="checkbox" data-select-all class="form-check-input"/></th>
           <th class="text-end"><a href="{{ sort_subscription }}"{% if sort == 'subscription_id' %} class="{{ order|lower }}"{% endif %}>{{ column_subscription_id }}</a></th>
           <th class="text-end"><a href="{{ sort_order }}"{% if sort == 'order_id' %} class="{{ order|lower }}"{% endif %}>{{ column_order_id }}</a></th>
           <th><a href="{{ sort_customer }}"{% if sort == 'customer' %} class="{{ order|lower }}"{% endif %}>{{ column_customer }}</a></th>

--- a/upload/admin/view/template/setting/store.twig
+++ b/upload/admin/view/template/setting/store.twig
@@ -4,7 +4,7 @@
     <div class="container-fluid">
       <div class="float-end">
         <a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" form="form-store" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+        <button type="submit" form="form-store" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/tool/backup_history.twig
+++ b/upload/admin/view/template/tool/backup_history.twig
@@ -17,7 +17,7 @@
             <td class="d-none d-lg-table-cell">{{ history.date_added }}</td>
             <td class="text-end">
               <button type="button" value="{{ history.filename }}" title="{{ button_restore }}" class="btn btn-warning"><i class="fa-solid fa-rotate"></i></button>
-              <button type="button" onclick="location = '{{ history.download }}';" title="{{ button_download }}" class="btn btn-info"><i class="fa-solid fa-download"></i></button>
+              <button type="button" data-location="{{ history.download }}" title="{{ button_download }}" class="btn btn-info"><i class="fa-solid fa-download"></i></button>
               <button type="button" value="{{ history.filename }}" title="{{ button_delete }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button></td>
           </tr>
         {% endfor %}

--- a/upload/admin/view/template/tool/menu.twig
+++ b/upload/admin/view/template/tool/menu.twig
@@ -5,7 +5,7 @@
       <div class="float-end">
         <a href="{{ link_add }}" title="{{ button_link }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
         <a href="{{ dropdown_add }}" title="{{ button_dropdown }}" class="btn btn-warning"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" form="form-menu" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+        <button type="submit" form="form-menu" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/tool/upload.twig
+++ b/upload/admin/view/template/tool/upload.twig
@@ -54,7 +54,7 @@
     </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#form-filter').on('submit', function(e) {
     e.preventDefault();
 

--- a/upload/admin/view/template/tool/upload.twig
+++ b/upload/admin/view/template/tool/upload.twig
@@ -3,8 +3,8 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end">
-        <button type="button" title="{{ button_filter }}" onclick="$('#filter-upload').toggleClass('d-none');" class="btn btn-light d-md-none"><i class="fa-solid fa-filter"></i></button>
-        <button type="submit" form="form-upload" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+        <button type="button" title="{{ button_filter }}" data-toggle="#filter-upload" class="btn btn-light d-md-none"><i class="fa-solid fa-filter"></i></button>
+        <button type="submit" form="form-upload" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/user/api.twig
+++ b/upload/admin/view/template/user/api.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end"><a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" form="form-api" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+        <button type="submit" form="form-api" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/admin/view/template/user/api_form.twig
+++ b/upload/admin/view/template/user/api_form.twig
@@ -64,7 +64,7 @@
                     {% for api_ip in api_ips %}
                       <tr id="ip-row-{{ ip_row }}">
                         <td><input type="text" name="api_ip[]" value="{{ api_ip }}" placeholder="{{ entry_ip }}" class="form-control"/></td>
-                        <td class="text-end"><button type="button" onclick="$('#ip-row-{{ ip_row }}').remove()" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
+                        <td class="text-end"><button type="button" data-remove="#ip-row-{{ ip_row }}" title="{{ button_remove }}" class="btn btn-danger"><i class="fa-solid fa-minus-circle"></i></button></td>
                       </tr>
                       {% set ip_row = ip_row + 1 %}
                     {% endfor %}

--- a/upload/admin/view/template/user/user.twig
+++ b/upload/admin/view/template/user/user.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end">
-        <button type="button" title="{{ button_filter }}" onclick="$('#filter-user').toggleClass('d-none');" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
+        <button type="button" title="{{ button_filter }}" data-toggle="#filter-user" class="btn btn-light d-lg-none"><i class="fa-solid fa-filter"></i></button>
         <a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
         <div class="btn-group">
           <button type="button" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown"><i class="fa-solid fa-list-check"></i> {{ button_action }} <i class="fa-solid fa-caret-down fa-fw"></i></button>
@@ -11,7 +11,7 @@
             <li><button type="submit" form="form-user" formaction="{{ enable }}" class="dropdown-item"><i class="fa-solid fa-toggle-on text-success"></i> {{ text_enable }}</button></li>
             <li><button type="submit" form="form-user" formaction="{{ disable }}" class="dropdown-item"><i class="fa-solid fa-toggle-off text-danger"></i> {{ text_disable }}</button></li>
             <li><hr class="dropdown-divider"></li>
-            <li><button type="submit" form="form-user" formaction="{{ delete }}" onclick="return confirm('{{ text_confirm }}');" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
+            <li><button type="submit" form="form-user" formaction="{{ delete }}" data-confirm="{{ text_confirm }}" class="dropdown-item"><i class="fa-regular fa-trash-can text-danger"></i> {{ text_delete }}</button></li>
           </ul>
         </div>
       </div>

--- a/upload/admin/view/template/user/user_group.twig
+++ b/upload/admin/view/template/user/user_group.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end"><a href="{{ add }}" title="{{ button_add }}" class="btn btn-primary"><i class="fa-solid fa-plus"></i></a>
-        <button type="submit" form="form-user-group" formaction="{{ delete }}" title="{{ button_delete }}" onclick="return confirm('{{ text_confirm }}');" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
+        <button type="submit" form="form-user-group" formaction="{{ delete }}" title="{{ button_delete }}" data-confirm="{{ text_confirm }}" class="btn btn-danger"><i class="fa-regular fa-trash-can"></i></button>
       </div>
       <h1>{{ heading_title }}</h1>
       <ol class="breadcrumb">

--- a/upload/extension/opencart/admin/view/template/api/coupon.twig
+++ b/upload/extension/opencart/admin/view/template/api/coupon.twig
@@ -29,7 +29,7 @@
     </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#form-coupon').on('submit', function(e) {
     e.preventDefault();
 

--- a/upload/extension/opencart/admin/view/template/api/reward.twig
+++ b/upload/extension/opencart/admin/view/template/api/reward.twig
@@ -29,7 +29,7 @@
     </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#form-reward').on('submit', function(e) {
     e.preventDefault();
 

--- a/upload/extension/opencart/admin/view/template/fraud/ip.twig
+++ b/upload/extension/opencart/admin/view/template/fraud/ip.twig
@@ -57,7 +57,7 @@
     </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#ip').on('click', '.pagination a', function(e) {
     e.preventDefault();
 

--- a/upload/extension/opencart/admin/view/template/module/bestseller.twig
+++ b/upload/extension/opencart/admin/view/template/module/bestseller.twig
@@ -67,7 +67,7 @@
     </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#report').on('click', '.pagination a', function(e) {
     e.preventDefault();
 

--- a/upload/extension/opencart/admin/view/template/module/featured.twig
+++ b/upload/extension/opencart/admin/view/template/module/featured.twig
@@ -66,7 +66,7 @@
     </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#input-product').autocomplete({
     source: function(request, response) {
         $.ajax({

--- a/upload/extension/opencart/admin/view/template/report/customer.twig
+++ b/upload/extension/opencart/admin/view/template/report/customer.twig
@@ -35,7 +35,7 @@
     </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#customer').on('click', '.pagination a', function(e) {
     e.preventDefault();
 

--- a/upload/extension/opencart/admin/view/template/report/customer_activity.twig
+++ b/upload/extension/opencart/admin/view/template/report/customer_activity.twig
@@ -36,7 +36,7 @@
     </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#customer-activity').on('click', '.pagination a', function(e) {
     e.preventDefault();
 

--- a/upload/extension/opencart/admin/view/template/report/customer_order.twig
+++ b/upload/extension/opencart/admin/view/template/report/customer_order.twig
@@ -40,7 +40,7 @@
     </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#customer-order').on('click', '.pagination a', function(e) {
     e.preventDefault();
 

--- a/upload/extension/opencart/admin/view/template/report/customer_reward.twig
+++ b/upload/extension/opencart/admin/view/template/report/customer_reward.twig
@@ -32,7 +32,7 @@
     </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#customer-reward').on('click', '.pagination a', function(e) {
     e.preventDefault();
 

--- a/upload/extension/opencart/admin/view/template/report/customer_search.twig
+++ b/upload/extension/opencart/admin/view/template/report/customer_search.twig
@@ -40,7 +40,7 @@
     </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#customer-search').on('click', '.pagination a', function(e) {
     e.preventDefault();
 

--- a/upload/extension/opencart/admin/view/template/report/customer_transaction.twig
+++ b/upload/extension/opencart/admin/view/template/report/customer_transaction.twig
@@ -32,7 +32,7 @@
     </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#customer-transaction').on('click', '.pagination a', function(e) {
     e.preventDefault();
 

--- a/upload/extension/opencart/admin/view/template/report/marketing.twig
+++ b/upload/extension/opencart/admin/view/template/report/marketing.twig
@@ -36,7 +36,7 @@
     </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#marketing').on('click', '.pagination a', function(e) {
     e.preventDefault();
 

--- a/upload/extension/opencart/admin/view/template/report/product_purchased.twig
+++ b/upload/extension/opencart/admin/view/template/report/product_purchased.twig
@@ -36,7 +36,7 @@
     </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#product-purchased').on('click', '.pagination a', function(e) {
     e.preventDefault();
 

--- a/upload/extension/opencart/admin/view/template/report/product_viewed.twig
+++ b/upload/extension/opencart/admin/view/template/report/product_viewed.twig
@@ -7,7 +7,7 @@
   </div>
   <div id="product-viewed" class="card-body">{{ list }}</div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#product-viewed').on('click', '.pagination a', function(e) {
     e.preventDefault();
 

--- a/upload/extension/opencart/admin/view/template/report/sale_coupon.twig
+++ b/upload/extension/opencart/admin/view/template/report/sale_coupon.twig
@@ -27,7 +27,7 @@
     </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#sale-coupon').on('click', '.pagination a', function(e) {
     e.preventDefault();
 

--- a/upload/extension/opencart/admin/view/template/report/sale_order.twig
+++ b/upload/extension/opencart/admin/view/template/report/sale_order.twig
@@ -43,7 +43,7 @@
     </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#sale-order').on('click', '.pagination a', function(e) {
     e.preventDefault();
 

--- a/upload/extension/opencart/admin/view/template/report/sale_return.twig
+++ b/upload/extension/opencart/admin/view/template/report/sale_return.twig
@@ -44,7 +44,7 @@
     </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#sale-return').on('click', '.pagination a', function(e) {
     e.preventDefault();
 

--- a/upload/extension/opencart/admin/view/template/report/sale_shipping.twig
+++ b/upload/extension/opencart/admin/view/template/report/sale_shipping.twig
@@ -43,7 +43,7 @@
     </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#sale-shipping').on('click', '.pagination a', function(e) {
     e.preventDefault();
 

--- a/upload/extension/opencart/admin/view/template/report/sale_tax.twig
+++ b/upload/extension/opencart/admin/view/template/report/sale_tax.twig
@@ -44,7 +44,7 @@
     </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#sale-tax').on('click', '.pagination a', function(e) {
     e.preventDefault();
 

--- a/upload/extension/opencart/admin/view/template/report/subscription.twig
+++ b/upload/extension/opencart/admin/view/template/report/subscription.twig
@@ -43,7 +43,7 @@
       </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#subscription').on('click', '.pagination a', function(e) {
     e.preventDefault();
 

--- a/upload/install/view/template/install/step_2.twig
+++ b/upload/install/view/template/install/step_2.twig
@@ -247,7 +247,7 @@
     </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#form-step-2').on('submit', function(e) {
     e.preventDefault();
 

--- a/upload/install/view/template/install/step_3.twig
+++ b/upload/install/view/template/install/step_3.twig
@@ -138,7 +138,7 @@
     </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#input-db-driver').on('change', function(e) {
     e.preventDefault();
 

--- a/upload/install/view/template/upgrade/upgrade.twig
+++ b/upload/install/view/template/upgrade/upgrade.twig
@@ -48,7 +48,7 @@
     </div>
   </div>
 </div>
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{ nonce }}"><!--
 $('#button-continue').on('click', function() {
     var element = this;
 

--- a/upload/system/engine/loader.php
+++ b/upload/system/engine/loader.php
@@ -182,6 +182,12 @@ class Loader {
 		// Trigger the pre events
 		$this->event->trigger('view/' . $trigger . '/before', [&$route, &$data, &$code, &$output]);
 
+		// Content Security Policy: make the per-request nonce available to every template
+		// so inline <script> elements can declare nonce="{{ nonce }}".
+		if (!isset($data['nonce'])) {
+			$data['nonce'] = (string)$this->config->get('csp_nonce');
+		}
+
 		if (!$output) {
 			// Make sure it's only the last event that returns an output, if required.
 			$output = $this->template->render($route, $data, $code);

--- a/upload/system/framework.php
+++ b/upload/system/framework.php
@@ -106,6 +106,14 @@ if (php_sapi_name() != 'cli') {
 	$response->addHeader('Access-Control-Allow-Methods: PUT, POST, GET, OPTIONS, DELETE');
 	$response->addHeader('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0');
 	$response->addHeader('Pragma: no-cache');
+
+	// Content Security Policy: per-request nonce for inline scripts.
+	// Templates read the nonce via the `nonce` template variable (injected by the loader).
+	$csp_nonce = base64_encode(random_bytes(16));
+	$config->set('csp_nonce', $csp_nonce);
+
+	$response->addHeader("Content-Security-Policy: default-src 'self'; script-src 'self' 'nonce-" . $csp_nonce . "'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' https: data:; connect-src 'self'; frame-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self'");
+
 	$response->setCompression((int)$config->get('response_compression'));
 }
 

--- a/upload/system/framework.php
+++ b/upload/system/framework.php
@@ -112,7 +112,7 @@ if (php_sapi_name() != 'cli') {
 	$csp_nonce = base64_encode(random_bytes(16));
 	$config->set('csp_nonce', $csp_nonce);
 
-	$response->addHeader("Content-Security-Policy: default-src 'self'; script-src 'self' 'nonce-" . $csp_nonce . "'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' https: data:; connect-src 'self'; frame-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self'");
+	$response->addHeader("Content-Security-Policy: default-src 'self'; script-src 'self' 'nonce-" . $csp_nonce . "'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https:; connect-src 'self'; frame-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self'");
 
 	$response->setCompression((int)$config->get('response_compression'));
 }


### PR DESCRIPTION
# Add Content-Security-Policy with per-request nonces; replace inline event handlers

## Motivation

OpenCart currently does not send a `Content-Security-Policy` header, so any XSS
in an extension or template can execute arbitrary inline `<script>` code. This
patch adopts a nonce-based CSP following the "changes to support nonce-based
Content Security Policy adoption in web applications" secure-by-design pattern:

1. `system/framework.php` generates a per-request nonce
   (`base64_encode(random_bytes(16))`) and emits

   ```
   Content-Security-Policy:
     default-src 'self';
     script-src 'self' 'nonce-{X}';
     style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
     img-src 'self' data: https:;
     font-src 'self' https://fonts.gstatic.com data:;
     connect-src 'self';
     frame-src 'self' https:;
     object-src 'none';
     base-uri 'self';
     form-action 'self'
   ```

2. `system/engine/loader.php` makes the nonce available to every template as
   `{{ nonce }}` (single injection point, guarded with `isset()`).

3. The 34 inline `<script type="text/javascript">` tags in the core admin
   templates now carry `nonce="{{ nonce }}"`. External scripts are same-origin
   (`view/javascript/`, `../assets/`) and are covered by `'self'`.

4. Inline event handler attributes are **not** covered by `script-src` nonces,
   so all 117 `onclick="..."` attributes are replaced by declarative
   data-attributes handled by one delegated listener
   (`admin/view/javascript/handlers.js`, loaded from the admin footer on every
   page; delegation also covers rows added dynamically):

   | before                                   | after                                |
   |------------------------------------------|--------------------------------------|
   | `onclick="return confirm('…');"`         | `data-confirm="…"`                   |
   | `onclick="$('#x-row-N').remove();"`      | `data-remove="#x-row-N"`             |
   | `onclick="$('#filter-x').toggle…"`      | `data-toggle="#filter-x"`            |
   | `onclick="…trigger('click');"`           | `data-select-all`                    |
   | `onclick="addRoute();"`                  | `data-call="addRoute"`               |
   | `onclick="addModule('content-top');"`    | `data-call="addModule" data-call-arg="content-top"` |
   | `onclick="location = '…';"`              | `data-location="…"`                  |

5. `admin/view/stylesheet/stylesheet.css` now imports Google Fonts over
   `https://` (was protocol-relative, which resolved to plain http).

## Deliberate policy choices

- `style-src 'unsafe-inline'` is kept for now: the templates still use a large
  number of inline `style=` attributes. This can be tightened in a follow-up
  without blocking the script-gating benefit.
- `frame-src 'self' https:` keeps payment modules (iframes) working.
- `img-src https:` keeps externally hosted product images working.
- Extensions that emit their own inline scripts must add
  `nonce="{{ nonce }}"` (the variable is always available); extensions using
  only external `.js` files need no change.

## Verification

- Fresh install in Docker (php:8.2-apache + MariaDB 11), admin and catalog boot.
- `curl -I /admin/` shows the CSP header; the header nonce equals the
  `nonce="…"` attribute on the rendered inline scripts of the same request
  (single-request comparison).
- Logged-in browser session (Chromium): dashboard and
  `catalog/category` list render with **zero CSP violations** in the console;
  category filter toggle (data-toggle), select-all, delete-confirm
  (data-confirm) and row removal (data-remove) all work through the delegate.
- `grep -rn "onclick=" admin/view/template` returns 0 matches.

## Scope notes

- The new static storefront entry (`upload/index.html` web-components shell) is
  not served through PHP; CSP for it would be delivered by the static hosting
  layer and is out of scope for this patch.
- OpenCart 5.0.0.0 Alpha master (commit 623db40).
