### PR TITLE
[Master] Remove the unreachable duplicate payment_methods case in the subscription API

### DIFF
--- a/upload/catalog/controller/api/subscription.php
+++ b/upload/catalog/controller/api/subscription.php
@@ -36,9 +36,6 @@ class Subscription extends \Opencart\System\Engine\Controller {
 			case 'payment_methods':
 				$output = $this->getPaymentMethods();
 				break;
-			case 'payment_methods':
-				$output = $this->getPaymentMethods();
-				break;
 			case 'confirm':
 				$output = $this->confirm();
 				break;


### PR DESCRIPTION
`case 'payment_methods':` appears twice in the same switch with the same body. PHP takes the first arm, so the second one has never run.
