### PR TITLE
Fix order row delete action

### DIFF
--- a/upload/admin/view/template/sale/order_list.twig
+++ b/upload/admin/view/template/sale/order_list.twig
@@ -127,7 +127,7 @@
                         <button type="button" data-toggle="dropdown" class="btn btn-primary dropdown-toggle"><span class="caret"></span></button>
                         <ul class="dropdown-menu dropdown-menu-right">
                           <li><a href="{{ order.edit }}"><i class="fa fa-pencil"></i> {{ button_edit }}</a></li>
-                          <li><a href="{{ order.order_id }}"><i class="fa fa-trash-o"></i> {{ button_delete }}</a></li>
+                          <li><a href="#" class="button-delete-order" data-order-id="{{ order.order_id }}"><i class="fa fa-trash-o"></i> {{ button_delete }}</a></li>
                         </ul>
                       </div>
                     </div></td>
@@ -243,14 +243,14 @@ $('#button-shipping, #button-invoice').on('click', function(e) {
 	$('#form-order').attr('action', this.getAttribute('formAction'));
 });
 
-$('#form-order li:last-child a').on('click', function(e) {
+$('#form-order .button-delete-order').on('click', function(e) {
 	e.preventDefault();
 	
 	var element = this;
 	
 	if (confirm('{{ text_confirm }}')) {
 		$.ajax({
-			url: '{{ catalog }}index.php?route=api/order/delete&api_token={{ api_token }}&store_id={{ store_id }}&order_id=' + $(element).attr('href'),
+			url: '{{ catalog }}index.php?route=api/order/delete&api_token={{ api_token }}&store_id={{ store_id }}&order_id=' + $(element).data('order-id'),
 			dataType: 'json',
 			beforeSend: function() {
 				$(element).parent().parent().parent().find('button').button('loading');


### PR DESCRIPTION
## Description

Fixes the delete action in the admin order list.

The current implementation stores the order ID in the `href` attribute and reads it using `attr('href')`.

This change:

- stores the order ID in `data-order-id`;
- uses a dedicated `.button-delete-order` selector;
- reads the order ID from the data attribute;
- keeps the existing delete API and confirmation behaviour unchanged.

## Testing

Tested on OpenCart 3.0.5.1.

1. Open Sales > Orders.
2. Click Delete from an individual order row.
3. Confirm deletion.
4. Verify the order is deleted and the order list reloads successfully.