### PR TITLE
[3.0.x.x] Select default zone in customer address form

### DIFF
--- a/upload/admin/view/template/customer/customer_form.twig
+++ b/upload/admin/view/template/customer/customer_form.twig
@@ -1181,7 +1181,7 @@
             html += '>' + json['zone'][i]['name'] + '</option>';
           }
         } else {
-          html += '<option value="0">{{ text_none }}</option>';
+          html += '<option value="0" selected="selected">{{ text_none }}</option>';
         }
 
         $('select[name=\'address[' + index + '][zone_id]\']').html(html);


### PR DESCRIPTION
Ensure the empty 'None' option is selected when a country has no available zones in the customer address form.